### PR TITLE
Fix for OpenGrok issue https://github.com/OpenGrok/OpenGrok/issues/1031

### DIFF
--- a/web/default/style.css
+++ b/web/default/style.css
@@ -357,6 +357,19 @@ table#revisions {
         color: #777777;
 }
 
+table#revisions tbody tr td p {
+	-ms-word-break: break-all;
+	-ms-word-wrap: break-all;
+	-webkit-word-break: break-word;
+	-webkit-word-wrap: break-word;
+	word-break: break-word;
+	word-wrap: break-word;
+	-webkit-hyphens: auto;
+	-moz-hyphens: auto;
+	-ms-hyphens: auto;
+	hyphens: auto;
+}
+
 .rssbadge { /* RSS/XML Feed on history page */
 	text-align: right;
 	margin: 1ex 0;

--- a/web/default/style.css
+++ b/web/default/style.css
@@ -370,6 +370,12 @@ table#revisions tbody tr td p {
 	hyphens: auto;
 }
 
+@-moz-document url-prefix() {
+    table#revisions tbody tr td p {
+        word-break: break-all;
+    }
+}
+
 .rssbadge { /* RSS/XML Feed on history page */
 	text-align: right;
 	margin: 1ex 0;

--- a/web/history.jsp
+++ b/web/history.jsp
@@ -80,6 +80,13 @@ include file="mast.jsp"
 %><script type="text/javascript">/* <![CDATA[ */
 document.domReady.push(function() {domReadyHistory();});
 /* ]]> */</script>
+<!--[if IE]>
+<style type="text/css">
+  table#revisions tbody tr td p {
+        word-break: break-all;
+    }
+</style>
+<![endif]-->
 <form action="<%= context + Prefix.DIFF_P + uriEncodedName %>">
 <table class="src" id="revisions">
     <caption>History log of <a href="<%= context + Prefix.XREF_P


### PR DESCRIPTION
Wrapping long strings in commit comments to prevent the history table width from expanding.