### PR TITLE
Add Scopes feature for CSharp

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -215,6 +215,7 @@ Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
         <run-jflex file="${src.dir}/org/opensolaris/opengrok/analysis/vb/VBXref.lex"/>
         <run-jflex file="${src.dir}/org/opensolaris/opengrok/analysis/csharp/CSharpSymbolTokenizer.lex"/>
         <run-jflex file="${src.dir}/org/opensolaris/opengrok/analysis/csharp/CSharpXref.lex"/>
+        <run-jflex file="${src.dir}/org/opensolaris/opengrok/analysis/csharp/CSharpScopeParser.lex"/>	
         <run-jflex file="${src.dir}/org/opensolaris/opengrok/analysis/uue/UuencodeXref.lex"/>
         <run-jflex file="${src.dir}/org/opensolaris/opengrok/analysis/uue/UuencodeFullTokenizer.lex"/>
         <run-jflex file="${src.dir}/org/opensolaris/opengrok/search/context/HistoryLineTokenizer.lex"/>

--- a/src/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.analysis.csharp;
 
@@ -27,6 +27,7 @@ import java.io.Reader;
 import java.io.Writer;
 import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
+import org.opensolaris.opengrok.analysis.JFlexScopeParser;
 import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
@@ -41,6 +42,11 @@ public class CSharpAnalyzer extends AbstractSourceCodeAnalyzer {
 
     protected CSharpAnalyzer(FileAnalyzerFactory factory) {
         super(factory);
+    }
+
+    @Override
+    protected JFlexScopeParser newScopeParser(Reader reader) {
+        return new CSharpScopeParser(reader);
     }
 
     @Override

--- a/src/org/opensolaris/opengrok/analysis/csharp/CSharpScopeParser.lex
+++ b/src/org/opensolaris/opengrok/analysis/csharp/CSharpScopeParser.lex
@@ -1,0 +1,89 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").  
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ */
+
+/*
+ * Parses CSharp scopes - ignores comments, strings, keywords
+ */
+
+package org.opensolaris.opengrok.analysis.csharp;
+import org.opensolaris.opengrok.analysis.JFlexScopeParser;
+
+%%
+%public
+%class CSharpScopeParser
+%extends JFlexScopeParser
+%unicode
+%line
+%column
+%int
+%{
+  // TODO move this into an include file when bug #16053 is fixed
+  @Override
+  protected int getLineNumber() { return yyline; }
+  @Override
+  protected void setLineNumber(int x) { yyline = x; }
+  @Override
+  protected void start(String defText) { level = defText.trim().endsWith("{") ? 1 : 0; }
+  
+  private int level = 0;
+  private void incScope() { level++; }
+  private void decScope() { if (level > 0) { level--; if (level == 0) { scope.lineTo = yyline; } } }
+%}
+
+
+%state STRING COMMENT SCOMMENT QSTRING
+
+%%
+
+<YYINITIAL> {
+
+ \{     { incScope(); }
+ \}     { decScope(); if (level == 0) { return yyeof; } }
+
+ \"     { yybegin(STRING); }
+ \'     { yybegin(QSTRING); }
+ "/*"   { yybegin(COMMENT); }
+ "//"   { yybegin(SCOMMENT); }
+}
+
+<STRING> {
+ \"     { yybegin(YYINITIAL); }
+\\\\ | \\\"     {}
+}
+
+<QSTRING> {
+ \'     { yybegin(YYINITIAL); }
+}
+
+<COMMENT> {
+"*/"    { yybegin(YYINITIAL);}
+}
+
+<SCOMMENT> {
+\n      { yybegin(YYINITIAL);}
+}
+
+<YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
+<<EOF>>   { return yyeof;}
+[^]    {}
+}

--- a/test/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzerFactoryTest.java
+++ b/test/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzerFactoryTest.java
@@ -96,7 +96,7 @@ public class CSharpAnalyzerFactoryTest {
      */
     @Test
     public void testScopeAnalyzer() throws Exception {
-        String path = "D:/projects/GitHub/OpenGrok/testdata/sources/csharp/Sample.cs"; //repository.getSourceRoot() + "/csharp/Sample.cs";
+        String path = repository.getSourceRoot() + "/csharp/Sample.cs";
         File f = new File(path);
         if (!(f.canRead() && f.isFile())) {
             fail("csharp testfile " + f + " not found");

--- a/test/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzerFactoryTest.java
+++ b/test/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzerFactoryTest.java
@@ -1,0 +1,140 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.analysis.csharp;
+
+import org.opensolaris.opengrok.analysis.c.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableField;
+import java.io.InputStream;
+import java.io.StringWriter;
+import org.apache.lucene.document.Field;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.opensolaris.opengrok.analysis.AnalyzerGuru.string_ft_nstored_nanalyzed_norms;
+import org.opensolaris.opengrok.analysis.Ctags;
+import org.opensolaris.opengrok.analysis.FileAnalyzer;
+import org.opensolaris.opengrok.analysis.Scopes;
+import org.opensolaris.opengrok.analysis.Scopes.Scope;
+import org.opensolaris.opengrok.analysis.StreamSource;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
+import org.opensolaris.opengrok.search.QueryBuilder;
+import org.opensolaris.opengrok.util.TestRepository;
+
+/**
+ *
+ * @author kotal
+ */
+public class CSharpAnalyzerFactoryTest {
+    
+    FileAnalyzer analyzer;
+    private String ctagsProperty = "org.opensolaris.opengrok.analysis.Ctags";
+    private static Ctags ctags;
+    private static TestRepository repository;
+
+    public CSharpAnalyzerFactoryTest() {
+        CSharpAnalyzerFactory analFact = new CSharpAnalyzerFactory();
+        this.analyzer = analFact.getAnalyzer();
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.setCtags(System.getProperty(ctagsProperty, "ctags"));
+        if (env.validateExuberantCtags()) {
+            this.analyzer.setCtags(new Ctags());
+        }
+    }
+    
+    private static StreamSource getStreamSource(final String fname) {
+        return new StreamSource() {
+            @Override
+            public InputStream getStream() throws IOException {
+                return new FileInputStream(fname);
+            }
+        };
+    }
+    
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        ctags = new Ctags();
+        ctags.setBinary(RuntimeEnvironment.getInstance().getCtags());
+
+        repository = new TestRepository();
+        repository.create(CSharpAnalyzerFactoryTest.class.getResourceAsStream(
+                "/org/opensolaris/opengrok/index/source.zip"));
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {        
+        ctags.close();
+        ctags = null;
+    }
+
+    /**
+     * Test of writeXref method, of class CSharpAnalyzerFactory.
+     */
+    @Test
+    public void testScopeAnalyzer() throws Exception {
+        String path = "D:/projects/GitHub/OpenGrok/testdata/sources/csharp/Sample.cs"; //repository.getSourceRoot() + "/csharp/Sample.cs";
+        File f = new File(path);
+        if (!(f.canRead() && f.isFile())) {
+            fail("csharp testfile " + f + " not found");
+        }
+        
+        Document doc = new Document();
+        doc.add(new Field(QueryBuilder.FULLPATH, path,
+            string_ft_nstored_nanalyzed_norms));
+        StringWriter xrefOut = new StringWriter();
+        analyzer.setCtags(ctags);
+        analyzer.setScopesEnabled(true);
+        analyzer.analyze(doc, getStreamSource(path), xrefOut);
+        
+        IndexableField scopesField = doc.getField(QueryBuilder.SCOPES);
+        assertNotNull(scopesField);
+        Scopes scopes = Scopes.deserialize(scopesField.binaryValue().bytes);
+        Scope globalScope = scopes.getScope(-1);
+        assertEquals(4, scopes.size()); //TODO 5
+        
+        for (int i=0; i<41; ++i) {
+            if (i >= 10 && i <= 10) {
+                assertEquals("M1", scopes.getScope(i).name);
+                assertEquals("class:MyNamespace.TopClass", scopes.getScope(i).scope);
+            } else if (i >= 12 && i <= 14) {
+                assertEquals("M2", scopes.getScope(i).name);
+                assertEquals("class:MyNamespace.TopClass", scopes.getScope(i).scope);
+            } else if (i >= 19 && i <= 25) {
+                assertEquals("M3", scopes.getScope(i).name);
+                assertEquals("class:MyNamespace.TopClass", scopes.getScope(i).scope);
+//TODO add support for generic classes                
+//            } else if (i >= 28 && i <= 30) { 
+//                assertEquals("M4", scopes.getScope(i).name);
+//                assertEquals("class:MyNamespace.TopClass", scopes.getScope(i).scope);
+            } else if (i >= 34 && i <= 36) {
+                assertEquals("M5", scopes.getScope(i).name);
+                assertEquals("class:MyNamespace.TopClass.InnerClass", scopes.getScope(i).scope);
+            }
+        }
+    }
+    
+}

--- a/testdata/sources/csharp/Sample.cs
+++ b/testdata/sources/csharp/Sample.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace MyNamespace
+{
+    /// <summary>
+    /// summary
+    /// </summary>
+    [Tag]
+    class TopClass {
+        public int M1() { }
+
+        public static void M2() {
+            //public static int MERR() {}
+        }
+
+        /// <summary>
+        /// sum
+        /// </summary>
+        public void M3() 
+        {
+            /* hi 
+                public static int MERR() {
+                }
+            */
+        }
+
+        [Tag]
+        private T M4<T>(T p) where T : new()
+        {
+        }
+
+        public class InnerClass 
+        {
+            private string M5(int x) {  
+                return null;
+            }
+        }
+
+    {
+
+}


### PR DESCRIPTION
I followed Scopes implementation for C/Java and added support for CSharp.

Lex parser without any modification should work in 99% cases.

Known issues:
- generic methods with type constraints are not recognized.
Eg. private T M4<T>(T p) where T : new()
Text 'where T' between ) : confuse the parser

--
We could easily add same support for Javascript, maybe more languages.
Do we want always copy the same .lex file (as it was done for C/Java), or should we share one base for all common languages?

--
I'd like to propose 2 simple patches to Scopes ui, if you and especially author of Scopes agree, I would:
- add at least word 'in ' before scope name in search context - for regular user it may not be clear what the 'name()' really means. 
- blue is nice, but too much visible compared to search results, 'darkgray' works good for me. Scopes are helpful, but search results are still more important.
