### PR TITLE
Analyze .tcc files as C++ source code

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/c/CxxAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/c/CxxAnalyzerFactory.java
@@ -44,7 +44,8 @@ public class CxxAnalyzerFactory extends FileAnalyzerFactory {
         "HH",
         "CXX",
         "HXX",
-        "TXX"
+        "TXX",
+        "TCC"
     };
 
     public CxxAnalyzerFactory() {


### PR DESCRIPTION
`.tcc` is a fairly standard extension for template implementations (e.g. used in libstdc++; see https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen/files.html), so we should analyze `.tcc` files when working with C++ codebases.
