### PR TITLE
removing select from common input style

### DIFF
--- a/web/default/style.css
+++ b/web/default/style.css
@@ -308,6 +308,9 @@ label {
 
 #qtbl input.q, #qtbl select.q {
     width: 100%;
+}
+
+#qtbl input.q {
     height: 1.3em;
 }
 

--- a/web/offwhite/style.css
+++ b/web/offwhite/style.css
@@ -310,6 +310,9 @@ label {
 
 #qtbl input.q, #qtbl select.q {
     width: 100%;
+}
+
+#qtbl input.q {
     height: 1.3em;
 }
 

--- a/web/polished/style.css
+++ b/web/polished/style.css
@@ -350,6 +350,9 @@ label {
 
 #qtbl input.q, #qtbl select.q {
     width: 100%;
+}
+
+#qtbl input.q {
     height: 1.3em;
 }
 


### PR DESCRIPTION
Removing the text cut in the select box: (before)
![screenshot from 2016-11-14 12-37-21](https://cloud.githubusercontent.com/assets/6997160/20263497/54c4a98e-aa67-11e6-9d38-165c404dec84.png)
(after):
![screenshot from 2016-11-14 12-37-33](https://cloud.githubusercontent.com/assets/6997160/20263498/54e90036-aa67-11e6-90cd-8892e21a463d.png)
