### PR TITLE
Add Pascal support

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -227,6 +227,8 @@ Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
         <run-jflex file="${src.dir}/org/opensolaris/opengrok/analysis/clojure/ClojureXref.lex"/>
         <run-jflex file="${src.dir}/org/opensolaris/opengrok/analysis/uue/UuencodeXref.lex"/>
         <run-jflex file="${src.dir}/org/opensolaris/opengrok/analysis/uue/UuencodeFullTokenizer.lex"/>
+        <run-jflex file="${src.dir}/org/opensolaris/opengrok/analysis/pascal/PascalSymbolTokenizer.lex"/>
+        <run-jflex file="${src.dir}/org/opensolaris/opengrok/analysis/pascal/PascalXref.lex"/>
         <run-jflex file="${src.dir}/org/opensolaris/opengrok/search/context/HistoryLineTokenizer.lex"/>
         <run-jflex file="${src.dir}/org/opensolaris/opengrok/search/context/PlainLineTokenizer.lex"/>
     </target>

--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -70,6 +70,7 @@ import org.opensolaris.opengrok.analysis.lua.LuaAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.java.JavaAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.javascript.JavaScriptAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.lisp.LispAnalyzerFactory;
+import org.opensolaris.opengrok.analysis.pascal.PascalAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.perl.PerlAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.php.PhpAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.plain.PlainAnalyzerFactory;
@@ -188,7 +189,8 @@ public class AnalyzerGuru {
             new FortranAnalyzerFactory(),
             new HaskellAnalyzerFactory(),
             new GolangAnalyzerFactory(),
-            new LuaAnalyzerFactory()
+            new LuaAnalyzerFactory(),
+            new PascalAnalyzerFactory()
         };
 
         for (FileAnalyzerFactory analyzer : analyzers) {

--- a/src/org/opensolaris/opengrok/analysis/Ctags.java
+++ b/src/org/opensolaris/opengrok/analysis/Ctags.java
@@ -164,6 +164,18 @@ public class Ctags {
                 command.add("--regex-clojure=/\\([[:space:]]*intern[[:space:]]+([-[:alnum:]*+!_:\\/.?]+)/\\1/v,intern/");
                 command.add("--regex-clojure=/\\([[:space:]]*ns[[:space:]]+([-[:alnum:]*+!_:\\/.?]+)/\\1/n,namespace/");
 
+            command.add("--langdef=pascal");
+            command.add("--langmap=pascal:.pas");
+            command.add("--regex-pascal=/(\\w+)\\s*=\\s*\\(\\s*\\w\\s*\\)/\\1/t,Type/");
+            command.add("--regex-pascal=/(\\w+)\\s*=\\s*class\\s*[^;]*$/\\1/c,Class/");
+            command.add("--regex-pascal=/(\\w+)\\s*=\\s*interface\\s*[^;]*$/\\1/c,interface/");
+            command.add("--regex-pascal=/^constructor\\s+(T[a-zA-Z0-9_]+(<[a-zA-Z0-9_, ]+>)?\\.)([a-zA-Z0-9_<>, ]+)(.*)+/\\1\\3/n,Constructor/");
+            command.add("--regex-pascal=/^destructor\\s+(T[a-zA-Z0-9_]+(<[a-zA-Z0-9_, ]+>)?\\.)([a-zA-Z0-9_<>, ]+)(.*)+/\\1\\3/d,Destructor/");
+            command.add("--regex-pascal=/^(procedure|function)\\s+T[a-zA-Z0-9_<>, ]+\\.([a-zA-Z0-9_<>, ]+)(.*)/\\2/m,Method/");
+            command.add("--regex-pascal=/^procedure\\s+([a-zA-Z0-9_<>, ]+)[;(]/\\1/p,Procedure/");
+            command.add("--regex-pascal=/^function\\s+([a-zA-Z0-9_<>, ]+)[;(]/\\1/f,Function/");
+            command.add("--regex-pascal=/^(uses|interface|implementation)$/\\1/s,Section/");
+            command.add("--regex-pascal=/^unit\\s+([a-zA-Z0-9_<>, ]+)[;(]/\\1/s,unit/");
             /* Add extra command line options for ctags. */
             if (CTagsExtraOptionsFile != null) {
                 LOGGER.log(Level.INFO, "Adding extra options to ctags");

--- a/src/org/opensolaris/opengrok/analysis/pascal/Consts.java
+++ b/src/org/opensolaris/opengrok/analysis/pascal/Consts.java
@@ -37,6 +37,7 @@ public class Consts{
         kwd.add( "as" );
         kwd.add( "asm" );
         kwd.add( "begin" );
+        kwd.add( "boolean" );
         kwd.add( "break" );
         kwd.add( "case" );
         kwd.add( "class" );
@@ -49,6 +50,7 @@ public class Consts{
         kwd.add( "div" );
         kwd.add( "dispose" );
         kwd.add( "do" );
+        kwd.add( "double" );
         kwd.add( "downto" );
         kwd.add( "else" );
         kwd.add( "end" );
@@ -68,6 +70,7 @@ public class Consts{
         kwd.add( "inherited" );
         kwd.add( "initialization" );
         kwd.add( "inline" );
+        kwd.add( "integer" );
         kwd.add( "interface" );
         kwd.add( "is" );
         kwd.add( "label" );
@@ -100,8 +103,8 @@ public class Consts{
         kwd.add( "set" );
         kwd.add( "shl" );
         kwd.add( "shr" );
-        kwd.add( "strict" );
         kwd.add( "string" );
+        kwd.add( "strict" );
         kwd.add( "then" );
         kwd.add( "threadvar" );
         kwd.add( "to" );

--- a/src/org/opensolaris/opengrok/analysis/pascal/Consts.java
+++ b/src/org/opensolaris/opengrok/analysis/pascal/Consts.java
@@ -43,6 +43,7 @@ public class Consts{
         kwd.add( "const" );
         kwd.add( "constructor" );
         kwd.add( "continue" );
+        kwd.add( "default" );
         kwd.add( "destructor" );
         kwd.add( "dispinterface" );
         kwd.add( "div" );
@@ -81,6 +82,7 @@ public class Consts{
         kwd.add( "operator" );
         kwd.add( "or" );
         kwd.add( "out" );
+        kwd.add( "override" );
         kwd.add( "packed" );
         kwd.add( "private" );
         kwd.add( "procedure" );

--- a/src/org/opensolaris/opengrok/analysis/pascal/Consts.java
+++ b/src/org/opensolaris/opengrok/analysis/pascal/Consts.java
@@ -18,8 +18,7 @@
  */
 
 /*
- * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
- * Use is subject to license terms.
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.analysis.pascal;
 
@@ -27,7 +26,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
-  * Holds static hash set containing the Java keywords
+  * Holds static hash set containing the Pascal keywords
   */
 public class Consts{
     public static final Set<String> kwd = new HashSet<String>() ;

--- a/src/org/opensolaris/opengrok/analysis/pascal/Consts.java
+++ b/src/org/opensolaris/opengrok/analysis/pascal/Consts.java
@@ -1,0 +1,119 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+package org.opensolaris.opengrok.analysis.pascal;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+  * Holds static hash set containing the Java keywords
+  */
+public class Consts{
+    public static final Set<String> kwd = new HashSet<String>() ;
+    static {
+        kwd.add( "abstract" );
+        kwd.add( "and" );
+        kwd.add( "array" );
+        kwd.add( "as" );
+        kwd.add( "asm" );
+        kwd.add( "begin" );
+        kwd.add( "break" );
+        kwd.add( "case" );
+        kwd.add( "class" );
+        kwd.add( "const" );
+        kwd.add( "constructor" );
+        kwd.add( "continue" );
+        kwd.add( "destructor" );
+        kwd.add( "dispinterface" );
+        kwd.add( "div" );
+        kwd.add( "dispose" );
+        kwd.add( "do" );
+        kwd.add( "downto" );
+        kwd.add( "else" );
+        kwd.add( "end" );
+        kwd.add( "except" );
+        kwd.add( "exit" );
+        kwd.add( "exports" );
+        kwd.add( "false" );
+        kwd.add( "file" );
+        kwd.add( "finalization" );
+        kwd.add( "finally" );
+        kwd.add( "for" );
+        kwd.add( "function" );
+        kwd.add( "goto" );
+        kwd.add( "if" );
+        kwd.add( "implementation" );
+        kwd.add( "in" );
+        kwd.add( "inherited" );
+        kwd.add( "initialization" );
+        kwd.add( "inline" );
+        kwd.add( "interface" );
+        kwd.add( "is" );
+        kwd.add( "label" );
+        kwd.add( "library" );
+        kwd.add( "mod" );
+        kwd.add( "new" );
+        kwd.add( "nil" );
+        kwd.add( "not" );
+        kwd.add( "object" );
+        kwd.add( "of" );
+        kwd.add( "on" );
+        kwd.add( "operator" );
+        kwd.add( "or" );
+        kwd.add( "out" );
+        kwd.add( "packed" );
+        kwd.add( "private" );
+        kwd.add( "procedure" );
+        kwd.add( "program" );
+        kwd.add( "property" );
+        kwd.add( "protected" );
+        kwd.add( "public" );
+        kwd.add( "published" );
+        kwd.add( "raise" );
+        kwd.add( "read" );
+        kwd.add( "record" );
+        kwd.add( "repeat" );
+        kwd.add( "resourcestring" );
+        kwd.add( "self" );
+        kwd.add( "set" );
+        kwd.add( "shl" );
+        kwd.add( "shr" );
+        kwd.add( "string" );
+        kwd.add( "then" );
+        kwd.add( "threadvar" );
+        kwd.add( "to" );
+        kwd.add( "true" );
+        kwd.add( "try" );
+        kwd.add( "type" );
+        kwd.add( "unit" );
+        kwd.add( "until" );
+        kwd.add( "uses" );
+        kwd.add( "var" );
+        kwd.add( "virtual" );
+        kwd.add( "while" );
+        kwd.add( "with" );
+        kwd.add( "write" );
+        kwd.add( "xor" );
+    }
+}

--- a/src/org/opensolaris/opengrok/analysis/pascal/Consts.java
+++ b/src/org/opensolaris/opengrok/analysis/pascal/Consts.java
@@ -98,6 +98,7 @@ public class Consts{
         kwd.add( "set" );
         kwd.add( "shl" );
         kwd.add( "shr" );
+        kwd.add( "strict" );
         kwd.add( "string" );
         kwd.add( "then" );
         kwd.add( "threadvar" );

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.analysis.pascal;
 

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzer.java
@@ -1,0 +1,68 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.analysis.pascal;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import org.opensolaris.opengrok.analysis.Definitions;
+import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
+import org.opensolaris.opengrok.analysis.JFlexTokenizer;
+import org.opensolaris.opengrok.analysis.JFlexXref;
+import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
+import org.opensolaris.opengrok.configuration.Project;
+import org.opensolaris.opengrok.history.Annotation;
+
+/**
+ *
+ * @author Alex Anthony
+ */
+public class PascalAnalyzer extends AbstractSourceCodeAnalyzer {
+
+    /**
+     * Creates a new instance of JavaAnalyzer
+     */
+    protected PascalAnalyzer(FileAnalyzerFactory factory) {
+        super(factory);
+    }
+    
+    @Override
+    protected JFlexTokenizer newSymbolTokenizer(Reader reader) {
+        return new PascalSymbolTokenizer(reader);
+    }
+
+    @Override
+    protected JFlexXref newXref(Reader reader) {
+        return new PascalXref(reader);
+    }
+    
+    @Override
+    protected boolean supportsScopes() {
+        return true;
+    }
+
+    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
+        PascalXref xref = new PascalXref(in);
+        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
+    }
+}

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  */
 
 package org.opensolaris.opengrok.analysis.pascal;
@@ -35,7 +35,7 @@ import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
- * @author Lubos Kosco
+ * @author Alex Anthony
  */
 
 public class PascalAnalyzerFactory extends FileAnalyzerFactory {

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzerFactory.java
@@ -1,0 +1,63 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2010, 2015 Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opensolaris.opengrok.analysis.pascal;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import org.opensolaris.opengrok.analysis.Definitions;
+import org.opensolaris.opengrok.analysis.FileAnalyzer;
+import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
+import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
+import org.opensolaris.opengrok.configuration.Project;
+import org.opensolaris.opengrok.history.Annotation;
+
+/**
+ *
+ * @author Lubos Kosco
+ */
+
+public class PascalAnalyzerFactory extends FileAnalyzerFactory {
+    
+    private static final String name = "Pascal";
+    
+    private static final String[] SUFFIXES = {
+        "PAS"
+    };
+
+    public PascalAnalyzerFactory() {
+        super(null, null, SUFFIXES, null, null, "text/plain", Genre.PLAIN, name);
+    }
+
+    @Override
+    protected FileAnalyzer newAnalyzer() {
+        return new PascalAnalyzer(this);
+    }
+
+    @Override
+    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
+        throws IOException {
+        PascalAnalyzer.writeXref(in, out, defs, annotation, project);
+    }
+}

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalSymbolTokenizer.lex
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  */
 
 /*

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalSymbolTokenizer.lex
@@ -1,0 +1,83 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").  
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2006, 2012, Oracle and/or its affiliates. All rights reserved.
+ */
+
+/*
+ * Gets Pascal symbols - ignores comments, strings, keywords
+ */
+
+package org.opensolaris.opengrok.analysis.pascal;
+import org.opensolaris.opengrok.analysis.JFlexTokenizer;
+
+%%
+%public
+%class PascalSymbolTokenizer
+%extends JFlexTokenizer
+%init{
+super(in);
+%init}
+%unicode
+%type boolean
+%eofval{
+this.finalOffset =  zzEndRead;
+return false;
+%eofval}
+%char
+
+Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
+
+%state STRING COMMENT SCOMMENT QSTRING
+
+%%
+
+<YYINITIAL> {
+{Identifier} {String id = yytext();
+                if(!Consts.kwd.contains(id)){
+                        setAttribs(id, yychar, yychar + yylength());
+                        return true; }
+              }
+ \"     { yybegin(STRING); }
+ \'     { yybegin(QSTRING); }
+ "{"   { yybegin(COMMENT); }
+ "//"   { yybegin(SCOMMENT); }
+}
+
+<STRING> {
+ \"     { yybegin(YYINITIAL); }
+}
+
+<QSTRING> {
+ \'     { yybegin(YYINITIAL); }
+}
+
+<COMMENT> {
+"}"    { yybegin(YYINITIAL);}
+}
+
+<SCOMMENT> {
+\n      { yybegin(YYINITIAL);}
+}
+
+<YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
+<<EOF>>   { this.finalOffset =  zzEndRead; return false;}
+[^]    {}
+}

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalSymbolTokenizer.lex
@@ -57,7 +57,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(QSTRING); }
- "{"   { yybegin(COMMENT); }
+ \{     { yybegin(COMMENT); }
  "//"   { yybegin(SCOMMENT); }
 }
 
@@ -70,7 +70,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <COMMENT> {
-"}"    { yybegin(YYINITIAL);}
+\}    { yybegin(YYINITIAL);}
 }
 
 <SCOMMENT> {

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalXref.lex
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  */
 
 /*
@@ -66,8 +66,8 @@ Number = (0[xX][0-9a-fA-F]+|[0-9]+\.[0-9]+|[0-9]+)(([eE][+-]?[0-9]+)?[ufdlUFDL]*
 
 %%
 <YYINITIAL>{
- "begin"     { incScope(); writeUnicodeChar(yycharat(0)); writeUnicodeChar(yycharat(1));writeUnicodeChar(yycharat(2)); writeUnicodeChar(yycharat(3));writeUnicodeChar(yycharat(4)); }
- "end"     { decScope(); writeUnicodeChar(yycharat(0)); writeUnicodeChar(yycharat(1)); writeUnicodeChar(yycharat(2));}
+ "begin"     { incScope(); out.write(yytext()); }
+ "end"     { decScope(); out.write(yytext());}
  \;     { endScope(); writeUnicodeChar(yycharat(0)); }
 
 {Identifier} {

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalXref.lex
@@ -1,0 +1,164 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").  
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ */
+
+/*
+ * Cross reference a Pascal file
+ */
+
+package org.opensolaris.opengrok.analysis.pascal;
+import org.opensolaris.opengrok.analysis.JFlexXref;
+import java.io.IOException;
+import java.io.Writer;
+import java.io.Reader;
+import org.opensolaris.opengrok.web.Util;
+
+%%
+%public
+%class PascalXref
+%extends JFlexXref
+%unicode
+%ignorecase
+%int
+%{
+  /* Must match WhiteSpace regex */
+  private final static String WHITE_SPACE = "[ \t\f\r]+";
+
+  // TODO move this into an include file when bug #16053 is fixed
+  @Override
+  protected int getLineNumber() { return yyline; }
+  @Override
+  protected void setLineNumber(int x) { yyline = x; }
+%}
+
+/* Must match WHITE_SPACE constant */
+WhiteSpace     = [ \t\f]+
+EOL = \r|\n|\r\n
+Identifier = [a-zA-Z_] [a-zA-Z0-9_]+
+
+URIChar = [\?\+\%\&\:\/\.\@\_\;\=\$\,\-\!\~\*\\]
+FNameChar = [a-zA-Z0-9_\-\.]
+File = [a-zA-Z]{FNameChar}* "." ("pas"|"properties"|"props"|"xml"|"conf"|"txt"|"htm"|"html"|"ini"|"diff"|"patch")
+Path = "/"? [a-zA-Z]{FNameChar}* ("/" [a-zA-Z]{FNameChar}*[a-zA-Z0-9])+
+
+Number = (0[xX][0-9a-fA-F]+|[0-9]+\.[0-9]+|[0-9]+)(([eE][+-]?[0-9]+)?[ufdlUFDL]*)?
+
+ClassName = ({Identifier} ".")* {Identifier}
+ParamName = {Identifier} | "<" {Identifier} ">"
+
+%state  STRING COMMENT SCOMMENT QSTRING
+
+%%
+<YYINITIAL>{
+ \{     { incScope(); writeUnicodeChar(yycharat(0)); }
+ \}     { decScope(); writeUnicodeChar(yycharat(0)); }
+ \;     { endScope(); writeUnicodeChar(yycharat(0)); }
+
+{Identifier} {
+    String id = yytext();
+    writeSymbol(id, Consts.kwd, yyline);
+}
+
+"<" ({File}|{Path}) ">" {
+        out.write("&lt;");
+        String path = yytext();
+        path = path.substring(1, path.length() - 1);
+        out.write("<a href=\""+urlPrefix+"path=");
+        out.write(path);
+        appendProject();
+        out.write("\">");
+        out.write(path);
+        out.write("</a>");
+        out.write("&gt;");
+}
+
+/*{Hier}
+        { out.write(Util.breadcrumbPath(urlPrefix+"defs=",yytext(),'.'));}
+*/
+{Number}        { out.write("<span class=\"n\">"); out.write(yytext()); out.write("</span>"); }
+
+ \"     { yybegin(STRING);out.write("<span class=\"s\">\"");}
+ \'     { yybegin(QSTRING);out.write("<span class=\"s\">\'");}
+ "{"   { yybegin(COMMENT);out.write("<span class=\"c\">/*");}
+ "//"   { yybegin(SCOMMENT);out.write("<span class=\"c\">//");}
+}
+
+<STRING> {
+ \" {WhiteSpace} \"  { out.write(yytext());}
+ \"     { yybegin(YYINITIAL); out.write("\"</span>"); }
+ \\\\   { out.write("\\\\"); }
+ \\\"   { out.write("\\\""); }
+}
+
+<QSTRING> {
+ "\\\\" { out.write("\\\\"); }
+ "\\\'" { out.write("\\\'"); }
+ \' {WhiteSpace} \' { out.write(yytext()); }
+ \'     { yybegin(YYINITIAL); out.write("'</span>"); }
+}
+
+<COMMENT> {
+"}"    { yybegin(YYINITIAL); out.write("*/</span>"); }
+}
+
+<SCOMMENT> {
+  {WhiteSpace}*{EOL} {
+    yybegin(YYINITIAL); out.write("</span>");
+    startNewLine();
+  }
+}
+
+
+<YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
+"&"     {out.write( "&amp;");}
+"<"     {out.write( "&lt;");}
+">"     {out.write( "&gt;");}
+{WhiteSpace}*{EOL}      { startNewLine(); }
+ {WhiteSpace}   { out.write(yytext()); }
+ [!-~]  { out.write(yycharat(0)); }
+ [^\n]      { writeUnicodeChar(yycharat(0)); }
+}
+
+<STRING, COMMENT, SCOMMENT, STRING, QSTRING> {
+{Path}
+        { out.write(Util.breadcrumbPath(urlPrefix+"path=",yytext(),'/'));}
+
+{File}
+        {
+        String path = yytext();
+        out.write("<a href=\""+urlPrefix+"path=");
+        out.write(path);
+        appendProject();
+        out.write("\">");
+        out.write(path);
+        out.write("</a>");}
+
+("http" | "https" | "ftp" ) "://" ({FNameChar}|{URIChar})+[a-zA-Z0-9/]
+        {
+          appendLink(yytext());
+        }
+
+{FNameChar}+ "@" {FNameChar}+ "." {FNameChar}+
+        {
+          writeEMailAddress(yytext());
+        }
+}

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalXref.lex
@@ -62,15 +62,12 @@ Path = "/"? [a-zA-Z]{FNameChar}* ("/" [a-zA-Z]{FNameChar}*[a-zA-Z0-9])+
 
 Number = (0[xX][0-9a-fA-F]+|[0-9]+\.[0-9]+|[0-9]+)(([eE][+-]?[0-9]+)?[ufdlUFDL]*)?
 
-ClassName = ({Identifier} ".")* {Identifier}
-ParamName = {Identifier} | "<" {Identifier} ">"
-
 %state  STRING COMMENT SCOMMENT QSTRING
 
 %%
 <YYINITIAL>{
- \{     { incScope(); writeUnicodeChar(yycharat(0)); }
- \}     { decScope(); writeUnicodeChar(yycharat(0)); }
+ "begin"     { incScope(); writeUnicodeChar(yycharat(0)); writeUnicodeChar(yycharat(1));writeUnicodeChar(yycharat(2)); writeUnicodeChar(yycharat(3));writeUnicodeChar(yycharat(4)); }
+ "end"     { decScope(); writeUnicodeChar(yycharat(0)); writeUnicodeChar(yycharat(1)); writeUnicodeChar(yycharat(2));}
  \;     { endScope(); writeUnicodeChar(yycharat(0)); }
 
 {Identifier} {
@@ -98,7 +95,7 @@ ParamName = {Identifier} | "<" {Identifier} ">"
 
  \"     { yybegin(STRING);out.write("<span class=\"s\">\"");}
  \'     { yybegin(QSTRING);out.write("<span class=\"s\">\'");}
- "{"   { yybegin(COMMENT);out.write("<span class=\"c\">/*");}
+ \{     { yybegin(COMMENT);out.write("<span class=\"c\">{");}
  "//"   { yybegin(SCOMMENT);out.write("<span class=\"c\">//");}
 }
 
@@ -112,13 +109,14 @@ ParamName = {Identifier} | "<" {Identifier} ">"
 <QSTRING> {
  "\\\\" { out.write("\\\\"); }
  "\\\'" { out.write("\\\'"); }
- \' {WhiteSpace} \' { out.write(yytext()); }
+ \'     {WhiteSpace} \' { out.write(yytext()); }
  \'     { yybegin(YYINITIAL); out.write("'</span>"); }
 }
 
 <COMMENT> {
-"}"    { yybegin(YYINITIAL); out.write("*/</span>"); }
+\}      { yybegin(YYINITIAL); out.write("}</span>"); }
 }
+
 
 <SCOMMENT> {
   {WhiteSpace}*{EOL} {


### PR DESCRIPTION
A first go at adding pascal support. ctags has pascal support, but somewhat limited when it comes to object oriented pascal.
It isn't picking up defs as well as I'd like, but it's a start (never used jflex before).
Sort of fixes #929 