### PR TITLE
script wrapper for manipulating with groups

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/Groups.java
+++ b/src/org/opensolaris/opengrok/configuration/Groups.java
@@ -1,0 +1,416 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+ /*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.configuration;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import org.opensolaris.opengrok.util.Getopt;
+
+/**
+ *
+ * @author Krystof Tulinger
+ */
+public final class Groups {
+
+    private interface Walker {
+
+        /**
+         * @param g group
+         * @return true if traversing should end, false otherwise
+         */
+        boolean call(Group g);
+    }
+
+    public static void main(String[] argv) {
+        PrintStream out = System.out;
+        File outFile = null;
+        Configuration cfg = new Configuration();
+        String groupname = null;
+        String grouppattern = null;
+        String parent = null;
+        boolean list = false;
+        boolean delete = false;
+        String match = null;
+
+        Getopt getopt = new Getopt(argv, "i:o:hdp:n:r:m:l?");
+
+        try {
+            getopt.parse();
+        } catch (ParseException ex) {
+            System.err.println("Groups: " + ex.getMessage());
+            usage();
+            System.exit(1);
+        }
+
+        try {
+            int cmd;
+            File f;
+            getopt.reset();
+            while ((cmd = getopt.getOpt()) != -1) {
+                switch (cmd) {
+                    case 'd':
+                        delete = true;
+                        break;
+                    case 'h':
+                        usage();
+                        System.exit(0);
+                        break;
+                    case 'i':
+                        f = new File(getopt.getOptarg());
+                        try {
+                            cfg = Configuration.read(f);
+                        } catch (ArrayIndexOutOfBoundsException ex) {
+                            System.err.println("An error occured - this may mean that the input file is not well-formated.");
+                            System.err.println();
+                            ex.printStackTrace(System.err);
+                            System.exit(3);
+                        }
+                        break;
+                    case 'l':
+                        list = true;
+                        break;
+                    case 'm':
+                        match = getopt.getOptarg();
+                        break;
+                    case 'n':
+                        groupname = getopt.getOptarg();
+                        break;
+                    case 'o':
+                        outFile = new File(getopt.getOptarg());
+                        break;
+                    case 'p':
+                        parent = getopt.getOptarg();
+                        break;
+                    case 'r':
+                        grouppattern = getopt.getOptarg();
+                        break;
+                    case '?':
+                        usage();
+                        System.exit(0);
+                        break;
+                    default:
+                        System.err.println("Internal Error - Not implemented option: " + (char) cmd);
+                        usage();
+                        System.exit(1);
+                        break;
+                }
+            }
+        } catch (FileNotFoundException ex) {
+            System.err.println("An error occured - file does not exist");
+            ex.printStackTrace(System.err);
+            System.exit(3);
+        } catch (IOException ex) {
+            System.err.println("An uknown error occured - the input file may be corrupted");
+            ex.printStackTrace(System.err);
+            System.exit(3);
+        }
+
+        if (match != null) {
+            // perform matching
+            if (parent != null || groupname != null || grouppattern != null) {
+                System.err.println("Match option should be used without parent|groupname|groupregex options");
+                usage();
+                System.exit(1);
+            }
+            matchGroups(System.out, cfg.getGroups(), match);
+        } else if (delete) {
+            // perform delete
+            if (parent != null || grouppattern != null) {
+                System.err.println("Delete option should be used without parent|groupregex options");
+                usage();
+                System.exit(1);
+            }
+            if (groupname == null) {
+                System.err.println("You must specify the group name");
+                usage();
+                System.exit(1);
+            }
+            deleteGroup(cfg.getGroups(), groupname);
+            out = prepareOutput(outFile);
+            printOut(list, cfg, out);
+        } else if (groupname != null && grouppattern != null) {
+            // perform insert/update. parent may be null
+            if (!modifyGroup(cfg.getGroups(), groupname, grouppattern, parent)) {
+                System.err.println("Parent group does not exist \"" + parent + "\"");
+            } else {
+                out = prepareOutput(outFile);
+                printOut(list, cfg, out);
+            }
+        } else if (list) {
+            // just list the groups
+            if (groupname != null) {
+                System.err.println("List option should be used without groupname options");
+                usage();
+                System.exit(1);
+            }
+            printOut(list, cfg, out);
+        } else {
+            System.err.println("Wrong combination of options. See usage.");
+            usage();
+            System.exit(2);
+        }
+    }
+
+    /**
+     * Prints the configuration to the stream.
+     *
+     * @param list if true then it lists all available groups in configuration
+     * if @param out is different than stdout it also prints the current
+     * configuration to that stream otherwise it prints the configuration to the
+     * @param out stream.
+     * @param cfg configuration
+     * @param out output stream
+     */
+    private static void printOut(boolean list, Configuration cfg, PrintStream out) {
+        if (list) {
+            listGroups(System.out, cfg.getGroups());
+            if (out != System.out) {
+                out.print(cfg.getXMLRepresentationAsString());
+            }
+        } else {
+            out.print(cfg.getXMLRepresentationAsString());
+        }
+    }
+
+    private static PrintStream prepareOutput(File outFile) {
+        PrintStream out = System.out;
+        if (outFile != null) {
+            try {
+                out = new PrintStream(outFile, "utf-8");
+            } catch (FileNotFoundException ex) {
+                System.err.println("An error occured - file does not exist");
+                ex.printStackTrace(System.err);
+                System.exit(3);
+            } catch (UnsupportedEncodingException ex) {
+                System.err.println("An error occured - file contains unsupported charset");
+                ex.printStackTrace(System.err);
+                System.exit(3);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * List groups given as a parameter.
+     *
+     * @param out stream
+     * @param groups groups
+     */
+    private static void listGroups(PrintStream out, Set<Group> groups) {
+        treeTraverseGroups(groups, new Walker() {
+            @Override
+            public boolean call(Group g) {
+                for (int i = 0; i < g.getFlag() * 2; i++) {
+                    out.print(" ");
+                }
+                out.println(g.getName() + " ~ \"" + g.getPattern() + "\"");
+                return false;
+            }
+        });
+    }
+
+    /**
+     * Finds groups which would match the project.
+     *
+     * @param out stream to write the results
+     * @param groups set of groups
+     * @param match project description
+     */
+    private static void matchGroups(PrintStream out, Set<Group> groups, String match) {
+        Project p = new Project();
+        p.setDescription(match);
+
+        List<Group> matched = new ArrayList<>();
+        linearTraverseGroups(groups, new Walker() {
+            @Override
+            public boolean call(Group g) {
+                if (g.match(p)) {
+                    matched.add(g);
+                }
+                return false;
+            }
+        });
+
+        out.println(matched.size() + " group(s) match(es) the \"" + match + "\"");
+        for (Group g : matched) {
+            out.println(g.getName() + " \"" + g.getPattern() + "\"");
+        }
+    }
+
+    /**
+     * Adds a group into the xml tree.
+     *
+     * If group already exists, only the pattern is modified. Parent group can
+     * be null, in that case a new group is inserted as a top level group.
+     *
+     * @param groups existing groups
+     * @param groupname new group name
+     * @param grouppattern new group pattern
+     * @param parent parent
+     * @return false if parent group was not found, true otherwise
+     */
+    private static boolean modifyGroup(Set<Group> groups, String groupname, String grouppattern, String parent) {
+        Group g = new Group();
+        g.setName(groupname);
+        g.setPattern(grouppattern);
+
+        if (updateGroup(groups, groupname, grouppattern)) {
+            return true;
+        }
+
+        if (parent != null) {
+            if (insertToParent(groups, parent, g)) {
+                groups.add(g);
+                return true;
+            }
+            return false;
+        }
+
+        groups.add(g);
+        return true;
+    }
+
+    /**
+     * Removes group from the xml tree.
+     *
+     * @param groups existing groups
+     * @param groupname group to remove
+     */
+    private static void deleteGroup(Set<Group> groups, String groupname) {
+        for (Group g : groups) {
+            if (g.getName().equals(groupname)) {
+                groups.remove(g);
+                groups.removeAll(g.getDescendants());
+                return;
+            }
+        }
+    }
+
+    private static boolean treeTraverseGroups(Set<Group> groups, Walker f) {
+        LinkedList<Group> stack = new LinkedList<>();
+        for (Group g : groups) {
+            g.setFlag(0);
+            if (g.getParent() == null) {
+                stack.add(g);
+            }
+        }
+
+        while (!stack.isEmpty()) {
+            Group g = stack.getFirst();
+            stack.removeFirst();
+
+            if (f.call(g)) {
+                return true;
+            }
+
+            for (Group x : g.getSubgroups()) {
+                x.setFlag(g.getFlag() + 1);
+                stack.addFirst(x);
+            }
+        }
+        return false;
+    }
+
+    private static boolean linearTraverseGroups(Set<Group> groups, Walker f) {
+        for (Group g : groups) {
+            if (f.call(g)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean insertToParent(Set<Group> groups, String parent, Group g) {
+        return linearTraverseGroups(groups, new Walker() {
+            @Override
+            public boolean call(Group x) {
+                if (x.getName().equals(parent)) {
+                    x.addGroup(g);
+                    Group tmp = x.getParent();
+                    while (tmp != null) {
+                        tmp.addDescendant(g);
+                        tmp = tmp.getParent();
+                    }
+                    return true;
+                }
+                return false;
+            }
+        });
+    }
+
+    private static boolean updateGroup(Set<Group> groups, String groupname, String grouppattern) {
+        return linearTraverseGroups(groups, new Walker() {
+            @Override
+            public boolean call(Group g) {
+                if (g.getName().equals(groupname)) {
+                    g.setPattern(grouppattern);
+                    return true;
+                }
+                return false;
+            }
+        });
+    }
+
+    private static final void usage() {
+        System.err.println("Usage:");
+        System.err.println("Groups.java" + " [OPTIONS]");
+        System.err.println();
+        System.err.println("OPTIONS:");
+        System.err.println("Help");
+        System.err.println("-?                   print this help message");
+        System.err.println("-h                   print this help message");
+        System.err.println("-v                   verbose/debug mode");
+        System.err.println();
+        System.err.println("Input/Output");
+        System.err.println("-i /path/to/file     input file|default is empty configuration");
+        System.err.println("-o /path/to/file     output file|default is stdout");
+        System.err.println();
+        System.err.println("Listing");
+        System.err.println("-m <project name>    performs matching based on given project name");
+        System.err.println("-l                   lists all available groups in input file");
+        System.err.println();
+        System.err.println("Modification");
+        System.err.println("-n <group name>      specify group name which should be inserted|updated (requires either -r or -d option)");
+        System.err.println("-r <group regex>     specify group regex pattern (requires -n option)");
+        System.err.println("-p <parent group>    optional parameter for the parent group name (requires -n option)");
+        System.err.println("-d                   delete specified group (requires -n option)");
+        System.err.println();
+        System.err.println("NOTE: using modification options with -l forces the program to list all\n"
+                + "available groups after the modification. Output to a file can still be used.");
+        System.err.println();
+        System.err.println("Examples");
+        System.err.println("-i ~/c.xml -l                     # => list groups");
+        System.err.println("-n Abcd -r \"abcd.*\" -o ~/c.xml    # => add group and print to ~/c.xml");
+        System.err.println("-i ~/c.xml -m abcdefg             # => prints groups which would match this project description");
+        System.err.println("-i ~/c.xml -d -n Abcd             # => deletes group Abcd");
+        System.err.println("-n Bcde -r \".*bcde.*\" -l          # => add group and lists the result");
+    }
+}

--- a/test/org/opensolaris/opengrok/configuration/GroupsTest.java
+++ b/test/org/opensolaris/opengrok/configuration/GroupsTest.java
@@ -1,0 +1,267 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+ /*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.configuration;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GroupsTest {
+
+    static Groups instance = new Groups();
+
+    Configuration cfg;
+
+    @Before
+    public void setUp() {
+        try {
+            cfg = Configuration.makeXMLStringAsConfiguration(BASIC_CONFIGURATION);
+        } catch (IOException ex) {
+            Assert.fail("setUp method should not throw an exception");
+        }
+    }
+
+    @Test
+    public void testBasicConfiguration() {
+        Assert.assertEquals("Initial configuration should contain 6 groups",
+                6, cfg.getGroups().size());
+    }
+
+    @Test
+    public void testDeleteGroup() {
+        Set<Group> groups = cfg.getGroups();
+
+        invokeMethod("deleteGroup",
+                new Class[]{Set.class, String.class},
+                new Object[]{groups, "random not existing group"});
+
+        Assert.assertEquals(6, cfg.getGroups().size());
+
+        invokeMethod("deleteGroup",
+                new Class[]{Set.class, String.class},
+                new Object[]{groups, "apache"});
+
+        Assert.assertEquals(5, cfg.getGroups().size());
+
+        invokeMethod("deleteGroup",
+                new Class[]{Set.class, String.class},
+                new Object[]{groups, "ctags"});
+
+        Assert.assertEquals(1, cfg.getGroups().size());
+    }
+
+    @Test
+    public void testAddGroup() {
+        Set<Group> groups = cfg.getGroups();
+        Group grp;
+
+        grp = findGroup(groups, "new fantastic group");
+        Assert.assertNull(grp);
+
+        invokeMethod("modifyGroup",
+                new Class[]{Set.class, String.class, String.class, String.class},
+                new Object[]{groups, "new fantastic group", "some pattern", null});
+
+        Assert.assertEquals(7, groups.size());
+
+        grp = findGroup(groups, "new fantastic group");
+        Assert.assertNotNull(grp);
+        Assert.assertEquals(grp.getName(), "new fantastic group");
+        Assert.assertEquals(grp.getPattern(), "some pattern");
+    }
+
+    @Test
+    public void testAddGroupToParent() {
+        Set<Group> groups = cfg.getGroups();
+        Group grp;
+
+        grp = findGroup(groups, "apache");
+        Assert.assertNotNull(grp);
+
+        grp = findGroup(groups, "new fantastic group");
+        Assert.assertNull(grp);
+
+        invokeMethod("modifyGroup",
+                new Class[]{Set.class, String.class, String.class, String.class},
+                new Object[]{groups, "new fantastic group", "some pattern", "apache"});
+
+        Assert.assertEquals(7, groups.size());
+
+        grp = findGroup(groups, "apache");
+        Assert.assertNotNull(grp);
+        Assert.assertEquals(1, grp.getSubgroups().size());
+        Assert.assertEquals(1, grp.getDescendants().size());
+
+        grp = findGroup(groups, "new fantastic group");
+        Assert.assertNotNull(grp);
+        Assert.assertNotNull(grp.getParent());
+        Assert.assertEquals(grp.getName(), "new fantastic group");
+        Assert.assertEquals(grp.getPattern(), "some pattern");
+    }
+
+    @Test
+    public void testModifyGroup() {
+        Set<Group> groups = cfg.getGroups();
+        Group grp;
+
+        grp = findGroup(groups, "apache");
+        Assert.assertNotNull(grp);
+        Assert.assertEquals(grp.getName(), "apache");
+        Assert.assertEquals(grp.getPattern(), "apache-.*");
+
+        invokeMethod("modifyGroup",
+                new Class[]{Set.class, String.class, String.class, String.class},
+                new Object[]{groups, "apache", "different pattern", null});
+
+        grp = findGroup(groups, "apache");
+        Assert.assertNotNull(grp);
+        Assert.assertEquals(grp.getName(), "apache");
+        Assert.assertEquals(grp.getPattern(), "different pattern");
+    }
+
+    @Test
+    public void testMatchGroup() {
+        Object[][] tests = new Object[][]{
+            {"null", 0},
+            {"apache", 0},
+            {"apache-2.2", 1},
+            {"ctags 5.6.6.7.4", 1},
+            {"ctags", 0},
+            {"opengrok", 1},
+            {"opengrok-12.0-rc3", 1},
+            {"opengrk", 0}
+        };
+        Set<Group> groups = cfg.getGroups();
+
+        for (Object[] test : tests) {
+            testSingleMatch(groups, (int) test[1], (String) test[0]);
+        }
+    }
+
+    private void testSingleMatch(Set<Group> groups, int expectedlines, String match) {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(os);
+        invokeMethod("matchGroups",
+                new Class[]{PrintStream.class, Set.class, String.class},
+                new Object[]{out, groups, match});
+
+        String output = os.toString();
+
+        Assert.assertEquals(
+                "it expects that \"" + match + "\" will match " + expectedlines + " records",
+                expectedlines + 1,
+                output.split("\\r?\\n").length
+        );
+    }
+
+    private void invokeMethod(String name, Class[] params, Object[] values) {
+        try {
+            Method method = Groups.class.getDeclaredMethod(name, params);
+            method.setAccessible(true);
+            method.invoke(instance, values);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assert.fail("invokeMethod should not throw an exception");
+        }
+    }
+
+    private Group findGroup(Set<Group> groups, String needle) {
+        for (Group g : groups) {
+            if (g.getName().equals(needle)) {
+                return g;
+            }
+        }
+        return null;
+    }
+
+    final static String BASIC_CONFIGURATION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<java version=\"1.8.0_65\" class=\"java.beans.XMLDecoder\">\n"
+            + " <object class=\"org.opensolaris.opengrok.configuration.Configuration\" id=\"Configuration0\">\n"
+            + "    <void method=\"addGroup\">\n"
+            + "        <object class=\"org.opensolaris.opengrok.configuration.Group\">\n"
+            + "            <void property=\"name\">\n"
+            + "                <string>ctags</string>\n"
+            + "            </void>\n"
+            + "            <void property=\"pattern\">\n"
+            + "                <string></string>\n"
+            + "            </void>\n"
+            + "            <void method=\"addGroup\">\n"
+            + "                <object class=\"org.opensolaris.opengrok.configuration.Group\">\n"
+            + "                    <void property=\"name\">\n"
+            + "                        <string>ctags 5.6</string>\n"
+            + "                    </void>\n"
+            + "                    <void property=\"pattern\">\n"
+            + "                        <string>ctags 5.6.*</string>\n"
+            + "                    </void>\n"
+            + "                </object>\n"
+            + "            </void>\n"
+            + "            <void method=\"addGroup\">\n"
+            + "                <object class=\"org.opensolaris.opengrok.configuration.Group\">\n"
+            + "                    <void property=\"name\">\n"
+            + "                        <string>ctags 5.7</string>\n"
+            + "                    </void>\n"
+            + "                    <void property=\"pattern\">\n"
+            + "                        <string>ctags 5.7</string>\n"
+            + "                    </void>\n"
+            + "                </object>\n"
+            + "            </void>\n"
+            + "            <void method=\"addGroup\">\n"
+            + "                <object class=\"org.opensolaris.opengrok.configuration.Group\">\n"
+            + "                    <void property=\"name\">\n"
+            + "                        <string>ctags 5.8</string>\n"
+            + "                    </void>\n"
+            + "                    <void property=\"pattern\">\n"
+            + "                        <string>ctags 5.8</string>\n"
+            + "                    </void>\n"
+            + "                </object>\n"
+            + "            </void>\n"
+            + "        </object>\n"
+            + "    </void>\n"
+            + "    <void method=\"addGroup\">\n"
+            + "        <object class=\"org.opensolaris.opengrok.configuration.Group\">\n"
+            + "            <void property=\"name\">\n"
+            + "                <string>apache</string>\n"
+            + "            </void>\n"
+            + "            <void property=\"pattern\">\n"
+            + "                <string>apache-.*</string>\n"
+            + "            </void>\n"
+            + "        </object>\n"
+            + "    </void>\n"
+            + "    <void method=\"addGroup\">\n"
+            + "        <object class=\"org.opensolaris.opengrok.configuration.Group\">\n"
+            + "            <void property=\"name\">\n"
+            + "                <string>opengrok</string>\n"
+            + "            </void>\n"
+            + "            <void property=\"pattern\">\n"
+            + "                <string>opengrok.*</string>\n"
+            + "            </void>\n"
+            + "        </object>\n"
+            + "    </void>\n"
+            + " </object>\n"
+            + "</java>";
+}

--- a/tools/Groups
+++ b/tools/Groups
@@ -1,0 +1,549 @@
+#!/bin/sh
+
+# Supported Environment Variables:
+#   - OPENGROK_STANDARD_ENV       Run Time Shell Environment (Shell Script)
+#   - OPENGROK_CONFIGURATION      User Configuration (Shell Script)
+#
+# Supported Environment Variables for configuring the default setup:
+#   - OPENGROK_DISTRIBUTION_BASE  Base Directory of the OpenGrok Distribution
+#									- determining the opengrok.jar
+#   - OPENGROK_INSTANCE_BASE      Base Directory of the OpenGrok User Data Area
+#									- determining the configuration
+#                                 switch), default is DATA_ROOT/etc/ctags.config
+#   - JAVA_HOME                   Full Path to Java Installation Root
+#   - JAVA                        Full Path to java binary (to enable 64bit JDK)
+#   - JAVA_OPTS                   Java options (e.g. for JVM memory increase view
+#   - READ_XML_CONFIGURATION      file with read only configuration
+#									- determining the configuration
+
+PROGNAME=`basename $0`
+
+Usage()
+{
+    exec >&2
+    echo ""
+    echo "Usage: ${PROGNAME} <add|delete|match|list|help> [--help] [--verbose] [-d]"
+    echo "       ${PROGNAME} add <name> <pattern>"
+    echo "       ${PROGNAME} delete <name>"
+    echo "       ${PROGNAME} match <project name>"
+    echo ""
+    echo "  The script searches for the configuration in"
+    echo "    OPENGROK_INSTANCE_BASE/etc/configuration.xml or"
+    echo "    READ_XML_CONFIGURATION files or"
+    echo "    you can use the -i option."
+    echo "  When no such file exists it uses an empty configuration."
+    echo ""
+    echo "  Optional environment variables:"
+    echo "    OPENGROK_CONFIGURATION - location of your configuration"
+    echo "      e.g. $ OPENGROK_CONFIGURATION=/var/opengrok/myog.conf ${0} ... "
+    echo ""
+    echo "    See the code for more information on configuration options /" \
+        "variables"
+    echo ""
+}
+
+CommonInvocation()
+{
+	${DO} \
+	${JAVA} \
+	${JAVA_OPTS} \
+	${JAVA_CLASSPATH:+-classpath} ${JAVA_CLASSPATH} \
+	${MAIN_CLASS} \
+	${INPUT_FILE:+-i} ${INPUT_FILE:+"$INPUT_FILE"} \
+	${OUTPUT_FILE:+-o} ${OUTPUT_FILE:+"$OUTPUT_FILE"} \
+	"${@}"
+}
+
+StdInvocation()
+{
+	CommonInvocation \
+	${NAME:+-n} ${NAME:+"$NAME"} \
+	${PATTERN:+-r} ${PATTERN:+"$PATTERN"} \
+	${PARENT:+-p} ${PARENT:+"$PARENT"} \
+	${MATCH:+-m} ${MATCH:+"$MATCH"} \
+	${LIST:+-l} \
+	${DELETE:+-d} \
+	"${@}"
+}
+
+CheckInputFile()
+{
+	if [ -n "$INPUT_FILE" ] && ( [ ! -e "$INPUT_FILE" ] || [ ! -f "$INPUT_FILE" ] )
+	then
+		echo "input file does not exist or is not readable"
+		LocalUsage
+		exit 5
+	fi
+}
+
+
+OneArgument()
+{
+	if [ $# -gt 0 ]
+	then
+		echo "$1"
+	fi
+}
+
+ExpectOption()
+{  
+	if [ $# -lt 2 ]
+	then
+		echo "Argument \"$1\" expects a value"
+		exit 3
+	fi
+}
+
+Info()
+{
+	if $VERBOSE
+	then
+		echo "Configuration loaded"
+		echo "\tJAVA_HOME = "${JAVA_HOME}
+		if [ -n "$JAVA_HOME" ]
+		then
+			echo "\tJAVA = $JAVA_HOME/bin/java"
+		else
+			echo "\tJAVA ="
+		fi
+		echo "\tJAVA_OPTS = "${JAVA_OPTS}
+		echo "\tJAVA_CLASSPATH = "${JAVA_CLASSPATH}
+		echo "\tOPENGROK_JAR = "${OPENGROK_JAR}
+		echo "\tOPENGROK_CONFIGURATION = "${OPENGROK_CONFIGURATION}
+		echo "\tOPENGROK_STANDARD_ENV = "${OPENGROK_STANDARD_ENV}
+		echo "\tOPENGROK_INSTANCE_BASE = "${OPENGROK_INSTANCE_BASE}
+		echo "\tOPENGROK_DISTRIBUTION_BASE = "${OPENGROK_DISTRIBUTION_BASE}
+		echo "\tREAD_XML_CONFIGURATION = "${READ_XML_CONFIGURATION}
+		echo "\tOPENGROK_JAR = "${OPENGROK_JAR}
+		echo ""
+		echo "Files used"
+		echo "\tINPUT_FILE = "${INPUT_FILE:-empty configuration}
+		echo "\tOUTPUT_FILE = "${OUTPUT_FILE:-standard output}
+		echo "\tPATTERN = "${PATTERN:-$PATTERN}
+		echo "\tNAME = "${NAME:-$NAME}
+		echo "\tPARENT = "${PARENT:-$PARENT}
+		echo ""
+	fi
+}
+
+Progress()
+{
+	if $VERBOSE
+	then
+		echo "$@"
+	fi
+}
+
+Match ()
+{
+	LocalUsage()
+	{
+		echo "Usage:"
+		echo "${PROGNAME} match <project name> [-i|--input <file>] [-v|--verbose] [-d]"
+		echo ""
+		echo "  Lists which groups would match the project name (description)"
+		echo ""
+		echo "Options:"
+		echo " -d option performs dry run with verbose mode"
+		echo " -i option can be used for specifying the input file"
+	}
+
+	while [ $# -gt 0 ]
+	do
+		opt="$1"
+		case $opt in
+			-i|--input)
+				ExpectOption "$@"
+				shift
+				INPUT_FILE=$(OneArgument "$@")
+			;;
+			-d)
+				DO=echo
+				VERBOSE=true
+			;;
+			-v|--verbose)
+				VERBOSE=true
+			;;
+			-h|--help)
+				LocalUsage
+				exit 0
+			;;
+			-*)
+				echo "Uknown option \"$opt\"" && LocalUsage && exit 5
+			;;
+			*)
+				if [ "x$MATCH" = "x" ]
+				then
+					MATCH=$(OneArgument "$@")
+				else
+					echo "match must be specified only once" && LocalUsage && exit 5
+				fi
+			;;
+		esac
+		shift
+	done
+
+	[ -z "$MATCH" ] && echo "project name must be specified" && LocalUsage && exit 5
+
+	CheckInputFile
+	Info
+	StdInvocation
+}
+
+List ()
+{
+	LocalUsage()
+	{
+		echo "Usage:"
+		echo "${PROGNAME} list [-i|--input <file>] [-v|--verbose] [-d]"
+		echo ""
+		echo "  Lists the current configuration"
+		echo ""
+		echo "Options:"
+		echo " -d option performs dry run with verbose mode"
+		echo " -i option can be used for specifying the input file"
+	}
+
+	while [ $# -gt 0 ]
+	do
+		opt="$1"
+		case $opt in
+			-i|--input)
+				ExpectOption "$@"
+				shift
+				INPUT_FILE=$(OneArgument "$@")
+			;;
+			-d)
+				DO=echo
+				VERBOSE=true
+			;;
+			-v|--verbose)
+				VERBOSE=true
+			;;
+			-h|--help)
+				LocalUsage
+				exit 0
+			;;
+			-*)
+				echo "Uknown option \"$opt\"" && LocalUsage && exit 5
+			;;
+			*)
+				echo "this requires no other parameter"
+				LocalUsage
+				exit 5
+			;;
+		esac
+		shift
+	done
+
+	LIST=true
+
+	CheckInputFile
+	Info
+	StdInvocation
+}
+
+Delete ()
+{
+	LocalUsage()
+	{
+		echo "Usage:"
+		echo "${PROGNAME} delete <name> [-i|--input <file>] [-o|--output <file>] [-l] [-v|--verbose] [-u|--update] [-d]"
+		echo ""
+		echo "  Deletes a group with given name from the input configuration"
+		echo ""
+		echo "Options:"
+		echo " -d option performs dry run with verbose mode"
+		echo " -i option can be used for specifying the input file"
+		echo " -l option prints the overview to stdout (still -o can be used)"
+		echo " -o option can be used for saving the result"
+		echo " -u option forces the script to use same output file as input file (overwrite)"
+	}
+
+	while [ $# -gt 0 ]
+	do
+		opt="$1"
+		case $opt in
+			-i|--input)
+				ExpectOption "$@"
+				shift
+				INPUT_FILE=$(OneArgument "$@")
+			;;
+			-o|--output)
+				ExpectOption "$@"
+				shift
+				OUTPUT_FILE=$(OneArgument "$@")
+			;;
+			-u|--update)
+				OUTPUT_FILE="$INPUT_FILE"
+			;;
+			-l|--list)
+				LIST=true
+			;;
+			-d)
+				DO=echo
+				VERBOSE=true
+			;;
+			-v|--verbose)
+				VERBOSE=true
+			;;
+			-h|--help)
+				LocalUsage
+				exit 0
+			;;
+			-*)
+				echo "Uknown option \"$opt\"" && LocalUsage && exit 5
+			;;
+			*)
+				if [ "x$NAME" = "x" ]
+				then
+					NAME=$(OneArgument "$@")
+				else
+					echo "name must be specified only once" && LocalUsage && exit 5
+				fi
+			;;
+		esac
+		shift
+	done
+
+	[ -z "$NAME" ] && echo "name must be specified" && LocalUsage && exit 5
+
+
+	DELETE=true
+
+	CheckInputFile
+	Info
+	StdInvocation
+}
+
+Add ()
+{
+	LocalUsage()
+	{
+		echo "Usage:"
+		echo "${PROGNAME} add <name> <pattern> [-i|--input <file>] [-o|--output <file>] [-l] [-v|--verbose] [-u|--update] [-d]"
+		echo ""
+		echo "  Adds or updates a group with given name"
+		echo "    1) If given group name already exists, the pattern is updated."
+		echo "    2) If given group name does not exist, the group is inserted"
+		echo "    3) If the parent group exists, the group is inserted as its child"
+		echo ""
+		echo "Options:"
+		echo " -d option performs dry run with verbose mode"
+		echo " -i option can be used for specifying the input file"
+		echo " -l option prints the overview to stdout (still -o can be used)"
+		echo " -o option can be used for saving the result"
+		echo " -u option forces the script to use same output file as input file (overwrite)"
+	}
+
+	NAME=""
+	PATTERN=""
+	while [ $# -gt 0 ]
+	do
+		opt="$1"
+		case $opt in
+			-i|--input)
+				ExpectOption "$@"
+				shift
+				INPUT_FILE=$(OneArgument "$@")
+			;;
+			-o|--output)
+				ExpectOption "$@"
+				shift
+				OUTPUT_FILE=$(OneArgument "$@")
+			;;
+			-p|--parent)
+				ExpectOption "$@"
+				shift
+				PARENT=$(OneArgument "$@")
+			;;
+			-u|--update)
+				OUTPUT_FILE="$INPUT_FILE"
+			;;
+			-l|--list)
+				LIST=true
+			;;
+			-d)
+				DO=echo
+				VERBOSE=true
+			;;
+			-v|--verbose)
+				VERBOSE=true
+			;;
+			-h|--help)
+				LocalUsage
+				exit 0
+			;;
+			-*)
+				echo "Uknown option \"$opt\"" && LocalUsage && exit 5
+			;;
+			*)
+				if [ "x$NAME" = "x" ]
+				then
+					NAME=$(OneArgument "$@")
+				elif [ "x$PATTERN" = "x" ]
+				then
+					PATTERN=$(OneArgument "$@")
+				else
+					echo "name and pattern must be specified only once" && LocalUsage && exit 5
+				fi
+			;;
+		esac
+		shift
+	done
+
+	[ -z "$NAME" ] && echo "name must be specified" && LocalUsage && exit 5
+	[ -z "$PATTERN" ] && echo "pattern must be specified" && LocalUsage && exit 5
+
+	CheckInputFile
+	Info
+	StdInvocation
+}
+
+
+# Find and load relevant configuration
+#
+# Taken (and modified) from original OpenGrok shell wrapper
+#
+SetupInstanceConfiguration()
+{
+	VERBOSE="${VERBOSE:-false}"
+
+    if [ -f "${OPENGROK_STANDARD_ENV}" ]
+    then
+        Progress "Loading ${OPENGROK_STANDARD_ENV} ..."
+        . "${OPENGROK_STANDARD_ENV}"
+    fi
+
+    if [ -n "${OPENGROK_CONFIGURATION}" -a -f "${OPENGROK_CONFIGURATION}" ]
+    then
+        # Load the Local OpenGrok Configuration Environment
+        Progress "Loading ${OPENGROK_CONFIGURATION} ..."
+        . "${OPENGROK_CONFIGURATION}"
+    fi
+
+    # REQUIRED: Java Home
+    JAVA_HOME="${JAVA_HOME:-`FindJavaHome`}"
+
+    # REQUIRED: Java Virtual Machine
+    JAVA="${JAVA:-$JAVA_HOME/bin/java}"
+
+    if [ -n "$OPENGROK_DISTRIBUTION_BASE" ] && [ -f "$OPENGROK_DISTRIBUTION_BASE/dist/opengrok.jar" ]
+    then
+	    OPENGROK_JAR="$OPENGROK_DISTRIBUTION_BASE/dist/opengrok.jar"
+	fi
+
+	if [ -z "$OPENGROK_JAR" ] && [ -f "../dist/opengrok.jar" ]
+	then
+		OPENGROK_JAR="${OPENGROK_JAR:-../dist/opengrok.jar}"
+	elif [ -z "$OPENGROK_JAR" ] && [ -f "dist/opengrok.jar" ]
+	then
+		OPENGROK_JAR="${OPENGROK_JAR:-dist/opengrok.jar}"
+	fi
+
+	JAVA_CLASSPATH="$CLASSPATH"
+	JAVA_CLASSPATH="${JAVA_CLASSPATH}:${OPENGROK_JAR}"
+    JAVA_OPTS="${JAVA_OPTS:--Xmx2048m}"
+    MAIN_CLASS="org.opensolaris.opengrok.configuration.Groups"
+	
+	unset NAME
+	unset PATTERN
+	unset PARENT
+	unset DELETE
+	unset MATCH
+	unset LIST
+
+    if [ -n "$OPENGROK_INSTANCE_BASE" ] && [ -f "$OPENGROK_INSTANCE_BASE/etc/configuration.xml" ]
+	then
+		INPUT_FILE="$OPENGROK_INSTANCE_BASE/etc/configuration.xml"
+	elif [ -n "$READ_XML_CONFIGURATION" ] && [ -f "$READ_XML_CONFIGURATION" ]
+	then
+		INPUT_FILE="$READ_XML_CONFIGURATION"
+	fi
+
+}
+
+# Find java home based on your system information
+#
+# Taken from original OpenGrok shell wrapper
+#
+FindJavaHome()
+{
+	if [ -x "/bin/uname" ]; then
+		OS_NAME="`/bin/uname -s`"
+		OS_VERSION="`/bin/uname -r`"
+	elif [ -x "/usr/bin/uname" ]; then
+		OS_NAME="`/usr/bin/uname -s`"
+		OS_VERSION="`/usr/bin/uname -r`"
+	else
+		echo "Cannot determine operating system version"
+		exit 3
+	fi
+
+    javaHome=""
+    case "${OS_NAME}:${OS_VERSION}" in
+		SunOS:5.10) javaHome="/usr/jdk/instances/jdk1.7.0" ;;
+		SunOS:5.11) javaHome="/usr/jdk/latest"             ;;
+		SunOS:5.12) javaHome="/usr/jdk/latest"             ;;
+		Darwin:*)    javaHome=`/usr/libexec/java_home`     ;;
+		Linux:*)
+            if [ -f /etc/alternatives/java ]
+            then
+               javaHome=`ls -l /etc/alternatives/java | cut -f 2 -d \> `
+               javaHome=`dirname $javaHome`
+               javaHome=`dirname $javaHome`
+            fi
+            ;;
+    esac
+
+    if [ -z "${javaHome}" ]
+    then
+        echo "Unable to determine Java Home" \
+              "for ${OS_NAME} ${OS_VERSION}"
+        exit 3
+    fi
+
+    if [ ! -d "${javaHome}" ]
+    then
+        echo "Missing Java Home ${javaHome}"
+        exit 3
+    fi
+
+    echo "${javaHome}"
+}
+
+
+if [ $# -eq 0 ]
+then
+	Usage
+	exit 1
+fi
+
+SetupInstanceConfiguration
+
+case "${1}" in
+    match)
+		shift
+		Match "$@"
+	;;
+	delete)
+		shift
+		Delete "$@"
+	;;
+	add)
+		shift
+		Add "$@"
+	;;
+	list)
+		shift
+		List "$@"
+	;;
+	help)
+		Usage
+		exit 0
+	;;
+	*)
+		Usage
+		exit 5
+	;;
+esac


### PR DESCRIPTION
This should help users to manipulate with group configuration if neccessary.

Script is located in tools/Groups and provides several commands
 - ```tools/Groups add``` - adding a group to configuration
 - ```tools/Groups delete``` - deleting a group from configuration
 - ```tools/Groups list``` - listing all available groups
 - ```tools/Groups match``` - match a project name against the groups

General section with usage is available under
```tools/Groups help```
Specific usage with arguments and options is under every command with ```--help``` switch
```tools/Group add --help```

Examples:

1. ```OPENGROK_INSTANCE_BASE=/var/opengrok tools/Groups list``` 

   Lists all groups in /var/opengrok/etc/configuration.xml

2.  ```READ_XML_CONFIGURATION=~/myconf.xml tools/Groups add name pattern```

   Adds a group to the configuration in ~/myconf.xml
   By default it prints the new xml configuration to the stdout. 
   Try options ```-o``` and ```-l``` to manipulate with  the output.

3.  ```tools/Groups add name pattern```

   Creates an empty configuration and inserts the group.


4.  ```tools/Groups add name pattern -i ~/myconf.xml -o ~/newconf.xml```

   You can even specify the input file with the ```-i``` switch and
   output file with ```-o``` switch.

4.  ```tools/Groups add name pattern -i ~/myconf.xml -d```

   ```-d``` performs the dry run - nothing gets changed.
   It just prints the current settings and the underlying command it would execute

**NOTE:**
The command  ```add ``` and  ```delete ``` comes also with ```-u``` option which provides a way to change the configuration IN PLACE. It is still very recommended to make a backup of the original configuration before making any changes with ```-u```, just in case.