### PR TITLE
Don't  display subrepositories without a parent url

### DIFF
--- a/src/org/opensolaris/opengrok/index/IgnoredDirs.java
+++ b/src/org/opensolaris/opengrok/index/IgnoredDirs.java
@@ -40,6 +40,7 @@ public final class IgnoredDirs extends Filter {
         "Codemgr_wsdata", // Teamware
         "deleted_files",  // Teamware
         ".svn",
+        ".repo",
         ".git",
         ".hg",
         ".razor",

--- a/src/org/opensolaris/opengrok/web/PageConfig.java
+++ b/src/org/opensolaris/opengrok/web/PageConfig.java
@@ -1007,7 +1007,7 @@ public final class PageConfig {
     public boolean resourceNotAvailable() {
         getIgnoredNames();
         return getResourcePath().equals("/") || ignoredNames.ignore(getPath())
-                || ignoredNames.ignore(resourceFile.getParentFile().getName())
+                || ignoredNames.ignore(resourceFile.getParentFile())
                 || ignoredNames.ignore(resourceFile);
     }
 

--- a/web/default/print.css
+++ b/web/default/print.css
@@ -99,6 +99,9 @@ label {
     display: none;
 }
 
+.projects .subrepository {
+    padding-left: 20px;
+}
 /* ############### start of header ############## */
 #whole_header {
 	display: none;

--- a/web/default/style.css
+++ b/web/default/style.css
@@ -137,6 +137,10 @@ label {
     display: block;
 }
 
+.projects .subrepository {
+    padding-left: 20px;
+}
+
 .panel > .panel-heading, .panel > .panel-heading-accordion {
   padding: 0 15px;
   border-bottom: 1px solid transparent;

--- a/web/offwhite/print.css
+++ b/web/offwhite/print.css
@@ -98,6 +98,10 @@ label {
     display: none;
 }
 
+.projects .subrepository {
+    padding-left: 20px;
+}
+
 /* ############### start of header ############## */
 #whole_header {
 	display: none;

--- a/web/offwhite/style.css
+++ b/web/offwhite/style.css
@@ -139,6 +139,10 @@ label {
     display: block;
 }
 
+.projects .subrepository {
+    padding-left: 20px;
+}
+
 .panel > .panel-heading, .panel > .panel-heading-accordion {
   padding: 0 15px;
   border-bottom: 1px solid transparent;

--- a/web/polished/print.css
+++ b/web/polished/print.css
@@ -103,6 +103,10 @@ label {
 	display: none;
 }
 
+.projects .subrepository {
+    padding-left: 20px;
+}
+
 #pagetitle { /* short verbal summary/description of the shown content */
 }
 

--- a/web/polished/style.css
+++ b/web/polished/style.css
@@ -158,6 +158,10 @@ label {
     display: block;
 }
 
+.projects .subrepository {
+    padding-left: 20px;
+}
+
 .panel > .panel-heading, .panel > .panel-heading-accordion {
   padding: 0 15px;
   border-bottom: 1px solid transparent;

--- a/web/repos.jspf
+++ b/web/repos.jspf
@@ -121,12 +121,16 @@ Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
                         %>
                         <%
                         for (RepositoryInfo ri : repos) {
+                            if(cnt > 0 && ri.getParent() == null)
+                                // discard repositories without a parent url
+                                continue;
                             if (cnt != 0) {
-                                projDesc = "";
+                                projDesc = ri.getDirectoryName()
+                                             .replace(cfg.getSourceRootPath() + File.separator, "");
                             }
                             %>
                             <tr>
-                                <td class="name">
+                                <td class="name <%= cnt > 0 ? "subrepository" : "repository" %>">
                     <a href="<%= request.getContextPath() + Prefix.XREF_P + "/" + projDesc%>"
                        title="Xref for project <%= Util.htmlize(projDesc) %>">
                         <%= Util.htmlize(projDesc) %>
@@ -199,16 +203,20 @@ Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
                             Integer cnt = 0;
                             Collections.sort(repos, comparatorRepo);
                             for (RepositoryInfo ri : repos) {
+                                if(cnt > 0 && ri.getParent() == null)
+                                    // discard repositories without a parent url
+                                    continue;
                                 if (cnt != 0) {
-                                    projDesc = "";
+                                    projDesc = ri.getDirectoryName()
+                                                 .replace(cfg.getSourceRootPath() + File.separator, "");
                                 }
                                 %>
-                                <tr><td class="name">
-                    <a href="<%= request.getContextPath() + Prefix.XREF_P + "/" + projDesc%>"
+                                <tr><td class="name <%= cnt > 0 ? "subrepository" : "repository" %>">
+                    <a href="<%= request.getContextPath() + Prefix.XREF_P + "/" + projDesc %>"
                        title="Xref for project <%= Util.htmlize(projDesc) %>">
                         <%= Util.htmlize(projDesc) %>
                     </a>
-                                    </td><%
+                    </td><%
                                 String parent = ri.getParent();
                                 if (parent == null) {
                                     parent = "N/A";


### PR DESCRIPTION
In some cases with nested repositories it's not really helpful the information about subrepositories when they don't have their parent url (or branch). I'd suggest to skip those and if the information about parent url is available then provide the xref.

Current (note that the first two subrepositories in "android" are inside the .repo directory):
![current screenshot](https://cloud.githubusercontent.com/assets/6997160/13181438/7cdac0ec-d72d-11e5-9e1b-0acc61580e74.png)


Proposed:
![proposed screenshot](https://cloud.githubusercontent.com/assets/6997160/13181095/a2d7b824-d72b-11e5-9ab9-1b7d61b63a33.png)

