### PR TITLE
removing unused and non-existent import

### DIFF
--- a/web/repos.jspf
+++ b/web/repos.jspf
@@ -21,7 +21,6 @@ CDDL HEADER END
 Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
 
 --%>
-<%@page import="org.jcp.xml.dsig.internal.dom.Utils"%>
 <%@page import="org.json.simple.JSONArray"%>
 <%@page import="org.opensolaris.opengrok.configuration.messages.Message"%>
 <%@page import="java.util.SortedSet"%>


### PR DESCRIPTION
Just to accept this faster to have a non-failing build of webapp:

removing non existent import

```java
-<%@page import="org.jcp.xml.dsig.internal.dom.Utils"%>
```

I have no idea how that came there.