### PR TITLE
Fix for https://github.com/OpenGrok/OpenGrok/issues/1076

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -160,6 +160,12 @@ public final class Configuration {
     public static final String EFTAR_DTAGS_FILE = "index/dtags.eftar";
     private transient File dtagsEftar = null;
 
+    /**
+     * Revision messages will be collapsible if they exceed this many number
+     * of characters. Front end enforces an appropriate minimum.
+     */
+    private int revisionMessageCollapseThreshold;
+
     /*
      * types of handling history for remote SCM repositories:
      *  ON - index history and display it in webapp
@@ -259,6 +265,7 @@ public final class Configuration {
         setFoldingEnabled(true);
         setFetchHistoryWhenNotInCache(true);
         setHandleHistoryOfRenamedFiles(true);
+        setRevisionMessageCollapseThreshold(200);
     }
 
     public String getRepoCmd(String clazzName) {
@@ -642,6 +649,14 @@ public final class Configuration {
 
     public void setTagsEnabled(boolean tagsEnabled) {
         this.tagsEnabled = tagsEnabled;
+    }
+
+    public void setRevisionMessageCollapseThreshold(int threshold) {
+        this.revisionMessageCollapseThreshold = threshold;
+    }
+
+    public int getRevisionMessageCollapseThreshold() {
+        return this.revisionMessageCollapseThreshold;
     }
 
     private transient Date lastModified;

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -957,6 +957,14 @@ public final class RuntimeEnvironment {
         threadConfig.get().setHandleHistoryOfRenamedFiles(enable);
     }
 
+    public void setRevisionMessageCollapseThreshold(int threshold) {
+        threadConfig.get().setRevisionMessageCollapseThreshold(threshold);
+    }
+
+    public int getRevisionMessageCollapseThreshold() {
+        return threadConfig.get().getRevisionMessageCollapseThreshold();
+    }
+
     public boolean isHandleHistoryOfRenamedFiles() {
         return threadConfig.get().isHandleHistoryOfRenamedFiles();
     }

--- a/src/org/opensolaris/opengrok/web/PageConfig.java
+++ b/src/org/opensolaris/opengrok/web/PageConfig.java
@@ -439,6 +439,10 @@ public final class PageConfig {
         return getIntParam("n", getEnv().getHitsPerPage());
     }
 
+    public int getRevisionMessageCollapseThreshold() {
+        return getEnv().getRevisionMessageCollapseThreshold();
+    }
+
     /**
      * Get sort orders from the request parameter {@code sort} and if this list
      * would be empty from the cookie {@code OpenGrokorting}.

--- a/web/default/style.css
+++ b/web/default/style.css
@@ -493,6 +493,10 @@ table#revisions tbody tr td p {
 	margin: 1ex 0;
 }
 
+.rev-message-hidden {
+  display: none;
+}
+
 
 /* *** diff page *** */
 #diffbar { /* diff navbar: contains the tabs to select diff format */

--- a/web/history.jsp
+++ b/web/history.jsp
@@ -279,8 +279,10 @@ revision2 = revision2 >= hist.getHistoryEntries().size() ? hist.getHistoryEntrie
                 %><%= author %><%
                 }
                 %></td>
-            <td><a name="<%= rev %>"></a><p><%
+            <td><a name="<%= rev %>"></a><%
+                int summaryLength = 200;
                 String cout = Util.htmlize(entry.getMessage());
+
                 if (bugPage != null && bugPage.length() > 0) {
                     cout = bugPattern.matcher(cout).replaceAll("<a href=\""
                         + bugPage + "$1\">$1</a>");
@@ -289,7 +291,26 @@ revision2 = revision2 >= hist.getHistoryEntries().size() ? hist.getHistoryEntrie
                     cout = reviewPattern.matcher(cout).replaceAll("<a href=\""
                         + reviewPage + "$1\">$1</a>");
                 }
-                %><%= cout %></p><%
+                
+                boolean showSummary = false;
+                String coutSummary = entry.getMessage();
+                if (coutSummary.length() > summaryLength) {
+                    showSummary = true;
+                    coutSummary = coutSummary.substring(0, summaryLength - 1);
+                    coutSummary = Util.htmlize(coutSummary);
+                }
+
+                if (showSummary) {
+                    %>
+                    <p class="rev-message-summary"><%= coutSummary %></p>
+                    <p class="rev-message-full rev-message-hidden"><%= cout %></p>
+                    <p class="rev-message-toggle" data-toggle-state="less"><a class="rev-toggle-a" href="#">show more ... </a></p>
+                    <%
+                }
+                else {
+                     %><p class="rev-message-full"><%= cout %></p><%
+                }
+
                 Set<String> files = entry.getFiles();
                 if (files != null) {
                 %><div class="filelist-hidden"><br/><%

--- a/web/history.jsp
+++ b/web/history.jsp
@@ -280,7 +280,8 @@ revision2 = revision2 >= hist.getHistoryEntries().size() ? hist.getHistoryEntrie
                 }
                 %></td>
             <td><a name="<%= rev %>"></a><%
-                int summaryLength = 200;
+                // revision message collapse threshold minimum of 10
+                int summaryLength = Math.max(10, cfg.getRevisionMessageCollapseThreshold());
                 String cout = Util.htmlize(entry.getMessage());
 
                 if (bugPage != null && bugPage.length() > 0) {

--- a/web/utils.js
+++ b/web/utils.js
@@ -854,6 +854,28 @@ function togglediffs() {
     );
 }
 
+$(document).ready(function() {
+  $(".rev-toggle-a").click(function() {
+    var toggleState = $(this).closest("p").attr("data-toggle-state");
+    var thisCell = $(this).closest("td");
+
+    if (toggleState == "less") {
+      $(this).closest("p").attr("data-toggle-state", "more");
+      thisCell.find(".rev-message-summary").addClass("rev-message-hidden");
+      thisCell.find(".rev-message-full").removeClass("rev-message-hidden");
+      $(this).html("... show less");
+    }
+    else if (toggleState == "more") {
+      $(this).closest("p").attr("data-toggle-state", "less");
+      thisCell.find(".rev-message-full").addClass("rev-message-hidden");
+      thisCell.find(".rev-message-summary").removeClass("rev-message-hidden");
+      $(this).html("show more ...");
+    }
+
+    return false;
+  });
+});
+
 function selectAllProjects() {
     $("#project *").attr("selected", "selected");
 }


### PR DESCRIPTION
New feature to allow users to collapse and expand long revision
messages on the history page.