### PR TITLE
deleting margin for messages

### DIFF
--- a/web/default/style.css
+++ b/web/default/style.css
@@ -1095,7 +1095,7 @@ span.scope-signature {
 
 .message-group {
     padding-left: 0;
-    margin: 0 2em 0 2em;
+    margin: 0 0 5px 0;
 }
 
 .message-group.limited {
@@ -1109,8 +1109,6 @@ span.scope-signature {
     position: relative;
     display: block;
     padding: 2px 10px;
-    margin-left: 1%;
-    margin-right: 1%;
     background-color: #fff;
     margin-bottom: 3px;
 }

--- a/web/offwhite/style.css
+++ b/web/offwhite/style.css
@@ -1127,7 +1127,7 @@ span.scope-signature {
 
 .message-group {
     padding-left: 0;
-    margin: 0 2em 0 2em;
+    margin: 0 0 5px 0;
 }
 
 .message-group.limited {
@@ -1146,8 +1146,6 @@ h6.message-group-caption {
     position: relative;
     display: block;
     padding: 2px 10px;
-    margin-left: 1%;
-    margin-right: 1%;
     background-color: #fff;
     margin-bottom: 3px;
 }

--- a/web/polished/style.css
+++ b/web/polished/style.css
@@ -1205,7 +1205,7 @@ span.scope-signature {
 
 .message-group {
     padding-left: 0;
-    margin: 0 2em 0 2em;
+    margin: 0 0 5px 0;
 }
 
 .message-group.limited {
@@ -1219,8 +1219,6 @@ span.scope-signature {
     position: relative;
     display: block;
     padding: 2px 10px;
-    margin-left: 1%;
-    margin-right: 1%;
     background-color: #fff;
     margin-bottom: 3px;
 }


### PR DESCRIPTION
After UI changes in #1252 the messages box was left intact. I corrected the size to match the project's box.
#### Before
![screenshot from 2016-12-30 16-59-51](https://cloud.githubusercontent.com/assets/6997160/21568077/a385c080-ceb1-11e6-99f5-a93a63a5289e.png)
#### After
![screenshot from 2016-12-30 17-00-23](https://cloud.githubusercontent.com/assets/6997160/21568076/a384f8a8-ceb1-11e6-84fc-a10ce41cfe3f.png)
