### PR TITLE
sample authorization plugin does not implement the interface

### DIFF
--- a/plugins/SampleAuthorizationPlugin.java
+++ b/plugins/SampleAuthorizationPlugin.java
@@ -32,8 +32,13 @@ import org.opensolaris.opengrok.configuration.Project;
 public class SampleAuthorizationPlugin implements IAuthorizationPlugin {
 
     @Override
-    public void reload() {
+    public void load() {
     }
+
+    @Override
+    public void unload() {
+    }
+
     
     @Override
     public boolean isAllowed(HttpServletRequest request, Project project) {


### PR DESCRIPTION
The SampleAuthorizationPlugin did not implement the IAuthorizationPlugin interface. This was introduced by #1117 but forgotten by travis.

Also:
Regading the authorization framework we have two new wikis:
- https://github.com/OpenGrok/OpenGrok/wiki/OpenGrok-Authorization
- https://github.com/OpenGrok/OpenGrok/wiki/OpenGrok-Groupings

Containing fairly similar things like in doc directory but with .md desing.