### PR TITLE
using a timeout for scopes update

### DIFF
--- a/web/httpheader.jspf
+++ b/web/httpheader.jspf
@@ -89,7 +89,7 @@ if (cfg.getPrefix().equals(Prefix.HIST_L)) {
 <script type="text/javascript" src="<%=ctxPath%>/js/tablesorter.parsers-0.0.1.js"></script>
 <script type="text/javascript" src="<%=ctxPath%>/js/searchable-option-list-2.0.2.min.js"></script>
 <%--<script type="text/javascript" src="<%=ctxPath%>/js/jquery.autocomplete-1.1.pack.js"></script> --%>
-<script type="text/javascript" src="<%=ctxPath%>/js/utils-0.0.2.js"></script>
+<script type="text/javascript" src="<%=ctxPath%>/js/utils-0.0.3.js"></script>
 <title><%=cfg.getTitle()%></title><%
     out.write(cfg.getHeaderData());
 %>

--- a/web/js/utils-0.0.3.js
+++ b/web/js/utils-0.0.3.js
@@ -1772,9 +1772,6 @@ function clearSearchFrom() {
     $("#type :selected").prop("selected", false);
 }
 
-var scope_visible = 0;
-var scope_text = '';
-
 /**
  * Fold or unfold a function definition.
  */
@@ -1787,30 +1784,38 @@ function fold(id) {
     $('#' + id + '_fold').toggle('fold');
 }
 
+var scope_timeout = null;
 /**
  * Function that is called when the #content div element is scrolled. Checks
  * if the top of the page is inside a function scope. If so, update the
  * scope element to show the name of the function and a link to its definition.
  */
 function scope_on_scroll() {
-    var cnt = document.getElementById("content");
-    var y = cnt.getBoundingClientRect().top + 2;
-    var c = document.elementFromPoint(15, y + 1);
-
-    if ($(c).is('.l, .hl')) {
-        var $par = $(c).closest('.scope-body, .scope-head')
-
-        if (!$par.length) {
-            return;
-        }
-
-        var $head = $par.hasClass('scope-body') ? $par.prev() : $par;
-        var $sig = $head.children().first()
-        if ($.scopesWindow.initialized) {
-            $.scopesWindow.update({
-                'id': $head.attr('id'),
-                'link': $sig.html(),
-            })
-        }
+    if (scope_timeout !== null) {
+        clearTimeout(scope_timeout)
+        scope_timeout = null
     }
+    scope_timeout = setTimeout(function () {
+        var cnt = document.getElementById("content");
+        var y = cnt.getBoundingClientRect().top + 2;
+        var c = document.elementFromPoint(15, y + 1);
+
+        if ($(c).is('.l, .hl')) {
+            var $par = $(c).closest('.scope-body, .scope-head')
+
+            if (!$par.length) {
+                return;
+            }
+
+            var $head = $par.hasClass('scope-body') ? $par.prev() : $par;
+            var $sig = $head.children().first()
+            if ($.scopesWindow.initialized) {
+                $.scopesWindow.update({
+                    'id': $head.attr('id'),
+                    'link': $sig.html(),
+                })
+            }
+        }
+        scope_timeout = null;
+    }, 150);
 }


### PR DESCRIPTION
For a large file (.c file 8000 lines) the performance of the scopes window almost disables the user to scroll causing the browser to freeze.

This introduces a timeout so the callback is not triggered after every scroll event.