### PR TITLE
hiding also the scope space on line toggle

### DIFF
--- a/web/js/utils.js
+++ b/web/js/utils.js
@@ -1412,10 +1412,12 @@ function lsttoggle() {
  */
 function lntoggle() {
     $(document.body).toggleClass("lines-hidden");
+    $('.fold-space, .fold-icon, .unfold-icon').toggle()
 }
 
 function lnshow() {
     $(document.body).removeClass("lines-hidden");
+    $('.fold-space, .fold-icon, .unfold-icon').show()
 }
 
 /* ------ Highlighting ------ */


### PR DESCRIPTION
fixes #1224

We should anyway consider to replace the `&nbsp;` by something else, like a fix-sized element, since ui positioning is not a job of html anymore.