### PR TITLE
Supporting older git < 2.6 which does not have --date:format option

### DIFF
--- a/src/org/opensolaris/opengrok/util/StringUtils.java
+++ b/src/org/opensolaris/opengrok/util/StringUtils.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
  */
 
 package org.opensolaris.opengrok.util;
@@ -107,4 +107,28 @@ public final class StringUtils {
 
       return (output.length() == 0 ? "0" : output);
   }
+
+    /**
+     * Finds n-th index of a given substring in a string.
+     *
+     * @param str an original string
+     * @param substr a substring to match
+     * @param n n-th occurrence
+     * @return the index of the first character of the substring in the original
+     * string where the substring occurred n-th times in the string. If the n-th
+     * candidate does not exist, -1 is returned.
+     */
+    public static int nthIndexOf(String str, String substr, int n) {
+        int pos = -1;
+        while (n > 0) {
+            if (pos >= str.length()) {
+                return -1;
+            }
+            if ((pos = str.indexOf(substr, pos + 1)) == -1) {
+                break;
+            }
+            n--;
+        }
+        return pos;
+    }
 }

--- a/test/org/opensolaris/opengrok/util/StringUtilsTest.java
+++ b/test/org/opensolaris/opengrok/util/StringUtilsTest.java
@@ -17,12 +17,13 @@
  * CDDL HEADER END
  */
 
-/*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ /*
+ * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.util;
 
 import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -47,6 +48,64 @@ public class StringUtilsTest {
 
         for (i = 0; i < values.length; i++) {
             assertEquals(expected[i], StringUtils.getReadableTime(values[i]));
+        }
+    }
+
+    @Test
+    public void testNthIndexOf() {
+        Object[][] tests = new Object[][]{
+            {"", "", -1},
+            {"", "", 0},
+            {"", "", 1},
+            {"", "", 2},
+            {"foo", "foo", 0},
+            {"foo", "foo", 1},
+            {"foo", "foo", 2},
+            {"foo", "foo", 3},
+            {"foo", "f", 0},
+            {"foo", "f", 1},
+            {"foo", "f", 2},
+            {"foo", "f", 3},
+            {"foo", "o", 0},
+            {"foo", "o", 1},
+            {"foo", "o", 2},
+            {"foo", "o", 3},
+            {"This is an example string", "a", 2},
+            {"This is an example string", "a", 3},
+            {"This is an example string", "i", 1},
+            {"This is an example string", "i", 2},
+            {"This is an example string", "i", 3},
+            {"This is an example string", "is", 1},
+            {"This is an example string", "is", 2},
+            {"aabbccddaabbccdd", "a", 1},
+            {"aabbccddaabbccdd", "a", 2},
+            {"aabbccddaabbccdd", "a", 3},
+            {"aabbccddaabbccdd", "a", 4},
+            {"aabbccddaabbccdd", "cd", 1},
+            {"aabbccddaabbccdd", "cd", 2},
+            {"aabbccddaabbccdd", "ccdd", 1},
+            {"aabbccddaabbccdd", "ccdd", 2},};
+
+        int[] indices = new int[]{
+            -1, -1, 0, -1,
+            -1, 0, -1, -1,
+            -1, 0, -1, -1,
+            -1, 1, 2, -1,
+            13, -1,
+            2, 5, 22,
+            2, 5,
+            0, 1, 8, 9,
+            5, 13,
+            4, 12
+        };
+
+        assertEquals(tests.length, indices.length);
+
+        for (int i = 0; i < tests.length; i++) {
+            int index = StringUtils.nthIndexOf((String) tests[i][0], (String) tests[i][1], (Integer) tests[i][2]);
+            assertEquals(String.format("%d-th occurrence of \"%s\" in \"%s\" should start at %d but started at %d",
+                    new Object[]{tests[i][2], tests[i][1], tests[i][0], indices[i], index}),
+                    index, indices[i]);
         }
     }
 }


### PR DESCRIPTION
Apparently our feature from #1262 is only supported in git2.6+ (as discovered [here](https://github.com/OpenGrok/OpenGrok/pull/1262#commitcomment-20273958)).

This patch should support older git versions by converting the date from rfc, without using the `--date=format:` option.

Also this was reported in #1310 which gave me the clue that not everybody uses upgraded git. 
