### PR TITLE
Remove file/revision ambiguity from git history log command

### DIFF
--- a/src/org/opensolaris/opengrok/history/GitRepository.java
+++ b/src/org/opensolaris/opengrok/history/GitRepository.java
@@ -135,6 +135,7 @@ public class GitRepository extends Repository {
         }
 
         if (filename.length() > 0) {
+            cmd.add("--");
             cmd.add(filename);
         }
 


### PR DESCRIPTION
Same fix for same issue that is avoided by https://github.com/OpenGrok/OpenGrok/blob/master/src/org/opensolaris/opengrok/history/GitRepository.java#L165