### PR TITLE
Fixing #927 regression

### DIFF
--- a/web/utils.js
+++ b/web/utils.js
@@ -1060,25 +1060,34 @@ function lntoggle() {
 }
 
 function lnhide() {
-    $("a").each(
+    $("a.hl").each(
         function() {
-            if (this.className === 'l' || this.className === 'hl') {
-                this.className = this.className + '-hide';
-                this.setAttribute("tmp", this.innerHTML);
-                this.innerHTML = '';
-            }
+            $(this).removeClass('hl').addClass('hl-hide');
+            this.setAttribute("tmp", this.innerHTML);
+            this.innerHTML = '';
+        }
+    );
+    $("a.l").each(
+        function() {
+            $(this).removeClass('l').addClass('l-hide');
+            this.setAttribute("tmp", this.innerHTML);
+            this.innerHTML = '';
         }
     );
     document.line_numbers_shown = 0;
 }
 
 function lnshow() {
-    $("a").each(
-        function() {
-            if (this.className === 'l-hide' || this.className === 'hl-hide') {
-                this.className = this.className.substr(0, this.className.indexOf('-'));
-                this.innerHTML = this.getAttribute("tmp");
-            }
+    $("a.l-hide").each(
+        function () {
+            $(this).removeClass('l-hide').addClass('l');
+            this.innerHTML = this.getAttribute("tmp");
+        }
+    );
+    $("a.hl-hide").each(
+        function () {
+            $(this).removeClass('hl-hide').addClass('hl');
+            this.innerHTML = this.getAttribute("tmp");
         }
     );
     document.line_numbers_shown = 1;


### PR DESCRIPTION
As mentioned in #927, 
commit 22e51bd introduced a bug - not hiding a line number on ```lntoggle()```.

The commit above added a class 'target' to the highlighted links, but in the code there was a strong 
test for ```className === 'someotherclass'``` upon hiding/showing, which should be better replaced by ```$.fn.hasClass()```

Result tested in Mozilla and IE9.