### PR TITLE
fix updating the timestamp in the webapp

### DIFF
--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -544,8 +544,8 @@ public class IndexDatabase {
     private void setDirty() {
         synchronized (lock) {
             try {
-                if (!dirty && !dirtyFile.createNewFile()) {
-                    if (!dirtyFile.exists()) {
+                if (!dirty) {
+                    if (!dirtyFile.createNewFile() && !dirtyFile.exists()) {
                         LOGGER.log(Level.FINE,
                                 "Failed to create \"dirty-file\": {0}",
                                 dirtyFile.getAbsolutePath());


### PR DESCRIPTION
As of #1175 where I discovered some unexpected behaviour around creating the dirty file for a project and at the end of the index also the problem of refreshing the timestamp for the webapp.

I believe that the following condition introduced in [link to the diff](https://github.com/OpenGrok/OpenGrok/commit/61910105#diff-9ee85b0329e20c488bfd4ea96464dae2R342) (cset 61910105) is wrong. 

```java
if (!dirty && !dirtyFile.createNewFile()) {
    if (!dirtyFile.exists()) {
        log.log(Level.FINE, "Failed to create \"dirty-file\": ", dirtyFile.getAbsolutePath());
    }
    dirty = true;
}
```

The problem is that it the `createNewFile` returns true if the file was created - so basically if the dirty variable is false and the file **could** be created then the if is skipped => the dirty variable does not set to true. Result is inconsistent state between the dirty variable and the existing dirty file.



I reproduced this by indexing a repository, deploying the webapp and then removing single file from the repository and indexing again - the timestamp at the bottom of the page wasn't updated, not even after full redeploy.

I'm not sure what happens with more changes in the repository. It seems the problem passes away, I wasn't able to reproduce it.