### PR TITLE
removing the ugly content jump on scope collapse

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/JFlexXref.java
+++ b/src/org/opensolaris/opengrok/analysis/JFlexXref.java
@@ -479,6 +479,7 @@ public abstract class JFlexXref {
     protected void startNewLine() throws IOException {
         String iconId = null;
         int line = getLineNumber() + 1;
+        boolean skipNl = false;
         setLineNumber(line);
 
         if (scopesEnabled) {
@@ -486,31 +487,34 @@ public abstract class JFlexXref {
 
             if (scopeOpen && scope == null) {
                 scopeOpen = false;
-                out.write("</span>");
+                out.write("\n</span>");
+                skipNl = true;
             } else if (scope != null) {
                 String scopeId = generateId(scope);
                 if (scope.getLineFrom() == line) {
-                    out.write("<span id='");
+                    out.write("\n<span id='");
                     out.write(scopeId);
                     out.write("' class='scope-head'><span class='scope-signature'>");
                     out.write(htmlize(scope.getName() + scope.getSignature()));
                     out.write("</span>");
                     iconId = scopeId + "_fold_icon";
+                    skipNl = true;
                 } else if (scope.getLineFrom() == line - 1) {
                     if (scopeOpen) {
                         out.write("</span>");
                     }
 
-                    out.write("<span id='");
+                    out.write("\n<span id='");
                     out.write(scopeId);
                     out.write("_fold' class='scope-body'>");
+                    skipNl = true;
                 }
                 scopeOpen = true;
             }
         }
 
         Util.readableLine(line, out, annotation, userPageLink, userPageSuffix,
-                getProjectPostfix(true));
+                getProjectPostfix(true), skipNl);
 
         if (foldingEnabled && scopesEnabled) {
             if (iconId != null) {


### PR DESCRIPTION
Mentioned in #1274.
I'm struggling with this for quite long time and I can't find the best solution - currently this is way nicer although not perfect.

Only the next line number jumps to the right and when it folds it becomes aligned with the others.
![screenshot from 2016-11-11 17-19-45](https://cloud.githubusercontent.com/assets/6997160/20221809/2301ba6c-a833-11e6-9194-51f2ae28f35e.png)

There is generally a problem with new lines, preformated text `<pre>` and block elements (the `fold` effect needs the element to be at least `inline-block`)

