### PR TITLE
removing extra newline in C/C++ files after one line comment

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/c/CXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/c/CXref.lex
@@ -119,7 +119,6 @@ Number = (0[xX][0-9a-fA-F]+|[0-9]+\.[0-9]+|[1-9][0-9]*)(([eE][+-]?[0-9]+)?[ufdlU
 
 <SCOMMENT> {
 {WhiteSpace}*{EOL}      {
-    out.write(yytext());
     yypop();
     startNewLine();}
 }


### PR DESCRIPTION
fixes #1163

I'm not a pro in lex files. However the removed line added a `{EOL}` into the output and after that the `startNewLine();` added a second one. It looks fine to me to trash the trailing whitespace and EOL as it's done also [in general EOL](https://github.com/OpenGrok/OpenGrok/blob/65a0ddded9e4776c836b5c683f3c33f750e0546d/src/org/opensolaris/opengrok/analysis/c/CXref.lex#L128-L132) later and basically it's not valuable for anything.

Requires reindex.