### PR TITLE
Fix semantics of -H flag and disabling history generation

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -268,6 +268,11 @@ DefaultInstanceConfiguration()
         GENERATE_HISTORY="-r ${OPENGROK_GENERATE_HISTORY}"
     fi
 
+    if [ "$OPENGROK_GENERATE_HISTORY" != "off" ]
+    then
+        GENERATE_HISTORY="${GENERATE_HISTORY} -H"
+    fi
+
     # OPTIONAL: override depth of scanning for repositories
     if [ -n "${OPENGROK_SCAN_DEPTH}" ]
     then
@@ -835,7 +840,7 @@ StdInvocation()
 
 UpdateGeneratedData()
 {
-    StdInvocation -H
+    StdInvocation
 }
 
 UpdateDataPartial()

--- a/README.txt
+++ b/README.txt
@@ -147,7 +147,8 @@ Note that OpenGrok ignores symbolic links.
 If you want to skip indexing the history of a particular directory
 (and all of it's subdirectories), you can touch '.opengrok_skip_history' file
 at the root of that directory.
-
+If you want to disable history generation for all repositories globally, then
+set OPENGROK_GENERATE_HISTORY environment variable to "off" during indexing.
 
 5.2 Using Opengrok shell wrapper script to create indexes
 ---------------------------------------------------------

--- a/src/org/opensolaris/opengrok/index/Indexer.java
+++ b/src/org/opensolaris/opengrok/index/Indexer.java
@@ -660,7 +660,9 @@ public final class Indexer {
         if (searchRepositories || listRepoPaths || !zapCache.isEmpty()) {
             LOGGER.log(Level.INFO, "Scanning for repositories...");
             long start = System.currentTimeMillis();
-            HistoryGuru.getInstance().addRepositories(env.getSourceRootPath());
+            if (refreshHistory == true) {
+                HistoryGuru.getInstance().addRepositories(env.getSourceRootPath());
+            }
             long time = (System.currentTimeMillis() - start) / 1000;
             LOGGER.log(Level.INFO, "Done scanning for repositories ({0}s)", time);
             if (listRepoPaths || !zapCache.isEmpty()) {
@@ -773,16 +775,17 @@ public final class Indexer {
             LOGGER.info("Done...");
         }
 
-        if (refreshHistory) {
-            LOGGER.log(Level.INFO, "Generating history cache for all repositories ...");
-            HistoryGuru.getInstance().createCache();
-            LOGGER.info("Done...");
-        } else if (repositories != null && !repositories.isEmpty()) {
-            LOGGER.log(Level.INFO, "Generating history cache for specified repositories ...");
-            HistoryGuru.getInstance().createCache(repositories);
-            LOGGER.info("Done...");
+         if (refreshHistory) {
+             if (repositories != null && !repositories.isEmpty()) {
+                  LOGGER.log(Level.INFO, "Generating history cache for specified repositories ...");
+                  HistoryGuru.getInstance().createCache(repositories);
+                  LOGGER.info("Done...");
+              } else {
+                  LOGGER.log(Level.INFO, "Generating history cache for all repositories ...");
+                  HistoryGuru.getInstance().createCache();
+                  LOGGER.info("Done...");
+              }
         }
-
         if (listFiles) {
             IndexDatabase.listAllFiles(subFiles);
         }


### PR DESCRIPTION
OpenGrok generates history regardless of what OPENGROK_GENERATE_HISTORY is set to, for local repositories.
This variable currently only goes into effect for remote repositories. Change its semantics such that
if -H is not passed, then history generation and caching is disabled altogether for all repositories.
This is useful when indexing large local repositories such as a local mirror of the AOSP sources which are 10s
of GB. History generation in this case results in the indexing never completing.

We also fix the semantics of OPENGROK_GENERATE_HISTORY in the wrapper script, such that if its set to "off",
then we don't pass -H at all to OpenGrok.

Signed-off-by: Joel Fernandes <agnel.joel@gmail.com>