### PR TITLE
Added method allowing user to manually update the lastModified variab…

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -626,6 +626,16 @@ public final class Configuration {
     }
 
     /**
+     * Update the lastModified variable, in the case of running a third party indexing job
+     *
+     * @param d
+     */
+
+    public void updateLastModified(Date d){
+        lastModified = d;
+    }
+
+    /**
      * Get the contents of a file or empty string if the file cannot be read.
      */
     private static String getFileContent(File file) {


### PR DESCRIPTION
Currently, the "Indexes Created: xxxxx" section of the footer on the homepage only updates every time the entirety of opengrok is restarted. When using a third party (Jenkins jobs) to re-index, this date is not updated, as the opengrok service itself has not rebooted. 

Proposal - add method that allows user to manually update the lastModified variable in the Configuration object, to avoid restarting opengrok every time a third party re-index job is run. 

Open tickets concerning this problem: https://github.com/OpenGrok/OpenGrok/issues/948