### PR TITLE
forcing the same create date for all messages in tests

### DIFF
--- a/test/org/opensolaris/opengrok/configuration/messages/NormalMessageTest.java
+++ b/test/org/opensolaris/opengrok/configuration/messages/NormalMessageTest.java
@@ -103,9 +103,11 @@ public class NormalMessageTest {
     @Test
     public void testApplyMultipleUnique() {
         Message[] m = makeArray(new NormalMessage(), new NormalMessage(), new NormalMessage());
+        Date d = new Date();
 
         for (int i = 0; i < m.length; i++) {
             m[i].addTag("main");
+            m[i].setCreated(d);
         }
 
         Assert.assertEquals(0, env.getMessagesInTheSystem());


### PR DESCRIPTION
fixes #1279

The creation of the three messages can't and doesn't happen at the same time.