### PR TITLE
Messages are group aware

### DIFF
--- a/src/org/opensolaris/opengrok/search/Results.java
+++ b/src/org/opensolaris/opengrok/search/Results.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
  *
  * Portions Copyright 2011 Jens Elkner.
  */
@@ -172,8 +172,9 @@ public final class Results {
             }
             JSONArray messages;
             if ((p = Project.getProject(parent)) != null
-                    && (messages = Util.messagesToJson(RuntimeEnvironment.MESSAGES_MAIN_PAGE_TAG,
-                            p.getDescription())).size() > 0) {
+                    && (messages = Util.messagesToJson(p,
+                            RuntimeEnvironment.MESSAGES_MAIN_PAGE_TAG
+                    )).size() > 0) {
                 out.write(" <a ");
                 out.write("href=\"" + xrefPrefix + "/" + p.getDescription() + "\">");
                 out.write("<span class=\"important-note important-note-rounded\" data-messages='" + messages + "'>!</span>");

--- a/src/org/opensolaris/opengrok/web/Util.java
+++ b/src/org/opensolaris/opengrok/web/Util.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
  */
 package org.opensolaris.opengrok.web;
@@ -1045,6 +1045,19 @@ public final class Util {
     }
 
     /**
+     * Print messages for given tags into json array
+     *
+     * @param tags list of tags
+     * @return json array of the messages
+     * @see #messagesToJson(String...)
+     * @see #messagesToJsonObject(String)
+     */
+    public static JSONArray messagesToJson(List<String> tags) {
+        String[] array = new String[tags.size()];
+        return messagesToJson(tags.toArray(array));
+    }
+
+    /**
      * Print messages for given project into json array. These messages are
      * tagged by project description or tagged by any of the project's group
      * name.
@@ -1064,7 +1077,7 @@ public final class Util {
         project.getGroups().stream().forEach((Group t) -> {
             tags.add(t.getName());
         });
-        return messagesToJson((String[]) tags.toArray());
+        return messagesToJson(tags);
     }
 
     /**
@@ -1078,6 +1091,32 @@ public final class Util {
      */
     public static JSONArray messagesToJson(Project project) {
         return messagesToJson(project, new String[0]);
+    }
+
+    /**
+     * Print messages for given group into json array.
+     *
+     * @param group the group
+     * @param additionalTags additional list of tags
+     * @return the json array
+     * @see #messagesToJson(java.util.List)
+     */
+    public static JSONArray messagesToJson(Group group, String... additionalTags) {
+        List<String> tags = new ArrayList<>();
+        tags.add(group.getName());
+        tags.addAll(Arrays.asList(additionalTags));
+        return messagesToJson(tags);
+    }
+
+    /**
+     * Print messages for given group into json array.
+     *
+     * @param group the group
+     * @return the json array
+     * @see #messagesToJson(Group, String...)
+     */
+    public static JSONArray messagesToJson(Group group) {
+        return messagesToJson(group, new String[0]);
     }
 
     /**

--- a/web/mast.jsp
+++ b/web/mast.jsp
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 
 --%><%--
@@ -107,8 +107,8 @@ include file="pageheader.jspf"
     <%
     JSONArray messages = new JSONArray();
     if (cfg.getProject() != null) {
-        messages = Util.messagesToJson(RuntimeEnvironment.MESSAGES_MAIN_PAGE_TAG,
-                            cfg.getProject().getDescription());
+        messages = Util.messagesToJson(cfg.getProject(),
+                    RuntimeEnvironment.MESSAGES_MAIN_PAGE_TAG);
     }
     %>
     <% if (!messages.isEmpty()) { %>

--- a/web/menu.jspf
+++ b/web/menu.jspf
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
 
 Portions Copyright 2011 Jens Elkner.
 
@@ -50,6 +50,7 @@ org.opensolaris.opengrok.web.Util"
 {
     // PageConfig cfg = PageConfig.get(request);
     ProjectHelper ph = ProjectHelper.getInstance(cfg);
+    JSONArray messages;
     Set<Project> projects = ph.getAllProjects();
     if (projects == null) {
         projects = new TreeSet<>();
@@ -191,8 +192,7 @@ org.opensolaris.opengrok.web.Util"
                     if (pRequested.contains(p.getDescription())) {
                         %> selected="selected"<%
                     }
-                    JSONArray messages = Util.messagesToJson(p.getDescription());
-                    if (!messages.isEmpty()) {
+                    if (!(messages = Util.messagesToJson(p)).isEmpty()) {
                     %> data-messages='<%= messages %>' <%
                         }
                     %>><%= Util.formQuoteEscape(p.getDescription()) %></option><%
@@ -209,8 +209,7 @@ org.opensolaris.opengrok.web.Util"
             if (pRequested.contains(p.getDescription())) {
                 %> selected="selected"<%
             }
-            JSONArray messages = Util.messagesToJson(p.getDescription());
-            if (!messages.isEmpty()) {
+            if (!(messages = Util.messagesToJson(p)).isEmpty()) {
                 %> data-messages='<%= messages %>' <%
             }
             %>><%= Util.formQuoteEscape(p.getDescription()) %></option><%

--- a/web/repos.jspf
+++ b/web/repos.jspf
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
 
 --%>
 <%@page import="org.json.simple.JSONArray"%>
@@ -48,6 +48,7 @@ Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
 <%
 {
     PageConfig cfg = PageConfig.get(request);
+    JSONArray messages;
 
     Util.printMessages(out, cfg.getMessages());
 
@@ -109,6 +110,10 @@ Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
                         <h4 class="clearfix">
                             <span class="pull-left">
                                 <span class="name"><%= Util.htmlize(group.getName())%></span>
+                                <%
+                                if (!(messages = Util.messagesToJson(group)).isEmpty()) { %>
+                                    <span class="important-note important-note-rounded" data-messages='<%= messages %>'>!</span>
+                                <% } %>
                                 <small>
                                     [<a href="#" class="projects_select_all">select all</a>]
                                     (<span title="Number of groups directly in this group"><%= pHelper.getSubgroups(group).size() %></span> +
@@ -158,8 +163,7 @@ Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
                         <%= Util.htmlize(projDesc) %>
                     </a>
                     <%
-                    JSONArray messages = Util.messagesToJson(project.getDescription());
-                    if (!messages.isEmpty()) { %>
+                    if (!(messages = Util.messagesToJson(project)).isEmpty()) { %>
                         <span class="important-note important-note-rounded" data-messages='<%= messages %>'>!</span>
                     <% } %>
                                 </td><%
@@ -236,7 +240,11 @@ Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
                         <div class="panel-heading-accordion">
                             <h4 class="clearfix">
                                 <span class="pull-left">
-                                    <span class="name">Other</span> 
+                                    <span class="name">Other</span>
+                                    <%
+                                    if (!(messages = Util.messagesToJson("other")).isEmpty()) { %>
+                                        <span class="important-note important-note-rounded" data-messages='<%= messages %>'>!</span>
+                                    <% } %>
                                     <small>
                                         [<a href="#" class="projects_select_all">select all</a>]
                                         (<span title="Number of repositories inside"><%= repositories.size() %></span>)
@@ -280,8 +288,7 @@ Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
                         <%= Util.htmlize(projDesc) %>
                     </a>
                     <%
-                    JSONArray messages = Util.messagesToJson(proj.getDescription());
-                    if (!messages.isEmpty()) { %>
+                    if (!(messages = Util.messagesToJson(proj)).isEmpty()) { %>
                         <span class="important-note important-note-rounded" data-messages='<%= messages %>'>!</span>
                     <% } %>
                     </td><%


### PR DESCRIPTION
fixes #1212

The special group "other" (projects without any group) is not handled. Only on the main page there is the exclamation mark next to the section "Others".

When viewing single project there are all messages which are connected to the project - main messages, project messages and group messages:
![screenshot from 2017-01-06 17-38-35](https://cloud.githubusercontent.com/assets/6997160/21725109/497b6f50-d437-11e6-8149-fbb3b9739c37.png)

On the main page, the exclamation mark is there for every group.
![screenshot from 2017-01-06 17-42-36](https://cloud.githubusercontent.com/assets/6997160/21725172/87a8f522-d437-11e6-9b4d-0f91f9f36748.png)

