### PR TITLE
Annotate - highlight recent file revisions lines

### DIFF
--- a/src/org/opensolaris/opengrok/history/Annotation.java
+++ b/src/org/opensolaris/opengrok/history/Annotation.java
@@ -47,6 +47,7 @@ public class Annotation {
 
     private final List<Line> lines = new ArrayList<Line>();
     private final Map<String, String> desc = new HashMap<String, String>();
+    private final Map<String, Integer> fileVersions = new HashMap<String, Integer>(); //maps revision to file version
     private int widestRevision;
     private int widestAuthor;
     private final String filename;
@@ -163,6 +164,30 @@ public class Annotation {
         return desc.get(revision);
     }
 
+    void addFileVersion(String revision, int fileVersion) {
+        fileVersions.put(revision, fileVersion);
+    }    
+
+    /**
+     * Translates repository revision number into file version.
+     * @param revision revision number
+     * @return file version number. 0 if unknown. 1 first version of file, etc.
+     */
+    public int getFileVersion(String revision) {
+        if( fileVersions.containsKey(revision) ) {
+            return fileVersions.get(revision);
+        } else {
+            return 0;
+        }
+    }   
+
+    /**
+     * @return Count of revisions on this file.
+     */
+    public int getFileVersionsCount() {
+        return fileVersions.size();
+    } 
+    
     /** Class representing one line in the file. */
     private static class Line {
         final String revision;

--- a/src/org/opensolaris/opengrok/history/HistoryGuru.java
+++ b/src/org/opensolaris/opengrok/history/HistoryGuru.java
@@ -141,6 +141,7 @@ public final class HistoryGuru {
             }
             if (hist != null && ret != null) {
              Set<String> revs = ret.getRevisions();
+             int revsMatched = 0;
              // !!! cannot do this because of not matching rev ids (keys)
              // first is the most recent one, so we need the position of "rev"
              // until the end of the list
@@ -154,6 +155,8 @@ public final class HistoryGuru {
                     ret.addDesc(short_rev, "changeset: " + he.getRevision() +
                         "\nsummary: " + he.getMessage() + "\nuser: " +
                         he.getAuthor() + "\ndate: " + he.getDate());
+                    ret.addFileVersion(short_rev, revs.size() - revsMatched); //history entries are coming from recent to older, file version should be from oldest to newer
+                    revsMatched++;
                 }
              }
             }

--- a/src/org/opensolaris/opengrok/web/Util.java
+++ b/src/org/opensolaris/opengrok/web/Util.java
@@ -511,6 +511,8 @@ public final class Util {
                     out.write("\" title=\"");
                     out.write(msg);
                 }
+                int versionVisibility = 221 - ((221 * annotation.getFileVersion(r)) / annotation.getFileVersionsCount()); //keep this in rance 0..221, 0 most visible
+                out.write("\" style=\"background-color: rgb(221,221,"+  versionVisibility +");");
                 out.write(closeQuotedTag);
             }
             StringBuilder buf = new StringBuilder();

--- a/src/org/opensolaris/opengrok/web/Util.java
+++ b/src/org/opensolaris/opengrok/web/Util.java
@@ -511,7 +511,10 @@ public final class Util {
                     out.write("\" title=\"");
                     out.write(msg);
                 }
-                int versionVisibility = 221 - ((221 * annotation.getFileVersion(r)) / annotation.getFileVersionsCount()); //keep this in rance 0..221, 0 most visible
+                int versionVisibility = annotation.getFileVersionsCount() > 1
+                    ? 221 - ((221 * Math.max(0, annotation.getFileVersion(r)-1) ) / (annotation.getFileVersionsCount()-1) ) //keep this in range 0..221, 0 most visible
+                    : 221
+                ;
                 out.write("\" style=\"background-color: rgb(221,221,"+  versionVisibility +");");
                 out.write(closeQuotedTag);
             }


### PR DESCRIPTION
On annotate page - color file revisions numbers background, according to their age, so that recent revisions are highlighted more.

This way it's easy to visually distinguish new/old parts of file, without exactly reading revision ids.

Preview here:
![opengrok-annotate-highlight](https://cloud.githubusercontent.com/assets/2125998/6544097/1f520316-c53d-11e4-818a-cd1235439b3a.png)

I will welcome any feedback, especially for css part. This could cooperate better with regular css styles in OpenGrok.