### PR TITLE
allowing users to disable the new project picker and use the old one

### DIFF
--- a/web/js/utils.js
+++ b/web/js/utils.js
@@ -1528,15 +1528,29 @@ function togglerevs() {
 }
 
 function selectAllProjects() {
-    $("#project").searchableOptionList().selectAll();
+    if ($("#project").data(SearchableOptionList.prototype.DATA_KEY)) {
+        $("#project").searchableOptionList().selectAll();
+    } else {
+        $("#project option").prop('selected', true)
+    }
 }
 
 function invertAllProjects() {
-    $("#project").searchableOptionList().invert();
+    if ($("#project").data(SearchableOptionList.prototype.DATA_KEY)) {
+        $("#project").searchableOptionList().invert();
+    } else {
+        $("#project option").each(function () {
+            $(this).prop('selected', !$(this).prop('selected'));
+        })
+    }
 }
 
-function deselectAllProjects(){
-    $("#project").searchableOptionList().deselectAll();
+function deselectAllProjects() {
+    if ($("#project").data(SearchableOptionList.prototype.DATA_KEY)) {
+        $("#project").searchableOptionList().deselectAll();
+    } else {
+        $("#project option").prop('selected', false)
+    }
 }
 
 function clearSearchFrom() {


### PR DESCRIPTION
If anyone likes the old behaviour then he can disable the new project picker by commenting out its init call in `utils.js`.

Select/DeselectAll and invert should then work like expected. Support for selecting particular groups is not migrated.

```javascript
/**
 * Initialize the new project picker
 */
    init_searchable_option_list()
```