### PR TITLE
render scope signature as html

### DIFF
--- a/web/js/utils.js
+++ b/web/js/utils.js
@@ -1056,7 +1056,7 @@
             }, options || {}), $.extend({
                 $scopes: $(),
                 buildLink: function (href, name) {
-                    return $('<a>').attr('href', '#' + href).attr('title', name).text(name)
+                    return $('<a>').attr('href', '#' + href).attr('title', name).html(name)
                 }
             }, context || {}));
         }


### PR DESCRIPTION
Changes the scope view from:
`foo( ..., List&lt;String&gt; subFiles, List&lt;String&gt; repositories, List&lt;String&gt; zapCache, boolean listRepoPaths)`
to:
`foo( ..., List<String> subFiles, List<String> repositories, List<String> zapCache, boolean listRepoPaths)`