### PR TITLE
Improve Perforce files history&annotate

### DIFF
--- a/src/org/opensolaris/opengrok/history/PerforceHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/PerforceHistoryParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
  */
 
 package org.opensolaris.opengrok.history;
@@ -30,7 +30,6 @@ import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -87,7 +86,7 @@ public class PerforceHistoryParser {
         ArrayList<String> cmd = new ArrayList<String>();
         cmd.add("p4");
         cmd.add("filelog");
-        cmd.add("-lt");
+        cmd.add("-lti");
         cmd.add(file.getName() + PerforceRepository.getRevisionCmd(rev));
         Executor executor = new Executor(cmd, file.getCanonicalFile().getParentFile());
         executor.exec();

--- a/src/org/opensolaris/opengrok/history/PerforceHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/PerforceHistoryParser.java
@@ -169,7 +169,6 @@ public class PerforceHistoryParser {
                     entry.setDate(newDate(year, month, day, hour, minute, second));
                     entry.setAuthor(matcher.group(8));
                     entry.setActive(true);
-                    entry.appendMessage("CL" + matcher.group(1) + " ");
                 } else {
                     if (entry != null) {
                         /* ... an entry can also finish when some branch/edit entry is encountered */

--- a/src/org/opensolaris/opengrok/history/PerforceHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/PerforceHistoryParser.java
@@ -30,6 +30,7 @@ import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -87,14 +88,14 @@ public class PerforceHistoryParser {
         cmd.add("p4");
         cmd.add("filelog");
         cmd.add("-lt");
-        cmd.add(file.getName() + ((rev == null) ? "" : "#"+rev));
+        cmd.add(file.getName() + PerforceRepository.getRevisionCmd(rev));
         Executor executor = new Executor(cmd, file.getCanonicalFile().getParentFile());
         executor.exec();
 
         return parseFileLog(executor.getOutputReader());
     }
 
-    private static final Pattern REVISION_PATTERN = Pattern.compile("#(\\d+) change \\d+ \\S+ on (\\d{4})/(\\d{2})/(\\d{2}) (\\d{2}):(\\d{2}):(\\d{2}) by ([^@]+)");
+    private static final Pattern REVISION_PATTERN = Pattern.compile("#\\d+ change (\\d+) \\S+ on (\\d{4})/(\\d{2})/(\\d{2}) (\\d{2}):(\\d{2}):(\\d{2}) by ([^@]+)");
     private static final Pattern CHANGE_PATTERN = Pattern.compile("Change (\\d+) on (\\d{4})/(\\d{2})/(\\d{2}) (\\d{2}):(\\d{2}):(\\d{2}) by ([^@]+)@\\S* '([^']*)'");
 
     /**
@@ -118,7 +119,7 @@ public class PerforceHistoryParser {
                 matcher.reset(line);
                 if (matcher.find()) {
                     HistoryEntry entry = new HistoryEntry();
-                    entry.setRevision(matcher.group(1));
+                    entry.setRevision(matcher.group(1)); 
                     int year = Integer.parseInt(matcher.group(2));
                     int month = Integer.parseInt(matcher.group(3));
                     int day = Integer.parseInt(matcher.group(4));
@@ -169,6 +170,7 @@ public class PerforceHistoryParser {
                     entry.setDate(newDate(year, month, day, hour, minute, second));
                     entry.setAuthor(matcher.group(8));
                     entry.setActive(true);
+                    entry.appendMessage("CL" + matcher.group(1) + " ");
                 } else {
                     if (entry != null) {
                         /* ... an entry can also finish when some branch/edit entry is encountered */

--- a/src/org/opensolaris/opengrok/history/PerforceRepository.java
+++ b/src/org/opensolaris/opengrok/history/PerforceRepository.java
@@ -74,8 +74,8 @@ public class PerforceRepository extends Repository {
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         cmd.add(this.cmd);
         cmd.add("annotate");
-        cmd.add("-q");
-        cmd.add(file.getPath() + ((rev == null) ? "" : "#" + rev));
+        cmd.add("-qc");
+        cmd.add(file.getPath() + getRevisionCmd(rev));
 
         Executor executor = new Executor(cmd, file.getParentFile());
         executor.exec();
@@ -110,7 +110,7 @@ public class PerforceRepository extends Repository {
         cmd.add(this.cmd);
         cmd.add("print");
         cmd.add("-q");
-        cmd.add(basename + ((rev == null) ? "" : "#" + rev));
+        cmd.add(basename + getRevisionCmd(rev));
         Executor executor = new Executor(cmd, new File(parent));
         executor.exec();
         return new ByteArrayInputStream(executor.getOutputString().getBytes());
@@ -208,5 +208,18 @@ public class PerforceRepository extends Repository {
     @Override
     History getHistory(File file) throws HistoryException {
         return new PerforceHistoryParser().parse(file, this);
+    }
+    
+    /**
+     * Parse internal rev number and returns it in format suitable for P4 command-line.
+     * @param rev Internal rev number.
+     * @return rev number formatted for P4 command-line.
+     */
+    public static String getRevisionCmd(String rev) {
+        if(rev == null) {
+            return "";
+        }
+        //TODO "#", split cl-#rev
+        return "@" + rev; //identify with changelist id
     }
 }

--- a/src/org/opensolaris/opengrok/history/PerforceRepository.java
+++ b/src/org/opensolaris/opengrok/history/PerforceRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.history;
 
@@ -74,7 +74,7 @@ public class PerforceRepository extends Repository {
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         cmd.add(this.cmd);
         cmd.add("annotate");
-        cmd.add("-qc");
+        cmd.add("-qci");
         cmd.add(file.getPath() + getRevisionCmd(rev));
 
         Executor executor = new Executor(cmd, file.getParentFile());
@@ -216,10 +216,9 @@ public class PerforceRepository extends Repository {
      * @return rev number formatted for P4 command-line.
      */
     public static String getRevisionCmd(String rev) {
-        if(rev == null) {
+        if(rev == null || "".equals(rev)) {
             return "";
         }
-        //TODO "#", split cl-#rev
-        return "@" + rev; //identify with changelist id
+        return "@" + rev;
     }
 }

--- a/test/org/opensolaris/opengrok/history/PerforceHistoryParserTest.java
+++ b/test/org/opensolaris/opengrok/history/PerforceHistoryParserTest.java
@@ -123,7 +123,7 @@ public class PerforceHistoryParserTest {
         assertEquals(4, result.getHistoryEntries().size());
 
         HistoryEntry e1 = result.getHistoryEntries().get(0);
-        assertEquals("4", e1.getRevision());
+        assertEquals("1234", e1.getRevision());
         assertEquals("User", e1.getAuthor());
         assertEquals(0, e1.getFiles().size());
         assertTrue(e1.getMessage().contains("number 4"));


### PR DESCRIPTION
Improve files version in Perforce repository:
Switch from '#file revision' to '@change number' as files version id.

Why?
'@change number' is version counter of whole repository. It's changelist ID, increased with each submit to repository.
'#file revision' - is version counter per file. Increased by 1 with every change on file. And is reset to 1 when file is moved/integrated!
(Description of #@ here http://www.perforce.com/perforce/r12.2/manuals/cmdref/o.fspecs.html)

That means with current #:
 - versions of one file are not always distinct
 - OG can show file version history like: 1,2,3,4,1,2 - (this completely ruins annotate feature on any moved/integrated file)
 - searching by changelist number does not work
 - directories use @ as version, so it is not consistent with files
 + the only advantage is that on annotate page, file versions are low numbers, so it's easy to compare them visualy 

After change to @:
 + file versions are distinct, so annotate is correct on moved/integrated files
 + searching for @ changelist id works
 + dirs/files have consistent versioning


----
Remaining issues (they are not introduced by this change):
1)
Getting version of moved/integrated file, before move/integration does not work.
Because old version is get from P4 on latest path, which is not valid before move/integration.
2)
I don't understand why, but storing history into DB with option '-D' still doesn't work.
It fails with:
WARNING: An error occured while creating cache for ... (PerforceRepository)
org.opensolaris.opengrok.history.HistoryException: java.sql.SQLIntegrityConstraintViolationException: The statement was aborted because it would have caused a duplicate key value in a unique or primary key constraint or unique index identified by 'CHANGESETS_REPO_REV_UNIQUE' defined on 'CHANGESETS'.
        at org.opensolaris.opengrok.history.JDBCHistoryCache.store(JDBCHistoryCache.java:677)
        at org.opensolaris.opengrok.history.Repository.createCache(Repository.java:328)
        at org.opensolaris.opengrok.history.HistoryGuru.createCache(HistoryGuru.java:496)
        at org.opensolaris.opengrok.history.HistoryGuru.ensureHistoryCacheExists(HistoryGuru.java:693)
        at org.opensolaris.opengrok.index.IndexDatabase.update(IndexDatabase.java:357)
        at org.opensolaris.opengrok.index.IndexDatabase$1.run(IndexDatabase.java:176)
I thought making files version distinct with this fix should help, but it's not enough.
I may create separate issue for this, if we can't solve it somehow easily as part of this pull request.