### PR TITLE
disabling spaces js plugin

### DIFF
--- a/web/utils.js
+++ b/web/utils.js
@@ -460,7 +460,8 @@
 
 $(document).ready(function () {
     // starting spaces plugin
-    $.spaces.init()
+    // TODO: disabled until fixed
+    // $.spaces.init()
     
     $.hash.init({ parent: "pre"})
 });


### PR DESCRIPTION
I'm disabling the spaces plugin (copy - paste space problem) until the selection is improved. This can't occur in the next rc.

This temporarily solves the stopper #1061 