### PR TITLE
Preserving whitespace on copy-paste

### DIFF
--- a/web/default/print.css
+++ b/web/default/print.css
@@ -8,6 +8,19 @@ a {
 	text-decoration: none;
 }
 
+
+div#src a.l, div#src a.hl {
+    padding: 0;
+}
+
+div#src a.l:after, div#src a.hl:after {
+    content: "\0020";
+}
+
+div#src a.l.selected:after, div#src a.hl.selected:after {
+    content: "";
+}
+
 a:link {
 	color: #2030A2;
 }

--- a/web/default/style.css
+++ b/web/default/style.css
@@ -10,6 +10,14 @@ a {
 	text-decoration: none;
 }
 
+div#src a.l:after, div#src a.hl:after {
+    content: "\0020";
+}
+
+div#src a.l.selected:after, div#src a.hl.selected:after {
+    content: "";
+}
+
 a:link {
 	color: #2030A2;
 }

--- a/web/offwhite/print.css
+++ b/web/offwhite/print.css
@@ -8,6 +8,18 @@ a {
 	text-decoration: none;
 }
 
+div#src a.l, div#src a.hl {
+    padding: 0;
+}
+
+div#src a.l:after, div#src a.hl:after {
+    content: "\0020";
+}
+
+div#src a.l.selected:after, div#src a.hl.selected:after {
+    content: "";
+}
+
 a:link {
 	color: #2030A2;
 }

--- a/web/offwhite/style.css
+++ b/web/offwhite/style.css
@@ -10,6 +10,18 @@ a {
 	text-decoration: none;
 }
 
+div#src a.l, div#src a.hl {
+    padding: 0;
+}
+
+div#src a.l:after, div#src a.hl:after {
+    content: "\0020";
+}
+
+div#src a.l.selected:after, div#src a.hl.selected:after {
+    content: "";
+}
+
 a:link {
 	color: #2030A2;
 }

--- a/web/polished/print.css
+++ b/web/polished/print.css
@@ -8,6 +8,18 @@ a {
 	text-decoration: none;
 }
 
+div#src a.l, div#src a.hl {
+    padding: 0;
+}
+
+div#src a.l:after, div#src a.hl:after {
+    content: "\0020";
+}
+
+div#src a.l.selected:after, div#src a.hl.selected:after {
+    content: "";
+}
+
 a:link {
 	color: #2030A2;
 }

--- a/web/polished/style.css
+++ b/web/polished/style.css
@@ -10,6 +10,18 @@ a {
 	text-decoration: none;
 }
 
+div#src a.l, div#src a.hl {
+    padding: 0;
+}
+
+div#src a.l:after, div#src a.hl:after {
+    content: "\0020";
+}
+
+div#src a.l.selected:after, div#src a.hl.selected:after {
+    content: "";
+}
+
 a:link {
 	color: #2030A2;
 }

--- a/web/utils.js
+++ b/web/utils.js
@@ -21,6 +21,264 @@
  * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
  */
 
+(function(window, $) {
+   
+    var spaces = function () {
+        var inner = {
+            self: this,
+            initialized: false,
+            /**
+             * Mouse selection event
+             * - upon a user's selection triggers a select event
+             */
+            mouse: {
+                dragging: false,
+                init: function () {
+                    var that = this
+                    $(document).mousedown(function (e) {
+                       that.dragging = false
+                    }).mousemove(function(e){
+                        that.dragging = true
+                    }).mouseup(function(e){
+                        var wasDragging = that.dragging
+                        that.dragging = false
+                        if(wasDragging) {
+                            $(document).trigger("select");
+                        }
+                    }).dblclick(function(e){
+                        //$(document).trigger("select")
+                    });
+                },
+            },           
+            defaults: {
+                "selector": "a.l, a.hl",
+                "parent": "div#src pre",
+                "selectedClass": "selected",
+                "sourceContainer": "pre",
+            },
+            options: {},
+            indent: function($el){
+                return $el.each(function() {
+                    if(! $(this).is("." + inner.options.selectedClass))
+                        $(this).html($(this).html() + "&nbsp");
+                    $(this).addClass(inner.options.selectedClass)
+                });
+            },
+            /**
+             * @returns {Boolean} if client is IE
+             */
+            ie: function() {
+                var ua = window.navigator.userAgent;
+                if (ua.indexOf('MSIE ') > 0 || 
+                    ua.indexOf('Trident/') > 0 ||
+                    ua.indexOf('Edge/') > 0 )
+                    return true;
+                return false;
+            },            
+            getSelection: function () {
+                if (window.getSelection)
+                    return window.getSelection()
+                return null
+            },
+            /**
+
+             * Select closest element giben by options.selector to the actual
+             * element
+             * 
+             * @param {jQuery Object} $el actual element
+             * @param {boolean} next direction
+             * @param {boolean} last if it is the last element in array
+             * @param {int} depth max distance from the path between the actual
+             *                    element and the root element
+             * @returns {Object} of {element found, used given direction}
+             */
+            around: function ($el, next, last, depth) {
+              var slc = inner.options.selector
+              depth = depth || 10
+              next = next || false      
+              last = last || false
+
+                if($el.is(slc)) {
+                  return { "element": $el, "directionUsed": false };
+              }  
+
+              var $tmp = $el;
+              var $result = null
+              var parentDepth = 10
+              // scan every previous parent up to partentDepth
+              // and scan every #depth nodes around a particular parent
+              while ( $tmp.length && 
+                      !$tmp.is (inner.options.sourceContainer) && 
+                      parentDepth >= 0 ) {
+                  if($tmp.is(slc))
+                      return { "element": $tmp, "directionUsed": false }
+                  if(!next) {
+                      // scan #depth previous nodes if they are desired
+                      for ( var i = 0, $tmp2 = $tmp; i < depth && $tmp2.length; i ++ ) {
+                          if ($tmp2.is(slc))
+                              return { "element": $tmp2, "directionUsed": true }
+                          $tmp2 = $tmp2.prev()
+                      }
+                  } else {
+                      // scan #depth next nodes if they are desired
+                      for ( var i = 0, $tmp2 = $tmp; i < depth && $tmp2.length; i ++ ) {
+                          if ($tmp2.is(slc))
+                              return { "element": $tmp2, "directionUsed": true }
+                          $tmp2 = $($tmp2.get(0).nextElementSibling)
+                      }              
+                  }
+                  // going level up
+                  $tmp = $tmp.parent()
+                  parentDepth --;
+              }
+              // no luck in parents -> find links within this node
+              var $down = $el.find(slc)
+              if($down.length){
+                  if(last) {
+                     return { "element": $down.last(), "directionUsed": false }
+                  } else {
+                     return { "element": $down.first (), "directionUsed": false }
+                  }
+              }      
+              return { "element": null, "directionUsed": false }
+            },
+            /**
+             * Handle select event by extracting a range, element lookup,
+             * extending range to approximate bounds and updating range back
+             * to the client
+             * 
+             * @param {Event} e
+             * @returns {undefined} nothing
+             */
+            selectHandler: function(e) {
+                var selection = null
+                if ( ( selection = inner.getSelection() ) == null ) {
+                    console.debug ( "No selection returned. No browser support?")
+                    return
+                }
+                var selector = inner.options.selector
+                var parentSelectorWithLinks = inner.options.selector
+                        .replace( /,/g, ", " + inner.options.parent + " ")
+                        .replace( /^/, inner.options.parent + " ");
+                
+                if(selection.rangeCount <= 0){
+                    //nothing to process
+                    return
+                }
+
+                var range = selection.getRangeAt(0)
+
+                for ( var i = 0; i < selection.rangeCount; i ++ ) {
+                    // if there were more ranges, select the one which is inside 
+                    // the parent element
+                    // default: div#src pre
+                    var r = selection.getRangeAt(i)
+                    if($(r.commonAncestorContainer).has(inner.options.parent).length){
+                        range = r;
+                    }
+                }
+                // clone range (so it works in chrome)
+                range = range.cloneRange()
+
+                // finding closest starting node based on inner.options.selector
+                // by default it's the closest line link
+                $start = $(range.startContainer);
+                $start = inner.around($start, next = false, last = false)
+                $start = $start.element;
+                if($start == null){
+                    // not successful
+                    // - no line link
+                    // - range is larger than the whole source container
+                    // find the first link in the source container
+                    $start = $(parentSelectorWithLinks).filter(":first")
+                }
+
+                if(! $start.length) {
+                    console.debug ( "Cannot determine start link");
+                    return
+                }
+
+                $end = $(range.endContainer);
+                if($end.is(inner.options.sourceContainer) && selection.toString().length <= 5) {
+                    // probably on the same line
+                    $end = $start.next().nextUntil(selector).next()
+                    $end_indir = true
+                } else {
+                    // not on the same line so find closest node according to 
+                    // selector in next nodes
+                    $end = inner.around($end, next = true, last = true)
+                    $end_indir = $end.directionUsed;
+                    $end = $end.element;            
+                }
+                if($end == null){
+                    // not successful
+                    // - no line link
+                    // - range is larger than the whole source container
+                    // find the last link in the source container
+                    $end = $(parentSelectorWithLinks).filter(":last")
+                    $end_dir = false
+                }
+                
+                if (!$end.length) {
+                    console.debug("Cannot determine end link")
+                    return
+                }          
+                
+                range.setStartBefore($start.get(0))
+                
+                if ($end_indir){
+                    range.setEndBefore($end.get(0))
+                } else {
+                    range.setEndAfter($end.get(0))
+                }
+
+                // extract contents (html now has dissapeared)
+                var content = range.extractContents()
+
+                try {
+                    // select all links in the content
+                    // indent link by one space
+                    inner.indent($(content.querySelectorAll(selector)))
+
+                } finally {
+                    // even if there was an error fill the html back to the site
+                    for( var i = 0; i < $(content).length; i ++ )
+                        range.insertNode(content)  
+                }
+
+                // clears the selection
+                selection.removeAllRanges()
+                // inserts the new updated range
+                selection.addRange(range)
+            },
+            init: function() {
+                
+                // IE does not need this feature
+                if( inner.ie () )
+                    return
+                
+                inner.mouse.init()
+                $(document).bind("select", inner.selectHandler );
+            }
+        } // inner
+        
+        this.init = function (options) {
+            if ( inner.initialized )
+                return this;
+            inner.options = $.extend(inner.defaults, options, {})
+            inner.init()
+            inner.initialized = true
+            return this;
+        }
+    }
+    $.spaces = new ($.extend(spaces, $.spaces ? $.spaces : {}));
+}) (window, window.jQuery);
+
+$(document).ready(function(){
+    // starting spaces plugin
+    $.spaces.init()
+});
+
 (function ($) {
     var accordion = function ($parent, options) {
         var inner = {

--- a/web/utils.js
+++ b/web/utils.js
@@ -274,11 +274,6 @@
     $.spaces = new ($.extend(spaces, $.spaces ? $.spaces : {}));
 }) (window, window.jQuery);
 
-$(document).ready(function(){
-    // starting spaces plugin
-    $.spaces.init()
-});
-
 (function ($) {
     var accordion = function ($parent, options) {
         var inner = {
@@ -342,7 +337,10 @@ $(document).ready(function(){
 
 $(document).ready(function () {
     $(".projects").accordion()
-
+    
+    // starting spaces plugin
+    $.spaces.init()
+    
     $(".projects_select_all").click(function (e) {
         var projects = $(this).closest(".panel").find("table tbody tr, .panel-heading table tbody tr")
         var multiselect = $("select#project")


### PR DESCRIPTION
fixes #540 

This deals with the problem of copy-paste whitespace between line number and the rest of the code.
It's pure javascript solution therefore it has no data overhead.

On Firefox and Chrome there is a space appended with css :after selector (but it's not copyable) and upon an user's selection this space is extended to ordinary space which is preserved in selected text.

Because of the natural form of files there is couple of limitations
 - Line gets selected from the beginning to the end (extending users selection)
 - Sometimes it wrongly guesses the first line (or last line) in selection resulting in more lines are selected
But for the usual use case - copying few lines of code to show them somewhere it's sufficient.

Solution is made effective. Lines processing and adding the whitespace is performed only upon the user's selection and only in the range of the selection.

Considering that indexed files shall not be extended with a space by default and considering the tradeoff between the efficiency and complexity; this solution looks reasonably ok for me.

IE preserves the css :after space, so there is no need for additional javascript (tested in IE 9 and 11)


Demo is here:
http://virtual99.cz.oracle.com/spaces/

Huge file  - can take a while to load -  [here](http://virtual99.cz.oracle.com/spaces/xref/sources/c/foobar.out) (150k lines)