### PR TITLE
More project prefix matching improvements

### DIFF
--- a/test/org/opensolaris/opengrok/configuration/ProjectTest.java
+++ b/test/org/opensolaris/opengrok/configuration/ProjectTest.java
@@ -110,6 +110,8 @@ public class ProjectTest {
         assertEquals(bar, Project.getProject("/foo-bar"));
         assertEquals(foo, Project.getProject("/foo/blah.c"));
         assertEquals(bar, Project.getProject("/foo-bar/ha.c"));
+        assertNull(Project.getProject("/foof"));
+        assertNull(Project.getProject("/foof/ha.c"));
 
         // Make sure that the matching is not dependent on list ordering.
         Collections.reverse(projects);
@@ -117,5 +119,7 @@ public class ProjectTest {
         assertEquals(bar, Project.getProject("/foo-bar"));
         assertEquals(foo, Project.getProject("/foo/blah.c"));
         assertEquals(bar, Project.getProject("/foo-bar/ha.c"));
+        assertNull(Project.getProject("/foof"));
+        assertNull(Project.getProject("/foof/ha.c"));
     }
 }


### PR DESCRIPTION
This is a follow-up to the fix for #1074.

Project.getProject() currently creates a copy of the project list and
sorts it on every call. This is more work than necessary. A single
pass through the unsorted project list should be enough to find the
longest matching prefix.

The patch also fixes a bug which would cause getProject() to think
that the path /foof/bar would be in the project with path /foo, if
there was no project which had the path /foof.