### PR TITLE
Added conditional Junit rule

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -883,6 +883,24 @@ you should be able to connect your Github to Travis CI.
 OpenGroks Travis is here: https://travis-ci.org/OpenGrok/OpenGrok
 
 
+9.9 Maven
+------------------
+The build can now be done through Maven (https://maven.apache.org/) which takes care of the dependency management
+and setup (calls Ant for certain actions).
+
+
+9.9.1 Unit Testing
+-------------------------
+You can test the code at the moment by running `./mvn test` which will execute *all* tests.
+Conditionally, if you don't have every type of repository installed, you can set it to unit-test only those which are
+found to be working on your system.
+
+> mvn test -Djunit-force-all=false
+
+You can also force a specific repository test from running through the following system property
+
+> mvn test -Djunit-force-all=false -Djunit-force-git=true
+
 10. Tuning OpenGrok for large code bases
 ---------------------------------------
 

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -176,6 +176,9 @@ Copyright (c) 2010, 2011, Oracle and/or its affiliates. All rights reserved.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <systemPropertyVariables>
+                        <junit-force-all>true</junit-force-all>
+                    </systemPropertyVariables>
                     <excludes>
                         <!-- Test helper class with name that confuses surefire -->
                         <exclude>**/TestRepository.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.4.201502262128</version>
+                <version>0.7.7.201606060606</version>
             </plugin>
 	    <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.4</version>
+                <version>0.7.4.201502262128</version>
             </plugin>
 	    <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/test/org/opensolaris/opengrok/condition/ConditionalRun.java
+++ b/test/org/opensolaris/opengrok/condition/ConditionalRun.java
@@ -1,0 +1,14 @@
+package org.opensolaris.opengrok.condition;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.METHOD, ElementType.TYPE})
+@Documented
+public @interface ConditionalRun {
+    Class<? extends RunCondition> condition();
+}

--- a/test/org/opensolaris/opengrok/condition/ConditionalRunRule.java
+++ b/test/org/opensolaris/opengrok/condition/ConditionalRunRule.java
@@ -8,13 +8,17 @@ import org.junit.runners.model.Statement;
 import java.lang.reflect.Modifier;
 
 /**
+ * 
+ * This rule can be added to a Junit test and will look for the annotation {@link ConditionalRun} on either the test class
+ * or method. The test is then skipped through Junit's {@link Assume} capabilities if the {@link RunCondition} provided in the
+ * annotation is not satisfied.
+ *
  * Cobbled together from:
  * http://www.codeaffine.com/2013/11/18/a-junit-rule-to-conditionally-ignore-tests/
  * https://gist.github.com/yinzara/9980184
  * http://cwd.dhemery.com/2010/12/junit-rules/
  * http://stackoverflow.com/questions/28145735/androidjunit4-class-org-junit-assume-assumetrue-assumptionviolatedexception/
  */
-
 public class ConditionalRunRule implements TestRule {
 
     @Override

--- a/test/org/opensolaris/opengrok/condition/ConditionalRunRule.java
+++ b/test/org/opensolaris/opengrok/condition/ConditionalRunRule.java
@@ -1,0 +1,121 @@
+package org.opensolaris.opengrok.condition;
+
+import org.junit.Assume;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.lang.reflect.Modifier;
+
+/**
+ * Cobbled together from:
+ * http://www.codeaffine.com/2013/11/18/a-junit-rule-to-conditionally-ignore-tests/
+ * https://gist.github.com/yinzara/9980184
+ * http://cwd.dhemery.com/2010/12/junit-rules/
+ * http://stackoverflow.com/questions/28145735/androidjunit4-class-org-junit-assume-assumetrue-assumptionviolatedexception/
+ */
+
+public class ConditionalRunRule implements TestRule {
+
+    @Override
+    public Statement apply(Statement aStatement, Description aDescription) {
+        if (hasConditionalIgnoreAnnotationOnMethod(aDescription)) {
+            RunCondition condition = getIgnoreConditionOnMethod(aDescription);
+            if (!condition.isSatisfied()) {
+                return new IgnoreStatement(condition);
+            }
+        }
+
+        if (hasConditionalIgnoreAnnotationOnClass(aDescription)) {
+            RunCondition condition = getIgnoreConditionOnClass(aDescription);
+            if (!condition.isSatisfied()) {
+                return new IgnoreStatement(condition);
+            }
+        }
+
+        return aStatement;
+    }
+
+    private static boolean hasConditionalIgnoreAnnotationOnClass( Description aDescription ) {
+        return aDescription.getTestClass().getAnnotation(ConditionalRun.class) != null;
+    }
+
+    private static RunCondition getIgnoreConditionOnClass( Description aDescription ) {
+        ConditionalRun annotation = aDescription.getTestClass().getAnnotation(ConditionalRun.class);
+        return new IgnoreConditionCreator(aDescription.getTestClass(), annotation ).create();
+    }
+
+    private static boolean hasConditionalIgnoreAnnotationOnMethod( Description aDescription ) {
+        return aDescription.getAnnotation(ConditionalRun.class) != null;
+    }
+
+    private static RunCondition getIgnoreConditionOnMethod( Description aDescription ) {
+        ConditionalRun annotation = aDescription.getAnnotation(ConditionalRun.class);
+        return new IgnoreConditionCreator(aDescription.getTestClass(), annotation ).create();
+    }
+
+    private static class IgnoreConditionCreator {
+        private final Class<?> mTestClass;
+        private final Class<? extends RunCondition> conditionType;
+
+        IgnoreConditionCreator(Class<?> aTestClass, ConditionalRun annotation) {
+            this.mTestClass = aTestClass;
+            this.conditionType = annotation.condition();
+        }
+
+        RunCondition create() {
+            checkConditionType();
+            try {
+                return createCondition();
+            } catch( RuntimeException re ) {
+                throw re;
+            } catch( Exception e ) {
+                throw new RuntimeException( e );
+            }
+        }
+
+        private RunCondition createCondition() throws Exception {
+            RunCondition result;
+            if(isConditionTypeStandalone()) {
+                result = conditionType.newInstance();
+            } else {
+                result = conditionType.getDeclaredConstructor(mTestClass).newInstance(mTestClass);
+            }
+            return result;
+        }
+
+        private void checkConditionType() {
+            if(!isConditionTypeStandalone() && !isConditionTypeDeclaredInTarget()) {
+                String msg
+                        = "Conditional class '%s' is a member class "
+                        + "but was not declared inside the test case using it.\n"
+                        + "Either make this class a static class, "
+                        + "standalone class (by declaring it in it's own file) "
+                        + "or move it inside the test case using it";
+                throw new IllegalArgumentException( String.format (msg, conditionType.getName()) );
+            }
+        }
+
+        private boolean isConditionTypeStandalone() {
+            return !conditionType.isMemberClass()
+                    || Modifier.isStatic(conditionType.getModifiers());
+        }
+
+        private boolean isConditionTypeDeclaredInTarget() {
+            return mTestClass.getClass().isAssignableFrom(conditionType.getDeclaringClass());
+        }
+    }
+
+    private static class IgnoreStatement extends Statement {
+        private RunCondition condition;
+
+        IgnoreStatement(RunCondition condition) {
+            this.condition = condition;
+        }
+
+        @Override
+        public void evaluate() {
+            Assume.assumeTrue("Ignored by " + condition.getClass().getSimpleName(), false );
+        }
+    }
+}

--- a/test/org/opensolaris/opengrok/condition/ConditionalRunRule.java
+++ b/test/org/opensolaris/opengrok/condition/ConditionalRunRule.java
@@ -8,7 +8,7 @@ import org.junit.runners.model.Statement;
 import java.lang.reflect.Modifier;
 
 /**
- * 
+ *
  * This rule can be added to a Junit test and will look for the annotation {@link ConditionalRun} on either the test class
  * or method. The test is then skipped through Junit's {@link Assume} capabilities if the {@link RunCondition} provided in the
  * annotation is not satisfied.

--- a/test/org/opensolaris/opengrok/condition/RepositoryInstalled.java
+++ b/test/org/opensolaris/opengrok/condition/RepositoryInstalled.java
@@ -1,0 +1,73 @@
+package org.opensolaris.opengrok.condition;
+
+import org.opensolaris.opengrok.history.BazaarRepository;
+import org.opensolaris.opengrok.history.CVSRepository;
+import org.opensolaris.opengrok.history.GitRepository;
+import org.opensolaris.opengrok.history.MercurialRepository;
+import org.opensolaris.opengrok.history.PerforceRepository;
+import org.opensolaris.opengrok.history.Repository;
+
+/**
+ * A template {@link org.opensolaris.opengrok.condition.RunCondition} that will disable certain tests
+ * if the repository is not working - generally means not available through the CLI.
+ * 
+ * Each run condition can be forced on with the system property <b>junit-force-{name}=true</b> or <b>junit-force-all=true</b>
+ */
+public abstract class RepositoryInstalled implements RunCondition {
+
+    static final String FORCE_ALL_PROPERTY = "junit-force-all";
+
+    private final String name;
+    private final Repository repository;
+
+    public RepositoryInstalled(String name, Repository repository) {
+        this.name = name;
+        this.repository = repository;
+    }
+
+    @Override
+    public boolean isSatisfied() {
+        if (Boolean.getBoolean(FORCE_ALL_PROPERTY)) {
+            return true;
+        }
+        if (Boolean.getBoolean(forceSystemProperty())) {
+            return true;
+        }
+        return repository.isWorking();
+    }
+
+    private String forceSystemProperty() {
+        return String.format("junit-force-%s", name);
+    }
+
+    public static class MercurialInstalled extends RepositoryInstalled {
+        public MercurialInstalled() {
+            super("mercurial", new MercurialRepository());
+        }
+    }
+
+    public static class GitInstalled extends RepositoryInstalled {
+        public GitInstalled() {
+            super("git", new GitRepository());
+        }
+    }
+
+    public static class BazaarInstalled extends RepositoryInstalled {
+        public BazaarInstalled() {
+            super("bazaar", new BazaarRepository());
+        }
+    }
+
+    public static class CvsInstalled extends RepositoryInstalled {
+        public CvsInstalled() {
+            super("cvs", new CVSRepository());
+        }
+    }
+
+    public static class PerforceInstalled extends RepositoryInstalled {
+        public PerforceInstalled() {
+            super("perforce", new PerforceRepository());
+        }
+    }
+
+}

--- a/test/org/opensolaris/opengrok/condition/RunCondition.java
+++ b/test/org/opensolaris/opengrok/condition/RunCondition.java
@@ -1,27 +1,6 @@
 package org.opensolaris.opengrok.condition;
 
-import org.opensolaris.opengrok.history.GitRepository;
-import org.opensolaris.opengrok.history.MercurialRepository;
-import org.opensolaris.opengrok.history.Repository;
-
 public interface RunCondition {
 
     boolean isSatisfied();
-
-    class MercurialInstalled implements RunCondition {
-        private final Repository REPO = new MercurialRepository();
-        @Override
-        public boolean isSatisfied() {
-            return REPO.isWorking();
-        }
-    }
-
-    class GitInstalled implements RunCondition {
-        private final Repository REPO = new GitRepository();
-        @Override
-        public boolean isSatisfied() {
-            return REPO.isWorking();
-        }
-    }
-
 }

--- a/test/org/opensolaris/opengrok/condition/RunCondition.java
+++ b/test/org/opensolaris/opengrok/condition/RunCondition.java
@@ -1,0 +1,27 @@
+package org.opensolaris.opengrok.condition;
+
+import org.opensolaris.opengrok.history.GitRepository;
+import org.opensolaris.opengrok.history.MercurialRepository;
+import org.opensolaris.opengrok.history.Repository;
+
+public interface RunCondition {
+
+    boolean isSatisfied();
+
+    class MercurialInstalled implements RunCondition {
+        private final Repository REPO = new MercurialRepository();
+        @Override
+        public boolean isSatisfied() {
+            return REPO.isWorking();
+        }
+    }
+
+    class GitInstalled implements RunCondition {
+        private final Repository REPO = new GitRepository();
+        @Override
+        public boolean isSatisfied() {
+            return REPO.isWorking();
+        }
+    }
+
+}

--- a/test/org/opensolaris/opengrok/history/BazaarRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/BazaarRepositoryTest.java
@@ -29,14 +29,23 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.opensolaris.opengrok.condition.ConditionalRun;
+import org.opensolaris.opengrok.condition.ConditionalRunRule;
+import org.opensolaris.opengrok.condition.RepositoryInstalled;
+
 import static org.junit.Assert.*;
 
 /**
  *
  * @author austvik
  */
+@ConditionalRun(condition = RepositoryInstalled.BazaarInstalled.class)
 public class BazaarRepositoryTest {
+
+    @Rule
+    public ConditionalRunRule rule = new ConditionalRunRule();
 
     BazaarRepository instance;
 

--- a/test/org/opensolaris/opengrok/history/CVSRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/CVSRepositoryTest.java
@@ -29,14 +29,24 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.opensolaris.opengrok.condition.ConditionalRun;
+import org.opensolaris.opengrok.condition.ConditionalRunRule;
+import org.opensolaris.opengrok.condition.RepositoryInstalled;
+import org.opensolaris.opengrok.condition.RunCondition;
+
 import static org.junit.Assert.*;
 
 /**
  *
  * @author austvik
  */
+@ConditionalRun(condition = RepositoryInstalled.CvsInstalled.class)
 public class CVSRepositoryTest {
+
+    @Rule
+    public ConditionalRunRule rule = new ConditionalRunRule();
 
     CVSRepository instance;
 

--- a/test/org/opensolaris/opengrok/history/GitRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/GitRepositoryTest.java
@@ -29,14 +29,23 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.opensolaris.opengrok.condition.ConditionalRun;
+import org.opensolaris.opengrok.condition.ConditionalRunRule;
+import org.opensolaris.opengrok.condition.RunCondition;
+
 import static org.junit.Assert.*;
 
 /**
  *
  * @author austvik
  */
+@ConditionalRun(condition = RunCondition.GitInstalled.class)
 public class GitRepositoryTest {
+
+    @Rule
+    public ConditionalRunRule rule = new ConditionalRunRule();
 
     GitRepository instance;
 

--- a/test/org/opensolaris/opengrok/history/GitRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/GitRepositoryTest.java
@@ -33,6 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.opensolaris.opengrok.condition.ConditionalRun;
 import org.opensolaris.opengrok.condition.ConditionalRunRule;
+import org.opensolaris.opengrok.condition.RepositoryInstalled;
 import org.opensolaris.opengrok.condition.RunCondition;
 
 import static org.junit.Assert.*;
@@ -41,7 +42,7 @@ import static org.junit.Assert.*;
  *
  * @author austvik
  */
-@ConditionalRun(condition = RunCondition.GitInstalled.class)
+@ConditionalRun(condition = RepositoryInstalled.GitInstalled.class)
 public class GitRepositoryTest {
 
     @Rule

--- a/test/org/opensolaris/opengrok/history/MercurialRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/MercurialRepositoryTest.java
@@ -36,14 +36,22 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.opensolaris.opengrok.condition.ConditionalRun;
+import org.opensolaris.opengrok.condition.ConditionalRunRule;
+import org.opensolaris.opengrok.condition.RunCondition;
 import org.opensolaris.opengrok.util.Executor;
 import org.opensolaris.opengrok.util.TestRepository;
 
 /**
  * Tests for MercurialRepository.
  */
+@ConditionalRun(condition = RunCondition.MercurialInstalled.class)
 public class MercurialRepositoryTest {
+
+    @Rule
+    public ConditionalRunRule rule = new ConditionalRunRule();
 
     /**
      * Revision numbers present in the Mercurial test repository, in the order

--- a/test/org/opensolaris/opengrok/history/MercurialRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/MercurialRepositoryTest.java
@@ -22,10 +22,14 @@
  */
 package org.opensolaris.opengrok.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.fail;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.opensolaris.opengrok.condition.ConditionalRun;
+import org.opensolaris.opengrok.condition.ConditionalRunRule;
+import org.opensolaris.opengrok.condition.RepositoryInstalled;
+import org.opensolaris.opengrok.util.Executor;
+import org.opensolaris.opengrok.util.TestRepository;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,19 +39,15 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.opensolaris.opengrok.condition.ConditionalRun;
-import org.opensolaris.opengrok.condition.ConditionalRunRule;
-import org.opensolaris.opengrok.condition.RunCondition;
-import org.opensolaris.opengrok.util.Executor;
-import org.opensolaris.opengrok.util.TestRepository;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for MercurialRepository.
  */
-@ConditionalRun(condition = RunCondition.MercurialInstalled.class)
+@ConditionalRun(condition = RepositoryInstalled.MercurialInstalled.class)
 public class MercurialRepositoryTest {
 
     @Rule

--- a/test/org/opensolaris/opengrok/history/PerforceRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/PerforceRepositoryTest.java
@@ -23,22 +23,32 @@
  */
 package org.opensolaris.opengrok.history;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.opensolaris.opengrok.condition.ConditionalRun;
+import org.opensolaris.opengrok.condition.ConditionalRunRule;
+import org.opensolaris.opengrok.condition.RepositoryInstalled;
+import org.opensolaris.opengrok.util.FileUtilities;
+
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.opensolaris.opengrok.util.FileUtilities;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Do basic testing of the Perforce support
  *
  * @author Trond Norbye
  */
+@ConditionalRun(condition = RepositoryInstalled.PerforceInstalled.class)
 public class PerforceRepositoryTest {
+
+    @Rule
+    public ConditionalRunRule rule = new ConditionalRunRule();
 
     private static boolean skip;
     private static List<File> files;


### PR DESCRIPTION
In order to remove lots of the warnings that exhibit if a developer attempts to run the tests
without some of the repository tools installed, the addition of JUnit rules are used.

If people aren't opposed to the PR I can add the remaining changes to annotate the remaining tests classes/methods.