### PR TITLE
Make the Projects list box larger

### DIFF
--- a/web/menu.jspf
+++ b/web/menu.jspf
@@ -167,7 +167,7 @@ org.opensolaris.opengrok.web.Util"
     <select tabindex="8" ondblclick="javascript: goFirstProject();"
         onkeyup="javascript: checkEnter(event);" class="q" id="project"
         name="project" multiple="multiple" size="<%=
-        Math.min(6, projects.size()) %>"><%
+        Math.min(15, projects.size()) %>"><%
         SortedSet<String> pRequested = cfg.getRequestedProjects();
         for (Entry<String,String> e : pMap.entrySet()) {
             // TODO below "selected" has no effect if one refreshes the page


### PR DESCRIPTION
When there are many projects, scrolling through them all becomes difficult with such a small select box.  Dragging the slider by even one pixel can move the list more than 6 elements making it hard to scan for an item of interest and making scrolling very disorienting.

Making it a bit bigger in this case helps greatly.  For installations with a small number of projects the size of the box will not change so there should be no adverse impact on them.
