### PR TITLE
Clean up encoding and decoding of URL parameters.

### DIFF
--- a/src/org/opensolaris/opengrok/web/PageConfig.java
+++ b/src/org/opensolaris/opengrok/web/PageConfig.java
@@ -201,8 +201,8 @@ public final class PageConfig {
                     in[i] = HistoryGuru.getInstance().getRevision(f.getParent(), f.getName(), data.rev[i]);
                     if (in[i] == null) {
                         data.errorMsg = "Unable to get revision "
-                                + data.rev[i] + " for file: "
-                                + getResourceFile().getPath();
+                                + Util.htmlize(data.rev[i]) + " for file: "
+                                + Util.htmlize(getPath());
                         return data;
                     }
                 }
@@ -549,12 +549,12 @@ public final class PageConfig {
     /**
      * Get the revision parameter {@code r} from the request.
      *
-     * @return {@code "r=<i>revision</i>"} if found, an empty string otherwise.
+     * @return revision if found, an empty string otherwise.
      */
     public String getRequestedRevision() {
         if (rev == null) {
             String tmp = req.getParameter("r");
-            rev = (tmp != null && tmp.length() > 0) ? "r=" + tmp : "";
+            rev = (tmp != null && tmp.length() > 0) ? tmp : "";
         }
         return rev;
     }
@@ -682,16 +682,6 @@ public final class PageConfig {
             }
         }
         return requestedProjectsString;
-    }
-
-    /**
-     * Get the document hash provided by the request parameter {@code h}.
-     *
-     * @return {@code null} if the request does not contain such a parameter,
-     * its value otherwise.
-     */
-    public String getDocumentHash() {
-        return req.getParameter("h");
     }
 
     /**

--- a/src/org/opensolaris/opengrok/web/Util.java
+++ b/src/org/opensolaris/opengrok/web/Util.java
@@ -17,8 +17,8 @@
  * CDDL HEADER END
  */
 
- /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+/*
+ * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
  */
 package org.opensolaris.opengrok.web;
@@ -63,65 +63,6 @@ public final class Util {
     private static final String SPAN_D = "<span class=\"d\">";
     private static final String SPAN_A = "<span class=\"a\">";
     private static final String SPAN_E = "</span>";
-
-    private static final char[][] specialCharactersRepresentation = new char[63][];
-
-    static {
-        specialCharactersRepresentation[38] = "&amp;".toCharArray();
-        specialCharactersRepresentation[60] = "&lt;".toCharArray();
-        specialCharactersRepresentation[62] = "&gt;".toCharArray();
-        specialCharactersRepresentation[34] = "&#034;".toCharArray();
-        specialCharactersRepresentation[39] = "&#039;".toCharArray();
-    }
-
-    /**
-     * Please use this function to show any variable from servlet getParameter
-     * in a html/js This is to avoid XSS such as
-     * http://OPENGROK_SERVER/source/xref/?r=%27;alert(1)// 
-     * big thnx to Alex Concha alex.concha at automattic.com
-     * - taken from jstl 1.2
-     *
-     * @param buffer
-     * @return
-     */
-    public static String escapeXml(String buffer) {
-        if (buffer == null) {
-            return "";
-        }
-        int start = 0;
-        int length = buffer.length();
-        char[] arrayBuffer = buffer.toCharArray();
-        StringBuffer escapedBuffer = null;
-
-        for (int i = 0; i < length; ++i) {
-            char c = arrayBuffer[i];
-            if (c <= 62) {
-                char[] escaped = specialCharactersRepresentation[c];
-                if (escaped != null) {
-                    if (start == 0) {
-                        escapedBuffer = new StringBuffer(length + 5);
-                    }
-
-                    if (start < i) {
-                        escapedBuffer.append(arrayBuffer, start, i - start);
-                    }
-
-                    start = i + 1;
-                    escapedBuffer.append(escaped);
-                }
-            }
-        }
-
-        if (start == 0) {
-            return buffer;
-        } else {
-            if (start < length) {
-                escapedBuffer.append(arrayBuffer, start, length - start);
-            }
-
-            return escapedBuffer.toString();
-        }
-    }
 
     private Util() {
         // singleton

--- a/web/diff.jsp
+++ b/web/diff.jsp
@@ -41,9 +41,10 @@ org.opensolaris.opengrok.web.DiffType"
 %><%!
 private String getAnnotateRevision(DiffData data) {
     if (data.type == DiffType.OLD || data.type == DiffType.NEW) {
+        String rev = data.rev[data.type == DiffType.NEW ? 1 : 0];
         return "<script type=\"text/javascript\">/* <![CDATA[ */ "
-            + "document.rev = 'r=" + data.rev[data.type == DiffType.NEW ? 1 : 0]
-            + "'; /* ]]> */</script>";
+            + "document.rev = " + Util.htmlize(Util.jsStringLiteral(rev))
+            + "; /* ]]> */</script>";
     }
     return "";
 }

--- a/web/list.jsp
+++ b/web/list.jsp
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 
 --%><%@page import="
@@ -127,7 +127,7 @@ document.pageReady.push(function() { pageReadyList();});
             InputStream in = null;
             try {
                 in = HistoryGuru.getInstance()
-                    .getRevision(resourceFile.getParent(), basename, rev.substring(2));
+                    .getRevision(resourceFile.getParent(), basename, rev);
             } catch (Exception e) {
                 // fall through to error message
                 error = e.getMessage();
@@ -143,14 +143,12 @@ document.pageReady.push(function() { pageReadyList();});
                     {
 %>
 <div id="src">
-    Binary file [Click <a href="<%= rawPath %>?<%= rev
-        %>">here</a> to download]
+Binary file [Click <a href="<%= rawPath %>?r=<%= Util.URIEncode(rev) %>">here</a> to download]
 </div><%
                     } else {
 %>
 <div id="src">
-    <span class="pagetitle"><%= basename %> revision <%=
-        rev.substring(2) %></span>
+    <span class="pagetitle"><%= basename %> revision <%= Util.htmlize(rev) %></span>
     <pre><%
                         if (g == Genre.PLAIN) {
                             // We don't have any way to get definitions
@@ -164,13 +162,13 @@ document.pageReady.push(function() { pageReadyList();});
                                 annotation, Project.getProject(resourceFile));
                         } else if (g == Genre.IMAGE) {
     %></pre>
-    <img src="<%= rawPath %>?<%= rev %>"/>
+    <img src="<%= rawPath %>?r=<%= Util.URIEncode(rev) %>"/>
     <pre><%
                         } else if (g == Genre.HTML) {
                             r = new InputStreamReader(in);
                             Util.dump(out, r);
                         } else {
-        %> Click <a href="<%= rawPath %>?<%= rev %>">download <%= basename %></a><%
+    %> Click <a href="<%= rawPath %>?r=<%= Util.URIEncode(rev) %>">download <%= basename %></a><%
                         }
                     }
                 } catch (IOException e) {
@@ -198,13 +196,12 @@ document.pageReady.push(function() { pageReadyList();});
         } else if (g == Genre.IMAGE) {
 %>
 <div id="src">
-    <img src="<%= rawPath %>?<%= rev %>"/>
+    <img src="<%= rawPath %>?r=<%= Util.URIEncode(rev) %>"/>
 </div><%
         } else {
 %>
 <div id="src">
-    Binary file [Click <a href="<%= rawPath %>?<%= rev
-        %>">here</a> to download]
+Binary file [Click <a href="<%= rawPath %>?r=<%= Util.URIEncode(rev) %>">here</a> to download]
 </div><%
         }
     } else {

--- a/web/mast.jsp
+++ b/web/mast.jsp
@@ -76,12 +76,10 @@ include file="httpheader.jspf"
 
         %><body>
 <script type="text/javascript">/* <![CDATA[ */
-    document.hash = '<%= Util.escapeXml(cfg.getDocumentHash())
-    %>';document.rev = '<%= Util.escapeXml(rev)
-    %>';document.link = '<%= context + Prefix.XREF_P + uriEncodedPath
-    %>';document.annotate = <%= cfg.annotate() %>;
-    document.domReady.push(function() {domReadyMast();});
-    document.pageReady.push(function() { pageReadyMast();});
+    document.rev = getParameter("r");
+    document.annotate = <%= cfg.annotate() %>;
+    document.domReady.push(domReadyMast);
+    document.pageReady.push(pageReadyMast);
     
     function fold(id) {
         var e = document.getElementById(id + "_fold");
@@ -155,10 +153,8 @@ include file="pageheader.jspf"
             href="#" onclick="javascript:toggle_annotations(); return false;"
             title="Show or hide line annotation(commit revisions,authors)."
             ><span class="annotate"></span>Annotate</a></span><span
-            id="toggle-annotate"><a href="<%=
-                context + Prefix.XREF_P + uriEncodedPath
-                + (rev.length() == 0 ? "" : "?") + Util.escapeXml(rev)
-            %>"><span class="annotate"></span>Annotate</a></span></li><%
+            id="toggle-annotate"><a href="#"><span class="annotate"></span>
+            Annotate</a></span></li><%
     } else {
         %><li><a href="#" onclick="javascript:get_annotations(); return false;"
             ><span class="annotate"></span>Annotate</a></li><%
@@ -175,10 +171,10 @@ include file="pageheader.jspf"
         }
         %>
 	<li><a href="<%= context + Prefix.RAW_P + uriEncodedPath
-            + (rev.length() == 0 ? "" : "?") + Util.escapeXml(rev)
+            + (rev.length() == 0 ? "" : "?r=" + Util.URIEncode(rev))
             %>"><span id="raw"></span>Raw</a></li>
 	<li><a href="<%= context + Prefix.DOWNLOAD_P + uriEncodedPath
-            + (rev.length() == 0 ? "" : "?") + Util.escapeXml(rev)
+            + (rev.length() == 0 ? "" : "?r=" + Util.URIEncode(rev))
             %>"><span id="download"></span>Download</a></li>
 	<%
     }

--- a/web/raw.jsp
+++ b/web/raw.jsp
@@ -18,8 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
-Use is subject to license terms.
+Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
 
 Portions Copyright 2011 Jens Elkner.
 
@@ -59,10 +58,9 @@ include file="pageconfig.jspf"
     }
     InputStream in = null;
     try {
-        Prefix prefix;
         if (revision != null) {
             in = HistoryGuru.getInstance().getRevision(f.getParent(),
-                f.getName(), revision.substring(2));
+                f.getName(), revision);
         } else {
             long flast = cfg.getLastModified();
             if (request.getDateHeader("If-Modified-Since") >= flast) {

--- a/web/utils.js
+++ b/web/utils.js
@@ -491,11 +491,36 @@ function resizeContent() {
     }
 }
 
+/**
+ * Get a parameter value from the URL.
+ *
+ * @param p the name of the parameter
+ * @return the decoded value of parameter p
+ */
+function getParameter(p) {
+    // First split up the parameter list. That is, transform from
+    //       ?a=b&c=d
+    // to
+    //       [ ["a", "b"], ["c","d"] ]
+    if (getParameter.params === undefined) {
+        getParameter.params = window.location.search.substr(1).split("&").map(
+                function (x) { return x.split("="); });
+    }
+    var params = getParameter.params;
+    // Then look for the parameter.
+    for (var i in params) {
+        if (params[i][0] === p && params[i].length > 1) {
+            return decodeURIComponent(params[i][1]);
+        }
+    }
+    return undefined;
+}
+
 function domReadyMast() {
-    var h = document.hash;
     if (!window.location.hash) {
-        if (h != null && h != "null" && h != "")  {
-            window.location.hash=h
+        var h = getParameter("h");
+        if (h && h !== "") {
+            window.location.hash = h;
         } else {
             $('#content').focus();
         }
@@ -563,12 +588,19 @@ function domReadyHistory() {
 }
 
 function get_annotations() {
-    link = document.link +  "?a=true";
-    if (document.rev.length > 0) {
-        link += '&' + document.rev;
+    var link = window.location.pathname + "?a=true";
+    if (document.rev) {
+        link += "&r=" + encodeURIComponent(document.rev);
     }
-    hash = "&h=" + window.location.hash.substring(1, window.location.hash.length);
-    window.location = link + hash;
+    if (window.location.hash) {
+        // If a line is highlighted when "annotate" is clicked, we want to
+        // preserve the highlighting, but we don't want the page to scroll
+        // to the highlighted line. So put the line number in a URL parameter
+        // instead of in the hash.
+        link += "&h=";
+        link += window.location.hash.substring(1, window.location.hash.length);
+    }
+    window.location = link;
 }
 
 function toggle_annotations() {


### PR DESCRIPTION
mast.jsp needs to access some URL parameters in JavaScript code.
Currently, it does this in a Java snippet that escapes the parameter
value and prints it in the HTML. This patch changes it so that the
parameters are fetched by the JavaScript code itself, eliminating the
roundtrip via the Java and HTML domains, which simplifies the quoting.

Also remove Util.escapeXml(). Instead use Util.URIEncode(),
Util.htmlize() and Util.jsStringLiteral() as appropriate.
Util.escapeXml() was a hybrid of the latter two.

Also quote some values that were previously not quoted.