### PR TITLE
fixing revision number in annotation

### DIFF
--- a/src/org/opensolaris/opengrok/web/Util.java
+++ b/src/org/opensolaris/opengrok/web/Util.java
@@ -539,7 +539,7 @@ public final class Util {
                 }
                 if (annotation.getFileVersion(r) != 0) {
                     out.write("&lt;br/&gt;version: " + annotation.getFileVersion(r) + "/"
-                            + annotation.getFileVersionsCount());
+                            + annotation.getRevisions().size());
                 }
                 out.write(closeQuotedTag);
             }


### PR DESCRIPTION
Observable for example on OpenGrok file `web/default/style.css`. Find revision `1412e1e9` (image attached) and click on it - that takes you into that revision. However the revision number then shows 16/15 which is not correct. I think it's because there are some revisions which don't have information about author (that's different story - they're not available in `git log` in this case):

Before:
![screenshot from 2016-11-14 14-42-08](https://cloud.githubusercontent.com/assets/6997160/20266987/e53ad0ea-aa78-11e6-8112-fef5e1c390fd.png)

After:
![screenshot from 2016-11-14 14-41-08](https://cloud.githubusercontent.com/assets/6997160/20266999/fadb8a52-aa78-11e6-9784-f6ba8fe20f0f.png)

