### PR TITLE
Simplify toggling of line numbers and annotations.

### DIFF
--- a/web/default/print.css
+++ b/web/default/print.css
@@ -335,11 +335,12 @@ table#dirlist { /* the "Name" column */
 	font-size: small;
 }
 
-#src .l-hide, #src .hl-hide, .blame-hidden { /* hidden line number/annotation block */
+/* hidden line number/annotation block */
+.lines-hidden .l, .lines-hidden .hl, .blame-hidden .blame {
 	display: none
 }
 
-#src .l, #src .hl, .blame .r, .blame .a,
+.l, .hl, .blame .r, .blame .a,
 #results .l, #more .l,
 #difftable i, del.d { /* line number/annotation block */
 	display: inline-block;

--- a/web/default/style.css
+++ b/web/default/style.css
@@ -626,11 +626,12 @@ div[id^='src'] pre {
 	margin: 0;
 }
 
-div[id^='src'] .l-hide, #src .hl-hide, .blame-hidden { /* hidden line number/annotation block */
+/* hidden line number/annotation block */
+.lines-hidden .l, .lines-hidden .hl, .blame-hidden .blame {
 	display: none
 }
 
-div[id^='src'] .l, div[id^='src'] .hl, .blame .r, .blame .a,
+.l, .hl, .blame .r, .blame .a,
 #results .l, #more .l,
 #difftable i, del.d { /* line number/annotation block */
 	display: inline-block;

--- a/web/offwhite/print.css
+++ b/web/offwhite/print.css
@@ -347,11 +347,12 @@ table#dirlist { /* the "Name" column */
 	font-size: small;
 }
 
-#src .l-hide, #src .hl-hide, .blame-hidden { /* hidden line number/annotation block */
+/* hidden line number/annotation block */
+.lines-hidden .l, .lines-hidden .hl, .blame-hidden .blame {
 	display: none
 }
 
-#src .l, #src .hl, .blame .r, .blame .a,
+.l, .hl, .blame .r, .blame .a,
 #results .l, #more .l,
 #difftable i, del.d { /* line number/annotation block */
 	display: inline-block;

--- a/web/offwhite/style.css
+++ b/web/offwhite/style.css
@@ -655,11 +655,12 @@ div[id^='src'] pre {
 	margin: 0;
 }
 
-div[id^='src'] .l-hide, div[id^='src'] .hl-hide, .blame-hidden { /* hidden line number/annotation block */
+/* hidden line number/annotation block */
+.lines-hidden .l, .lines-hidden .hl, .blame-hidden .blame {
 	display: none
 }
 
-div[id^='src'] .l, div[id^='src'] .hl, .blame .r, .blame .a,
+.l, .hl, .blame .r, .blame .a,
 #results .l, #more .l,
 #difftable i, del.d { /* line number/annotation block */
 	display: inline-block;

--- a/web/polished/print.css
+++ b/web/polished/print.css
@@ -347,11 +347,12 @@ table#dirlist { /* the "Name" column */
 	font-size: small;
 }
 
-#src .l-hide, #src .hl-hide, .blame-hidden { /* hidden line number/annotation block */
+/* hidden line number/annotation block */
+.lines-hidden .l, .lines-hidden .hl, .blame-hidden .blame {
 	display: none
 }
 
-#src .l, #src .hl, .blame .r, .blame .a,
+.l, .hl, .blame .r, .blame .a,
 #results .l, #more .l,
 #difftable i, del.d { /* line number/annotation block */
 	display: inline-block;

--- a/web/polished/style.css
+++ b/web/polished/style.css
@@ -712,11 +712,12 @@ div[id^='src'] pre {
 	margin: 0;
 }
 
-div[id^='src'] .l-hide, div[id^='src'] .hl-hide, .blame-hidden { /* hidden line number/annotation block */
+/* hidden line number/annotation block */
+.lines-hidden .l, .lines-hidden .hl, .blame-hidden .blame {
 	display: none
 }
 
-div[id^='src'] .l, div[id^='src'] .hl, .blame .r, .blame .a,
+.l, .hl, .blame .r, .blame .a,
 #results .l, #more .l,
 #difftable i, del.d { /* line number/annotation block */
 	display: inline-block;

--- a/web/utils.js
+++ b/web/utils.js
@@ -604,15 +604,7 @@ function get_annotations() {
 }
 
 function toggle_annotations() {
-    $("span").each(
-        function() {
-            if (this.className == 'blame') {
-                this.className = 'blame-hidden';
-            } else if (this.className == 'blame-hidden') {
-                this.className = 'blame';
-            }
-        }
-    );
+    $(document.body).toggleClass("blame-hidden");
 }
 
 /** list.jsp */
@@ -736,45 +728,11 @@ function lsttoggle() {
  * Toggle the display of line numbers.
  */
 function lntoggle() {
-    if (typeof document.line_numbers_shown === 'undefined' || document.line_numbers_shown === 1) {
-        lnhide();
-    } else {
-        lnshow();
-    }
-}
-
-function lnhide() {
-    $("a.hl").each(
-        function() {
-            $(this).removeClass('hl').addClass('hl-hide');
-            this.setAttribute("tmp", this.innerHTML);
-            this.innerHTML = '';
-        }
-    );
-    $("a.l").each(
-        function() {
-            $(this).removeClass('l').addClass('l-hide');
-            this.setAttribute("tmp", this.innerHTML);
-            this.innerHTML = '';
-        }
-    );
-    document.line_numbers_shown = 0;
+    $(document.body).toggleClass("lines-hidden");
 }
 
 function lnshow() {
-    $("a.l-hide").each(
-        function () {
-            $(this).removeClass('l-hide').addClass('l');
-            this.innerHTML = this.getAttribute("tmp");
-        }
-    );
-    $("a.hl-hide").each(
-        function () {
-            $(this).removeClass('hl-hide').addClass('hl');
-            this.innerHTML = this.getAttribute("tmp");
-        }
-    );
-    document.line_numbers_shown = 1;
+    $(document.body).removeClass("lines-hidden");
 }
 
 /* ------ Highlighting ------ */


### PR DESCRIPTION
When line numbers or annotations are toggled, the anchors on every
line of the document are updated with a new class. It is easier to
just change the class of a parent element, such as the "body" element.

The motivation for this change was to speed up toggling of line
numbers in large documents. Unfortunately, it had no measurable
effect on the performance. It seems like most of the time is spent
doing the actual redrawing of the page, and the time spent on
manipulating the DOM is negligible in comparison.

It does however simplify the code that implements the toggling, and
less code is better.