### PR TITLE
Fix C# yyline mismatch issue.

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/csharp/CSharpXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/csharp/CSharpXref.lex
@@ -69,7 +69,7 @@ Number = (0[xX][0-9a-fA-F]+|[0-9]+\.[0-9]+|[0-9]+)(([eE][+-]?[0-9]+)?[ufdlUFDL]*
 
 {Identifier} {
     String id = yytext();
-    writeSymbol(id, Consts.kwd, yyline - 1);
+    writeSymbol(id, Consts.kwd, yyline);
 }
 
 "<" ({File}|{Path}) ">" {


### PR DESCRIPTION
This issue causes no html anchor generated at the definition position of
the symbol in C# xref source files, so can't navigate to that definition
location(in the same file) by a simple click.