### PR TITLE
C++ identifiers within angle brackets should be treated as identifiers

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/c/CXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/c/CXref.lex
@@ -30,6 +30,8 @@ import org.opensolaris.opengrok.analysis.JFlexXref;
 import java.io.IOException;
 import java.io.Writer;
 import java.io.Reader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.opensolaris.opengrok.web.Util;
 
 %%
@@ -68,11 +70,17 @@ Number = (0[xX][0-9a-fA-F]+|[0-9]+\.[0-9]+|[1-9][0-9]*)(([eE][+-]?[0-9]+)?[ufdlU
     writeSymbol(id, Consts.kwd, yyline);
 }
 
-"<" ({File}|{Path}|{Identifier}) ">" {
-        out.write("&lt;");
-        String path = yytext().substring(1, yylength() - 1);
-        out.write(Util.breadcrumbPath(urlPrefix + "path=", path));
-        out.write("&gt;");
+"#" {WhiteSpace}* "include" {WhiteSpace}* "<" ({File}|{Path}|{Identifier}) ">" {
+        Matcher match = Pattern.compile("(#.*)(include)(.*)<(.*)>").matcher(yytext());
+        if (match.matches()) {
+            out.write(match.group(1));
+            writeSymbol(match.group(2), Consts.kwd, yyline);
+            out.write(match.group(3));
+            out.write("&lt;");
+            String path = match.group(4);
+            out.write(Util.breadcrumbPath(urlPrefix + "path=", path));
+            out.write("&gt;");
+        }
 }
 
 /*{Hier}

--- a/src/org/opensolaris/opengrok/analysis/c/CxxXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/c/CxxXref.lex
@@ -30,6 +30,8 @@ import org.opensolaris.opengrok.analysis.JFlexXref;
 import java.io.IOException;
 import java.io.Writer;
 import java.io.Reader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.opensolaris.opengrok.web.Util;
 
 %%
@@ -68,11 +70,17 @@ Number = (0[xX][0-9a-fA-F]+|[0-9]+\.[0-9]+|[1-9][0-9]*)(([eE][+-]?[0-9]+)?[ufdlU
     writeSymbol(id, CxxConsts.kwd, yyline);
 }
 
-"<" ({File}|{Path}|{Identifier}) ">" {
-        out.write("&lt;");
-        String path = yytext().substring(1, yylength() - 1);
-        out.write(Util.breadcrumbPath(urlPrefix + "path=", path));
-        out.write("&gt;");
+"#" {WhiteSpace}* "include" {WhiteSpace}* "<" ({File}|{Path}|{Identifier}) ">" {
+        Matcher match = Pattern.compile("(#.*)(include)(.*)<(.*)>").matcher(yytext());
+        if (match.matches()) {
+            out.write(match.group(1));
+            writeSymbol(match.group(2), CxxConsts.kwd, yyline);
+            out.write(match.group(3));
+            out.write("&lt;");
+            String path = match.group(4);
+            out.write(Util.breadcrumbPath(urlPrefix + "path=", path));
+            out.write("&gt;");
+        }
 }
 
 /*{Hier}

--- a/test/org/opensolaris/opengrok/analysis/JFlexXrefTest.java
+++ b/test/org/opensolaris/opengrok/analysis/JFlexXrefTest.java
@@ -285,6 +285,20 @@ public class JFlexXrefTest {
     }
 
     /**
+     * Verify that template parameters are treated as class names rather than
+     * filenames.
+     */
+    @Test
+    public void testCxxXrefTemplateParameters() throws Exception {
+        StringReader in = new StringReader("#include <vector>\nclass MyClass;\nstd::vector<MyClass> *v;");
+        StringWriter out = new StringWriter();
+        JFlexXref xref = new CxxXref(in);
+        xref.write(out);
+        assertTrue("Link to search for definition of class not found",
+                   out.toString().contains("&lt;<a href=\"/source/s?defs=MyClass\""));
+    }
+
+    /**
      * Verify that ShXref handles here-documents. Bug #18198.
      */
     @Test


### PR DESCRIPTION
When indexing C++ source code, identifiers that are found within angle brackets are treated as filenames instead of identifiers.  For example, say you have the following source code:

    int main() {
        Wrapper<MyClass> x;
        return 0;
    }

When this gets processed, "MyClass" will link to "/source/s?path=MyClass".  Since MyClass is not a filename this search is not likely to return anything useful.  It should be linking to "defs" instead of "path".

The code was intended to handle things like "#include <filename.h>" but it activates in too many places.  The rule should be restricted so that it only applies following "#include".

My new code feels a bit hacky but I'm not familiar with JFlex and this was the best that I could come up with.  Suggestions for a better approach are welcome.
