### PR TITLE
Add current indexed version to repos table.

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -170,6 +170,13 @@ public final class Configuration {
     private int revisionMessageCollapseThreshold;
 
     /**
+     * Current indexed message will be collapsible if they exceed this many number of
+     * characters. Front end enforces an appropriate minimum.
+     */
+    private int currentIndexedCollapseThreshold;
+
+
+    /**
      * Upper bound for number of threads used for performing multi-project
      * searches. This is total for the whole webapp/CLI utility.
      */
@@ -287,6 +294,7 @@ public final class Configuration {
         setMaxSearchThreadCount(2 * Runtime.getRuntime().availableProcessors());
         setIndexRefreshPeriod(60);
         setMessageLimit(500);
+        setCurrentIndexedCollapseThreshold(27);
     }
 
     public String getRepoCmd(String clazzName) {
@@ -707,6 +715,14 @@ public final class Configuration {
 
     public int getRevisionMessageCollapseThreshold() {
         return this.revisionMessageCollapseThreshold;
+    }
+
+    public int getCurrentIndexedCollapseThreshold() {
+        return currentIndexedCollapseThreshold;
+    }
+
+    public void setCurrentIndexedCollapseThreshold(int currentIndexedCollapseThreshold) {
+        this.currentIndexedCollapseThreshold = currentIndexedCollapseThreshold;
     }
 
     private transient Date lastModified;

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -1088,6 +1088,14 @@ public final class RuntimeEnvironment {
         return threadConfig.get().getMaxSearchThreadCount();
     }
 
+    public int getCurrentIndexedCollapseThreshold() {
+        return threadConfig.get().getCurrentIndexedCollapseThreshold();
+    }
+
+    public void setCurrentIndexedCollapseThreshold(int currentIndexedCollapseThreshold) {
+        threadConfig.get().getCurrentIndexedCollapseThreshold();
+    }
+
     /**
      * Read an configuration file and set it as the current configuration.
      *

--- a/src/org/opensolaris/opengrok/history/GitRepository.java
+++ b/src/org/opensolaris/opengrok/history/GitRepository.java
@@ -662,4 +662,30 @@ public class GitRepository extends Repository {
 
         return branch;
     }
+
+    @Override
+    String determineCurrentVersion() throws IOException {
+        String line = null;
+        File directory = new File(directoryName);
+
+        List<String> cmd = new ArrayList<>();
+        ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
+        cmd.add(RepoCommand);
+        cmd.add("log");
+        cmd.add("-1");
+        cmd.add("--pretty=%cd: %h %an %s");
+        cmd.add("--date=format:%Y-%m-%d %H:%M");
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        pb.directory(directory);
+        Process process;
+        process = pb.start();
+
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            if ((line = in.readLine()) != null) {
+                line = line.trim();
+            }
+        }
+
+        return line;
+    }
 }

--- a/src/org/opensolaris/opengrok/history/Repository.java
+++ b/src/org/opensolaris/opengrok/history/Repository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.history;
 
@@ -363,6 +363,18 @@ public abstract class Repository extends RepositoryInfo {
      * Determine branch of this repository.
      */
     abstract String determineBranch() throws IOException;
+
+    /**
+     * Determine and return the current version of the repository.
+     *
+     * This operation is consider "heavy" so this function should not be
+     * called on every web request.
+     *
+     * @return the version
+     */
+    String determineCurrentVersion() throws IOException {
+        return null;
+    }
 
     /**
      * Returns true if this repository supports sub repositories (a.k.a.

--- a/src/org/opensolaris/opengrok/history/RepositoryFactory.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryFactory.java
@@ -134,6 +134,16 @@ public final class RepositoryFactory {
                     }
                 }
 
+                if (res.getCurrentVersion() == null || res.getCurrentVersion().length() == 0) {
+                    try {
+                        res.setCurrentVersion(res.determineCurrentVersion());
+                    } catch (IOException ex) {
+                        LOGGER.log(Level.WARNING,
+                                "Failed to determineCurrentVersion for {0}: {1}",
+                                new Object[]{file.getAbsolutePath(), ex});
+                    }
+                }
+
                 // If this repository displays tags only for files changed by tagged
                 // revision, we need to prepare list of all tags in advance.
                 if (env.isTagsEnabled() && res.hasFileBasedTags()) {

--- a/src/org/opensolaris/opengrok/history/RepositoryInfo.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryInfo.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.history;
 
@@ -42,6 +42,7 @@ public class RepositoryInfo implements Serializable {
     protected String datePattern;
     protected String parent;
     protected String branch;
+    protected String currentVersion;
 
     /**
      * Empty constructor to support serialization.
@@ -58,6 +59,7 @@ public class RepositoryInfo implements Serializable {
         this.datePattern = orig.datePattern;
         this.parent = orig.parent;
         this.branch = orig.branch;
+        this.currentVersion = orig.currentVersion;
     }
 
     /**
@@ -166,5 +168,13 @@ public class RepositoryInfo implements Serializable {
 
     public void setBranch(String branch) {
         this.branch = branch;
+    }
+
+    public String getCurrentVersion() {
+        return currentVersion;
+    }
+
+    public void setCurrentVersion(String currentVersion) {
+        this.currentVersion = currentVersion;
     }
 }

--- a/src/org/opensolaris/opengrok/web/PageConfig.java
+++ b/src/org/opensolaris/opengrok/web/PageConfig.java
@@ -477,6 +477,10 @@ public final class PageConfig {
         return getEnv().getRevisionMessageCollapseThreshold();
     }
 
+    public int getCurrentIndexedCollapseThreshold() {
+        return getEnv().getCurrentIndexedCollapseThreshold();
+    }
+
     /**
      * Get sort orders from the request parameter {@code sort} and if this list
      * would be empty from the cookie {@code OpenGrokorting}.

--- a/web/default/style.css
+++ b/web/default/style.css
@@ -215,6 +215,9 @@ label {
     margin-bottom: 0;
 }
 
+.panel-body > table tr td:last-child, .panel-body-accordion > table tr td:last-child {
+    width: 400px;
+}
 /*
  * Changesets colorization
  * 1 is the most recent changeset

--- a/web/js/repos.js
+++ b/web/js/repos.js
@@ -138,4 +138,5 @@ $(document).ready(function () {
 
         return false;
     });
+    domReadyHistory();
 });

--- a/web/js/utils.js
+++ b/web/js/utils.js
@@ -1483,6 +1483,7 @@ function domReadyHistory() {
     // I cannot say what will happen if they are not like that, togglediffs
     // will go mad !
     togglerevs();
+    toggleProjectInfo();
 }
 
 function get_annotations() {
@@ -1737,21 +1738,21 @@ function toggle_revtags() {
 }
 
 /**
- *  Function to toggle revision message length for long revision messages
+ *  Function to toggle message length presentation
  */
-function togglerevs() {
+function toggleCommon(closestType) {
   $(".rev-toggle-a").click(function() {
-    var toggleState = $(this).closest("p").attr("data-toggle-state");
+    var toggleState = $(this).closest(closestType).attr("data-toggle-state");
     var thisCell = $(this).closest("td");
 
-    if (toggleState == "less") {
-      $(this).closest("p").attr("data-toggle-state", "more");
+    if (toggleState === "less") {
+      $(this).closest(closestType).attr("data-toggle-state", "more");
       thisCell.find(".rev-message-summary").addClass("rev-message-hidden");
       thisCell.find(".rev-message-full").removeClass("rev-message-hidden");
       $(this).html("... show less");
     }
-    else if (toggleState == "more") {
-      $(this).closest("p").attr("data-toggle-state", "less");
+    else if (toggleState === "more") {
+      $(this).closest(closestType).attr("data-toggle-state", "less");
       thisCell.find(".rev-message-full").addClass("rev-message-hidden");
       thisCell.find(".rev-message-summary").removeClass("rev-message-hidden");
       $(this).html("show more ...");
@@ -1759,6 +1760,19 @@ function togglerevs() {
 
     return false;
   });
+}
+
+/**
+ *  Function to toggle revision message length for long revision messages
+ */
+function togglerevs() {
+  $(".rev-toggle-a").click(toggleCommon("p"));
+}
+/**
+ *  Function to toggle project info message length
+ */
+function toggleProjectInfo() {
+  $(".rev-toggle-a").click(toggleCommon("span"));
 }
 
 function selectAllProjects() {

--- a/web/offwhite/style.css
+++ b/web/offwhite/style.css
@@ -215,6 +215,10 @@ label {
     margin-bottom: 0;
 }
 
+.panel-body > table tr td:last-child, .panel-body-accordion > table tr td:last-child {
+    width: 400px;
+}
+
 /*
  * Changesets colorization
  * 1 is the most recent changeset

--- a/web/polished/style.css
+++ b/web/polished/style.css
@@ -233,6 +233,10 @@ label {
     margin-bottom: 0;
 }
 
+.panel-body > table tr td:last-child, .panel-body-accordion > table tr td:last-child {
+    width: 400px;
+}
+
 /*
  * Changesets colorization
  * 1 is the most recent changeset

--- a/web/repos.jspf
+++ b/web/repos.jspf
@@ -131,6 +131,7 @@ Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
                     <td><b>Mirror</b></td>
                     <td><b>SCM type</b></td>
                     <td><b>Parent (branch)</b></td>
+                    <td><b>Current version</b></td>
                     </tr>
                     </thead>
                     <tbody>
@@ -175,8 +176,36 @@ Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
                             if (branch == null) {
                                 branch = "N/A";
                             }
+                            String currentVersion = ri.getCurrentVersion();
+                            if (currentVersion == null) {
+                                currentVersion = "N/A";
+                            }
                             %><td><%= Util.htmlize(type) %></td><%
                             %><td><%= Util.htmlize(parent) %> (<%= Util.htmlize(branch) %>)</td><%
+                            %><td><%
+
+                            // Current index collapse threshold minimum of 10
+                            int summaryLength = Math.max(10, cfg.getCurrentIndexedCollapseThreshold());
+                            String cout = Util.htmlize(currentVersion);
+
+                            boolean showSummary = false;
+                            String coutSummary = currentVersion;
+                            if (coutSummary.length() > summaryLength) {
+                                showSummary = true;
+                                coutSummary = coutSummary.substring(0, summaryLength - 1);
+                                coutSummary = Util.htmlize(coutSummary);
+                            }
+                            if (showSummary) {
+                                %>
+                                <span class="rev-message-summary"><%= coutSummary %></span>
+                                <span class="rev-message-full rev-message-hidden"><%= cout %></span>
+                                <span  data-toggle-state="less"><a class="rev-toggle-a rev-message-toggle "  href="#">show more ... </a></span>
+                                <%
+                            }
+                            else {
+                                 %><span class="rev-message-full"><%= cout %></span><%
+                            }
+                            %></td><%
                             %></tr><%
                             cnt++;
                         }
@@ -224,11 +253,12 @@ Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
                     <div class="panel-body<% if (groups.size() > 0) {%>-accordion<% } %> <% if (pHelper.hasUngroupedFavourite()) { %> favourite<% } %>"
                         <% if (pHelper.hasUngroupedFavourite()) { %>data-accordion-visible="true"<% } %>>
                         <table>
-                            <thead>
+                        <thead>
                         <tr>
                         <td><b>Mirror</b></td>
                         <td><b>SCM type</b></td>
                         <td><b>Parent (branch)</b></td>
+                        <td><b>Current version</b></td>
                         </tr>
                             </thead>
                             <tbody>
@@ -270,8 +300,37 @@ Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
                                 if (branch == null) {
                                     branch = "N/A";
                                 }
+                                String currentVersion = ri.getCurrentVersion();
+                                if (currentVersion == null) {
+                                    currentVersion = "N/A";
+                                }
                                 %><td><%= Util.htmlize(type) %></td><%
                                 %><td><%= Util.htmlize(parent) %> (<%= Util.htmlize(branch) %>)</td><%
+                                %><td><%
+
+                                // Current index message collapse threshold minimum of 10
+                                int summaryLength = Math.max(10, cfg.getCurrentIndexedCollapseThreshold());
+                                String cout = Util.htmlize(currentVersion);
+
+                                boolean showSummary = false;
+                                String coutSummary = currentVersion;
+                                if (coutSummary.length() > summaryLength) {
+                                    showSummary = true;
+                                    coutSummary = coutSummary.substring(0, summaryLength - 1);
+                                    coutSummary = Util.htmlize(coutSummary);
+                                }
+
+                                if (showSummary) {
+                                    %>
+                                    <span class="rev-message-summary"><%= coutSummary %></span>
+                                    <span class="rev-message-full rev-message-hidden"><%= cout %></span>
+                                    <span  data-toggle-state="less"><a class="rev-toggle-a rev-message-toggle "  href="#">show more ... </a></span>
+                                    <%
+                                }
+                                else {
+                                     %><span class="rev-message-full"><%= cout %></span><%
+                                }
+                                %></td><%
                                 %></tr><%
                                 cnt++;
                             }


### PR DESCRIPTION
## Why needed 
Currently the repos table on home page already shows some details about the available projects. I found it very helpful to also show what is the current **indexed version** for each project. This way you can immediately know how much up to date the project is.

As a start I added the information for git SCM only but I prepared the infrastructure to add for other SCM (much like the “branch” column).

## Here is the result:
<img width="1434" alt="screen shot 2016-11-11 at 1 20 15 am" src="https://cloud.githubusercontent.com/assets/1177299/20198466/70e257f4-a7ad-11e6-91a8-190f56ed8d64.png">



