### PR TITLE
Improve scrolling to line number.

### DIFF
--- a/web/utils.js
+++ b/web/utils.js
@@ -390,7 +390,7 @@
                 var lines = inner.getLinesParts(window.location.hash);
                 if(lines.length > 0) {
                    var line = lines[0] // first line
-                   $("*").animate({
+                   $("#content").animate({
                       scrollTop: $(inner.format(inner.options.linkSelectorTemplate, {
                           parent: inner.options.parent,
                           n: line


### PR DESCRIPTION
The code that scrolls to the requested line in an xref page, looks
like this:

  $("*").animate(...)

That is, it calls animate() on every element in the page. When viewing
a very big document (say, a source file with 20000 lines), this is
suboptimal. In Chrome, it fails with "RangeError: Maximum call stack
size exceeded". Firefox, IE and Edge don't fail, but the code is very
slow and leaves the page unresponsive for a very long time after it
has loaded.

This patch changes the selector to only select the \<div\> element with
id="content", so that animate() is called on that single element
instead of every element in the document.