### PR TITLE
Show words in lines context for Regexp search

### DIFF
--- a/src/org/opensolaris/opengrok/search/context/QueryMatchers.java
+++ b/src/org/opensolaris/opengrok/search/context/QueryMatchers.java
@@ -34,6 +34,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
 
@@ -89,9 +90,19 @@ public final class QueryMatchers {
             getTerm((TermQuery) query);
         } else if (query instanceof PrefixQuery) {
             getPrefix((PrefixQuery) query);
+        } else if (query instanceof RegexpQuery) {
+            getRegexp((RegexpQuery) query);
         }
     }
-
+    
+    private void getRegexp(RegexpQuery query) {
+        if (useTerm(query.getField())) {
+            String term = query.toString(query.getField());
+            term = term.substring(1, term.length()-1); //trim / from /regexp/
+            matchers.add( new RegexpMatcher(term, true) );
+        }
+    }
+    
     private void getBooleans(BooleanQuery query) {
         BooleanClause[] queryClauses = query.getClauses();
         for (int i = 0; i < queryClauses.length; i++) {
@@ -145,7 +156,14 @@ public final class QueryMatchers {
      * Check whether a matcher should be created for a term.
      */
     private boolean useTerm(Term term) {
-        return fields.keySet().contains(term.field());
+        return useTerm(term.field());
+    }
+    
+    /**
+     * Check whether a matcher should be created for a term.
+     */
+    private boolean useTerm(String termField) {
+        return fields.keySet().contains(termField);
     }
 
     /**

--- a/src/org/opensolaris/opengrok/search/context/QueryMatchers.java
+++ b/src/org/opensolaris/opengrok/search/context/QueryMatchers.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
  */
 
 package org.opensolaris.opengrok.search.context;

--- a/src/org/opensolaris/opengrok/search/context/RegexpMatcher.java
+++ b/src/org/opensolaris/opengrok/search/context/RegexpMatcher.java
@@ -1,0 +1,35 @@
+package org.opensolaris.opengrok.search.context;
+
+import java.util.logging.Level;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.opensolaris.opengrok.OpenGrokLogger;
+
+/**
+ *
+ * @author dobrou@gmail.com
+ */
+class RegexpMatcher extends LineMatcher {
+    private final Pattern termRegexp;
+
+    public RegexpMatcher(String term, boolean caseInsensitive) {
+        super(caseInsensitive); 
+        Pattern regexp;
+        try {
+            regexp = Pattern.compile(term, caseInsensitive ? Pattern.CASE_INSENSITIVE : 0 );
+        } catch ( PatternSyntaxException  e) {
+            regexp = null;
+            OpenGrokLogger.getLogger().log(Level.WARNING, "RegexpMatcher: {0}", e.getMessage() );
+        }
+        this.termRegexp = regexp;
+    }
+
+    @Override
+    public int match(String line) {
+        return (termRegexp != null && termRegexp.matcher(line).matches() )
+            ? MATCHED 
+            : NOT_MATCHED
+        ;
+    }
+    
+}

--- a/src/org/opensolaris/opengrok/search/context/RegexpMatcher.java
+++ b/src/org/opensolaris/opengrok/search/context/RegexpMatcher.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
  */
 
 package org.opensolaris.opengrok.search.context;

--- a/src/org/opensolaris/opengrok/search/context/RegexpMatcher.java
+++ b/src/org/opensolaris/opengrok/search/context/RegexpMatcher.java
@@ -1,3 +1,26 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ */
+
 package org.opensolaris.opengrok.search.context;
 
 import java.util.logging.Level;

--- a/test/org/opensolaris/opengrok/search/context/ContextTest.java
+++ b/test/org/opensolaris/opengrok/search/context/ContextTest.java
@@ -452,4 +452,45 @@ public class ContextTest {
             assertEquals(tags[i], hits.get(i).getTag());
         }
     }
+    
+    /**
+     * Test that regexp search has matched words in context.
+     * @throws ParseException 
+     */
+    @Test
+    public void regexpSearchContextTest() throws ParseException {
+        //regex match is returned in context
+        searchContextTestHelper("one two three", "/t.o|three/", "two");
+        //regex match is returned in context
+        searchContextTestHelper("one two three", "/t.o|three/", "three");
+        //not matching regexp will not return anything
+        searchContextTestHelper("one two three", "/z..z/", null);
+    }
+
+    /**
+     * Helper method for testing presence of expected words in search context
+     * 
+     * @param searchInText Context of document we are searching in.
+     * @param queryString Definition of search query.
+     * @param expectWordInContext Word expected to be found by 'queryString' in 'searchInText' and to be included in context. Set null if context is expected to be empty.
+     * @throws ParseException 
+     */
+    private void searchContextTestHelper(String searchInText, String queryString, String expectWordInContext) throws ParseException {
+        Reader in = new StringReader(searchInText);
+        StringWriter out = new StringWriter();
+
+        QueryBuilder qb = new QueryBuilder().setFreetext(queryString);
+        Context c = new Context(qb.build(), qb.getQueries());
+
+        boolean match =
+                c.getContext(in, out, "", "", "", null, true, qb.isDefSearch(), null);
+     
+        if( expectWordInContext == null ) {
+            assertFalse("Match found", match);
+        } else {            
+            assertTrue("No match found", match);
+            String s = out.toString();
+            assertTrue("Searched word '"+expectWordInContext+"' not in context", s.contains("<b>"+expectWordInContext+"</b>"));
+        }
+    } 
 }

--- a/test/org/opensolaris/opengrok/search/context/ContextTest.java
+++ b/test/org/opensolaris/opengrok/search/context/ContextTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.search.context;
 

--- a/test/org/opensolaris/opengrok/search/context/RegexpMatcherTest.java
+++ b/test/org/opensolaris/opengrok/search/context/RegexpMatcherTest.java
@@ -1,0 +1,48 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opensolaris.opengrok.search.context;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the RegexpMatcher class.
+ */
+public class RegexpMatcherTest {
+    
+    /**
+     * Test of match method.
+     */
+    @Test
+    public void testMatch() {
+        RegexpMatcher m = new RegexpMatcher("reg[e]+x", true);
+        assertEquals(LineMatcher.NOT_MATCHED, m.match("regx"));
+        assertEquals(LineMatcher.MATCHED, m.match("regeex"));
+        
+        m = new RegexpMatcher("Reg[e]+x", false);
+        assertEquals(LineMatcher.NOT_MATCHED, m.match("regex"));
+        assertEquals(LineMatcher.MATCHED, m.match("Regex"));
+    }    
+    
+}

--- a/test/org/opensolaris/opengrok/search/context/RegexpMatcherTest.java
+++ b/test/org/opensolaris/opengrok/search/context/RegexpMatcherTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
  */
 
 package org.opensolaris.opengrok.search.context;


### PR DESCRIPTION
Simple implementation adding context lines with searched words for
Regexp search.
Java Regexp is used to find words on lines, so any differences to Lucene
Regexp are ignored.

This is easy solution, until there is something more robust 100% compatible with Lucene regexps. But for most cases this should work.

TODO: Add some unit tests, as soon as I will find right place for them in existing tests.