### PR TITLE
fix syntax highlight for C# verbatim strings

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/csharp/CSharpXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/csharp/CSharpXref.lex
@@ -94,6 +94,7 @@ Number = (0[xX][0-9a-fA-F]+|[0-9]+\.[0-9]+|[0-9]+)(([eE][+-]?[0-9]+)?[ufdlUFDL]*
  \'     { yybegin(QSTRING);out.write("<span class=\"s\">\'");}
  "/*"   { yybegin(COMMENT);out.write("<span class=\"c\">/*");}
  "//"   { yybegin(SCOMMENT);out.write("<span class=\"c\">//");}
+ "@\""  { yybegin(VSTRING);out.write("<span class=\"s\">@\"");}  
 }
 
 <STRING> {

--- a/test/org/opensolaris/opengrok/analysis/JFlexXrefTest.java
+++ b/test/org/opensolaris/opengrok/analysis/JFlexXrefTest.java
@@ -35,6 +35,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opensolaris.opengrok.analysis.c.CXref;
 import org.opensolaris.opengrok.analysis.c.CxxXref;
+import org.opensolaris.opengrok.analysis.csharp.CSharpXref;
 import org.opensolaris.opengrok.analysis.document.TroffXref;
 import org.opensolaris.opengrok.analysis.fortran.FortranXref;
 import org.opensolaris.opengrok.analysis.haskell.HaskellXref;
@@ -387,5 +388,17 @@ public class JFlexXrefTest {
                 + "<span class='c'>\n"
                 + "<a class=\"l\" name=\"2\" href=\"#2\">2</a>",
                 out.toString());
+    }
+    
+    /**
+     * Test that CSharpXref correctly handles verbatim strings that end with backslash
+     */
+    @Test
+    public void testCsharpXrefVerbatimString() throws IOException {
+        StringReader in = new StringReader("test(@\"\\some_windows_path_in_a_string\\\");");
+        CSharpXref xref = new CSharpXref(in);
+        StringWriter out = new StringWriter();
+        xref.write(out);
+        assertTrue(out.toString().contains("<span class=\"s\">@\"\\some_windows_path_in_a_string\\\"</span>"));
     }
 }


### PR DESCRIPTION
CSharpXref doesn't work correctly for verbatim strings that end with a backslash. This is the fix.