### PR TITLE
defining the type of cfg (PageConfig)

### DIFF
--- a/web/list.jsp
+++ b/web/list.jsp
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 
 --%>
@@ -51,7 +51,7 @@ org.opensolaris.opengrok.web.DirectoryListing"
     if (request.getCharacterEncoding() == null) {
         request.setCharacterEncoding("UTF-8");
     }
-    cfg = PageConfig.get(request);
+    PageConfig cfg = PageConfig.get(request);
     Annotation annotation = cfg.getAnnotation();
     if (annotation != null) {
         int r = annotation.getWidestRevision();


### PR DESCRIPTION
fixes #1356

This was some kind of race condition (that's what I think). The part under the diff to write the `<style>` into the page config sometimes didn't get executed. It's still in our code that the `cfg` variable is defined as a private property of the compiled JSP which must be a race condition if there is a heavy traffic and threads start to use this variable. **Therefore I suggest the next fix which is to get rid of this private variable.**

This fix makes the `cfg` local variable which shadows the member variable.

I discovered that this behaviour only happens under heavy traffic (or heavy load of the machine + heavy traffic). I tested the localhost with apache benchmark:

```bash
ab -n 1000 -c 10 -H 'X-FROM: 007' http://localhost:8080/source/xref/opengrok-master/src/org/opensolaris/opengrok/index/IndexDatabase.java?a=true
```

The results of successfully stored `<style>` data was:
 - 478 before the fix (out 1000 requests)
 - 10000 after the fix (out of 1000 requests)



