### PR TITLE
fixing clear button

### DIFF
--- a/web/js/utils.js
+++ b/web/js/utils.js
@@ -370,6 +370,7 @@ $(document).ready(function () {
 
     $("#sbox input[type='submit']").click(function (e) {
         $("#footer").not(".main_page").hide(); // footer
+        $("#results > p.suggestions").hide(); // suggestions
         $("#results > p.pagetitle").hide(); // description
         $("#results > p.slider").hide(); // pagination
         $("#results > h3").hide(); // error
@@ -834,14 +835,17 @@ function invertAllProjects() {
 
 function goFirstProject(e) {
     e = e || window.event
-    
-    if($(e.target).is("option")) {
-        var selected=$.map($('#project :selected'), function(e) {
-                return $(e).text();
-            });
+
+    var selected = $.map($('#project :selected'), function (e) {
+        return $(e).text();
+    });
+
+    if ($(e.target).is("select")) {
         window.location = document.xrefPath + '/' + selected[0];
-    } else if ( $(e.target).is("optgroup") ) {
-        if(! e.shiftKey) {
+    } else if ($(e.target).is("option")) {
+        window.location = document.xrefPath + '/' + selected[0];
+    } else if ($(e.target).is("optgroup")) {
+        if (!e.shiftKey) {
             $("#project :selected").prop("selected", false).change();
         }
         $(e.target).children().prop("selected", true).change();
@@ -849,17 +853,15 @@ function goFirstProject(e) {
 }
 
 function clearSearchFrom() {
-    $("#sbox :input[type=text]").each(
-        function() {
-                $(this).attr("value", "");
-        }
-    );
+    $("#sbox input[type='text']").each(function () {
+        $(this).val("");
+    });
     $("#type :selected").prop("selected", false);
 }
 
 function checkEnter(event) {
     concat='';
-    $("#sbox :input[type=text]").each(
+    $("#sbox input[type='text']").each(
         function() {
                 concat+=$.trim($(this).val());
         }

--- a/web/menu.jspf
+++ b/web/menu.jspf
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
 
 Portions Copyright 2011 Jens Elkner.
 
@@ -91,27 +91,27 @@ org.opensolaris.opengrok.web.Util"
 <table>
     <tr>
         <td><label for="s1" title="The text token(s) or other fields to be found (lucene query, this is not full text!)">Full&nbsp;Search</label></td>
-        <td><input tabindex="1" class="q" name="q" id="q" value="<%=
+        <td><input tabindex="1" class="q" name="q" id="q" type="text" value="<%=
                 Util.formQuoteEscape(queryParams.getFreetext()) %>"/></td>
     </tr>
     <tr>
 	    <td><label for="s2" title="Definition of function/variable/class">Definition</label></td>
-        <td><input class="q" tabindex="2" name="defs" id="defs" value="<%=
+        <td><input class="q" tabindex="2" name="defs" id="defs" type="text" value="<%=
             Util.formQuoteEscape(queryParams.getDefs()) %>"/></td>
     </tr>
     <tr>
         <td><label for="s3" title="Usage of function/variable/class">Symbol</label></td>
-        <td><input class="q" tabindex="3" name="refs" id="refs" value="<%=
+        <td><input class="q" tabindex="3" name="refs" id="refs" type="text" value="<%=
             Util.formQuoteEscape(queryParams.getRefs()) %>"/></td>
     </tr>
     <tr>
         <td><label for="s4" title="path or parts of it, no need to use dividers">File&nbsp;Path</label></td>
-        <td><input class="q" tabindex="4" name="path" id="path" value="<%=
+        <td><input class="q" tabindex="4" name="path" id="path" type="text" value="<%=
             Util.formQuoteEscape(queryParams.getPath()) %>"/></td>
     </tr>
     <tr>
         <td><label for="s5" title="Search in log messages">History</label></td>
-        <td><input class="q" tabindex="5" name="hist" id="hist" value="<%=
+        <td><input class="q" tabindex="5" name="hist" id="hist" type="text" value="<%=
             Util.formQuoteEscape(queryParams.getHist()) %>"/></td>
     </tr>
     <tr>

--- a/web/search.jsp
+++ b/web/search.jsp
@@ -141,7 +141,7 @@ include file="menu.jspf"
     } else if (searchHelper.hits.length == 0) {
         List<Suggestion> hints = searchHelper.getSuggestions();
         for (Suggestion hint : hints) {
-        %><p><font color="#cc0000">Did you mean (for <%= hint.name %>)</font>:<%
+        %><p class="suggestions"><font color="#cc0000">Did you mean (for <%= hint.name %>)</font>:<%
 	  if (hint.freetext!=null) { 
 	    for (String word : hint.freetext) {
             %> <a href="search?q=<%= Util.URIEncode(word) %>"><%=


### PR DESCRIPTION
The clear button wasn't working at all after moving to jquery 3.1.0. Obviously it couldn't select the [type=text] without having the inputs as text.

Moreover recalling #1136 I forgot to hide the suggestions - fixed now.