### PR TITLE
Fixing copy-paste problem when copying scope context

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/JFlexXref.java
+++ b/src/org/opensolaris/opengrok/analysis/JFlexXref.java
@@ -492,7 +492,6 @@ public abstract class JFlexXref {
     protected void startNewLine() throws IOException {
         String iconId = null;
         int line = getLineNumber() + 1;
-        boolean skipNl = false;
         setLineNumber(line);
 
         if (scopesEnabled) {
@@ -501,7 +500,6 @@ public abstract class JFlexXref {
             if (scopeOpen && scope == null) {
                 scopeOpen = false;
                 out.write("</span>");
-                skipNl = true;
             } else if (scope != null) {
                 String scopeId = generateId(scope);
                 if (scope.getLineFrom() == line) {
@@ -511,7 +509,6 @@ public abstract class JFlexXref {
                     out.write(htmlize(scope.getName() + scope.getSignature()));
                     out.write("</span>");
                     iconId = scopeId + "_fold_icon";
-                    skipNl = true;
                 } else if (scope.getLineFrom() == line - 1) {
                     if (scopeOpen) {
                         out.write("</span>");
@@ -520,14 +517,13 @@ public abstract class JFlexXref {
                     out.write("<span id='");
                     out.write(scopeId);
                     out.write("_fold' class='scope-body'>");
-                    skipNl = true;
                 }
                 scopeOpen = true;
             }
         }
 
         Util.readableLine(line, out, annotation, userPageLink, userPageSuffix,
-                getProjectPostfix(true), skipNl);
+                getProjectPostfix(true));
 
         if (foldingEnabled && scopesEnabled) {
             if (iconId != null) {

--- a/web/default/style.css
+++ b/web/default/style.css
@@ -1032,11 +1032,11 @@ a.scope            { /* scope              */ color: dodgerblue; font-weight: bo
 /* *** scopes *** */
 
 span.scope-head {
-    display: block;
+    display: inline;
 }
 
 span.scope-body {
-    display: block;
+    display: inline;
 }
 
 span.unfold-icon {

--- a/web/offwhite/style.css
+++ b/web/offwhite/style.css
@@ -1063,11 +1063,11 @@ a.scope            { /* scope              */ color: dodgerblue; font-weight: bo
 /* *** scopes *** */
 
 span.scope-head {
-    display: block;
+    display: inline;
 }
 
 span.scope-body {
-    display: block;
+    display: inline;
 }
 
 span.unfold-icon {

--- a/web/polished/style.css
+++ b/web/polished/style.css
@@ -1141,11 +1141,11 @@ a.scope            { /* scope              */ color: dodgerblue; font-weight: bo
 /* *** scopes *** */
 
 span.scope-head {
-    display: block;
+    display: inline;
 }
 
 span.scope-body {
-    display: block;
+    display: inline;
 }
 
 span.unfold-icon {


### PR DESCRIPTION
This should fix #1232. It works for me on java and C files. Can anyone else please verify it?

The idea is clear - `display: block` automatically does a new line break so `display: inline` leaves the responsibility to the xref text where the newline is already in the source code after each line.