### PR TITLE
READ_XML_CONF not set properly

### DIFF
--- a/platform/solaris/smf/ogindexd
+++ b/platform/solaris/smf/ogindexd
@@ -53,7 +53,7 @@ read_config() {
 	fi
 
 	if [ -r "$READONLY_CFG_FILE" ]; then
-		READ_XML_CONF="-R $a"
+		READ_XML_CONF="-R $READONLY_CFG_FILE"
 	fi
 }
 


### PR DESCRIPTION
-R $a was not valid, it should be referring to $READONLY_CFG_FILE