### PR TITLE
Authorization properly unloads plugins

### DIFF
--- a/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
@@ -145,6 +145,11 @@ public final class AuthorizationFramework {
 
     private void removePlugin(IAuthorizationPlugin plugin) {
         synchronized (this) {
+            try {
+                plugin.unload();
+            } catch (Throwable ex) {
+                LOGGER.log(Level.SEVERE, "Plugin \"" + plugin.getClass().getName() + "\" has failed while unloading with exception:", ex);
+            }
             plugins.remove(plugin);
         }
 
@@ -158,6 +163,13 @@ public final class AuthorizationFramework {
 
     private void removeAll() {
         synchronized (this) {
+            for (IAuthorizationPlugin plugin : getPlugins()) {
+                try {
+                    plugin.unload();
+                } catch (Throwable ex) {
+                    LOGGER.log(Level.SEVERE, "Plugin \"" + plugin.getClass().getName() + "\" has failed while unloading with exception:", ex);
+                }
+            }
             plugins.clear();
         }
     }
@@ -281,14 +293,7 @@ public final class AuthorizationFramework {
             }
         });
         
-        for (IAuthorizationPlugin plugin : getPlugins()) {
-            try {
-                plugin.unload();
-            } catch (Throwable ex) {
-                LOGGER.log(Level.SEVERE, "Plugin \"" + plugin.getClass().getName() + "\" has failed while unloading with exception:", ex);
-            }
-        }
-        
+        removeAll();
         plugins = new ArrayList<>();
 
         List<File> classfiles = listFilesRec(".class");
@@ -323,8 +328,8 @@ public final class AuthorizationFramework {
                 plugin.load();
             } catch (Throwable ex) {
                 // remove faulty plugin
-                removePlugin(plugin);
                 LOGGER.log(Level.SEVERE, "Plugin \"" + plugin.getClass().getName() + "\" has failed while loading with exception:", ex);
+                removePlugin(plugin);
             }
         }
     }
@@ -363,8 +368,8 @@ public final class AuthorizationFramework {
                     return false;
                 }
             } catch (Throwable ex) {
-                removePlugin(plugin);
                 LOGGER.log(Level.SEVERE, "Plugin \"" + plugin.getClass().getName() + "\" has failed with exception:", ex);
+                removePlugin(plugin);
             }
         }
 

--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -297,12 +297,6 @@ public final class Configuration {
     }
 
     public String getPluginDirectory() {
-        if (pluginDirectory == null) {
-            if (getDataRoot() == null) {
-                return PLUGIN_DIRECTORY_DEFAULT;
-            }
-            return getDataRoot() + "/../" + PLUGIN_DIRECTORY_DEFAULT;
-        }
         return pluginDirectory;
     }
 
@@ -462,6 +456,9 @@ public final class Configuration {
     }
 
     public void setDataRoot(String dataRoot) {
+        if(this.pluginDirectory == null) {
+            this.pluginDirectory = dataRoot + "/../" + PLUGIN_DIRECTORY_DEFAULT;
+        }
         this.dataRoot = dataRoot;
     }
 


### PR DESCRIPTION
- The authorization framework can properly unload plugins 7fa69f2
- The default value for plugin directory is set in `setDataRoot` ec794d2
   - tests don't contain nasty exceptions
   - functionality is the same (when the data root is set - the default plugin directory is set as well)