### PR TITLE
bump required Java and Tomcat versions for gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,12 +65,12 @@ Requirements:
 
 <ul>
   <li>
-  Latest <a href="http://www.oracle.com/technetwork/java//">Java</a> 1.7
+  Latest <a href="http://www.oracle.com/technetwork/java//">Java</a> 1.8
   </li>
 
   <li>
   A servlet container like <a href="https://glassfish.dev.java.net/">GlassFish</a>
-  or <a href="http://tomcat.apache.org/">Tomcat</a> (6.x, 7.x or later) also running with Java at least 1.7
+  or <a href="http://tomcat.apache.org/">Tomcat</a> (8.x or later) also running with Java at least 1.8
   </li>
 
   <li>


### PR DESCRIPTION
Update required Java version to 1.8 and Tomcat to 8.x, same as given in the requirements file.