### PR TITLE
Remove bashism in the OpenGrok script

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -714,7 +714,7 @@ ValidateConfiguration()
 
     if [ -n "${OPENGROK_DERBY}" ]
     then
-        if [ `uname -s` == "SunOS" -a -d /opt/SUNWjavadb -a -d /usr/opengrok ];
+        if [ "`uname -s`" = "SunOS" -a -d /opt/SUNWjavadb -a -d /usr/opengrok ];
 	then
 	    if [ -d "/var/tomcat6" -a \
 	        ! -r "/var/tomcat6/webapps/source/WEB-INF/lib/derbyclient.jar" ];


### PR DESCRIPTION
String equality should be tested with '=' and not with '=='. The
latter is an extension in bash. I'm seeing the following error on a
system where /bin/sh is dash:

/code/OpenGrok/OpenGrok: 717: [: Linux: unexpected operator