### PR TITLE
removing regression of eee3266

### DIFF
--- a/src/org/opensolaris/opengrok/web/PageConfig.java
+++ b/src/org/opensolaris/opengrok/web/PageConfig.java
@@ -642,7 +642,7 @@ public final class PageConfig {
         }
         getRequestedRevision();
         try {
-            annotation = HistoryGuru.getInstance().annotate(resourceFile, rev.isEmpty() ? null : rev.substring(2));
+            annotation = HistoryGuru.getInstance().annotate(resourceFile, rev.isEmpty() ? null : rev);
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Failed to get annotations: ", e);
             /* ignore */


### PR DESCRIPTION
fixes #1173

During this I've discovered [GitRepository.java#L272-L318](https://github.com/OpenGrok/OpenGrok/blob/master/src/org/opensolaris/opengrok/history/GitRepository.java#L272-L318), which is the part of the code which inserts different annotations for the specific lines when the revision number is wrong. The git is run with `-C` option searching for lines in the same commit which also got changed. Problem is like in #1173 that it inserts cruelly out of the way results into the file.

**NOTE: the problem happens still when the revision number is wrong (i. e. when user change the parameter `r` in url to whatever)**

It's hard to convert this to unit test - the lines are always eventually found even when they're wrong - so can anyone explain me the intention here?