### PR TITLE
Authorization framework enhancements

### DIFF
--- a/src/org/opensolaris/opengrok/authorization/AuthorizationCheck.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationCheck.java
@@ -1,0 +1,155 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+ /*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.authorization;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ *
+ * @author Krystof Tulinger
+ */
+public class AuthorizationCheck implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Enum for avaliable authorization roles.
+     */
+    public enum AuthorizationRole {
+        /**
+         * Failure of such a plugin will ultimately lead to the authorization
+         * framework returning failure but only after the remaining plugins have
+         * been invoked.
+         *
+         */
+        REQUIRED("required"),
+        /**
+         * Like required, however, in the case that such a plugin returns a
+         * failure, control is directly returned to the application. The return
+         * value is that associated with the first required or requisite plugin
+         * to fail.
+         *
+         */
+        REQUISITE("requisite"),
+        /**
+         * If such a plugin succeeds and no prior required plugin has failed the
+         * authorization framework returns success to the application
+         * immediately without calling any further plugins in the stack. A
+         * failure of a sufficient plugin is ignored and processing of the
+         * plugin list continues unaffected.
+         */
+        SUFFICIENT("sufficient");
+
+        private final String role;
+
+        private AuthorizationRole(String role) {
+            this.role = role;
+        }
+
+        @Override
+        public String toString() {
+            return this.role;
+        }
+
+        public static AuthorizationRole get(String role) {
+            try {
+                return AuthorizationRole.valueOf(role.toUpperCase());
+            } catch (IllegalArgumentException ex) {
+                // role does not exist -> add some more info about which roles do exist
+                throw new IllegalArgumentException(
+                        String.format("No authorization role \"%s\", available roles are [%s]. %s",
+                                role,
+                                Arrays.asList(AuthorizationRole.values())
+                                        .stream()
+                                        .map(AuthorizationRole::toString)
+                                        .collect(Collectors.joining(", ")),
+                                ex.getLocalizedMessage()), ex);
+            }
+        }
+    };
+
+    /**
+     * One of "required", "requisite", "sufficient".
+     */
+    private AuthorizationRole role;
+
+    /**
+     * Canonical name of a java class.
+     */
+    private String classname;
+
+    public AuthorizationCheck() {
+    }
+
+    public AuthorizationCheck(AuthorizationRole role, String classname) {
+        this.role = role;
+        this.classname = classname;
+    }
+
+    /**
+     * Get the value of classname
+     *
+     * @return the value of classname
+     */
+    public String getClassname() {
+        return classname;
+    }
+
+    /**
+     * Set the value of classname
+     *
+     * @param classname new value of classname
+     */
+    public void setClassname(String classname) {
+        this.classname = classname;
+    }
+
+    /**
+     * Get the value of role
+     *
+     * @return the value of role
+     */
+    public AuthorizationRole getRole() {
+        return role;
+    }
+
+    /**
+     * Set the value of role
+     *
+     * @param role new value of role
+     */
+    public void setRole(AuthorizationRole role) {
+        this.role = role;
+    }
+
+    /**
+     * Set the value of role
+     *
+     * @param role new value of role
+     */
+    public void setRole(String role) {
+        this.role = AuthorizationRole.get(role);
+    }
+}

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationCheck.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationCheck.java
@@ -37,7 +37,7 @@ public class AuthorizationCheck implements Serializable {
     /**
      * Enum for avaliable authorization roles.
      */
-    public enum AuthorizationRole {
+    public enum AuthControlFlag {
         /**
          * Failure of such a plugin will ultimately lead to the authorization
          * framework returning failure but only after the remaining plugins have
@@ -64,7 +64,7 @@ public class AuthorizationCheck implements Serializable {
 
         private final String role;
 
-        private AuthorizationRole(String role) {
+        private AuthControlFlag(String role) {
             this.role = role;
         }
 
@@ -73,17 +73,17 @@ public class AuthorizationCheck implements Serializable {
             return this.role;
         }
 
-        public static AuthorizationRole get(String role) {
+        public static AuthControlFlag get(String role) {
             try {
-                return AuthorizationRole.valueOf(role.toUpperCase());
+                return AuthControlFlag.valueOf(role.toUpperCase());
             } catch (IllegalArgumentException ex) {
                 // role does not exist -> add some more info about which roles do exist
                 throw new IllegalArgumentException(
                         String.format("No authorization role \"%s\", available roles are [%s]. %s",
                                 role,
-                                Arrays.asList(AuthorizationRole.values())
+                                Arrays.asList(AuthControlFlag.values())
                                         .stream()
-                                        .map(AuthorizationRole::toString)
+                                        .map(AuthControlFlag::toString)
                                         .collect(Collectors.joining(", ")),
                                 ex.getLocalizedMessage()), ex);
             }
@@ -93,7 +93,7 @@ public class AuthorizationCheck implements Serializable {
     /**
      * One of "required", "requisite", "sufficient".
      */
-    private AuthorizationRole role;
+    private AuthControlFlag role;
 
     /**
      * Canonical name of a java class.
@@ -103,7 +103,7 @@ public class AuthorizationCheck implements Serializable {
     public AuthorizationCheck() {
     }
 
-    public AuthorizationCheck(AuthorizationRole role, String classname) {
+    public AuthorizationCheck(AuthControlFlag role, String classname) {
         this.role = role;
         this.classname = classname;
     }
@@ -131,7 +131,7 @@ public class AuthorizationCheck implements Serializable {
      *
      * @return the value of role
      */
-    public AuthorizationRole getRole() {
+    public AuthControlFlag getRole() {
         return role;
     }
 
@@ -140,7 +140,7 @@ public class AuthorizationCheck implements Serializable {
      *
      * @param role new value of role
      */
-    public void setRole(AuthorizationRole role) {
+    public void setRole(AuthControlFlag role) {
         this.role = role;
     }
 
@@ -150,6 +150,6 @@ public class AuthorizationCheck implements Serializable {
      * @param role new value of role
      */
     public void setRole(String role) {
-        this.role = AuthorizationRole.get(role);
+        this.role = AuthControlFlag.get(role);
     }
 }

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
@@ -367,6 +367,13 @@ public final class AuthorizationFramework {
         }
     }
 
+    /**
+     * Wrapper around the class loading. Report all exceptions into the log.
+     *
+     * @param classname full name of the class
+     *
+     * @see #loadClass(String)
+     */
     private void handleLoadClass(String classname) {
         try {
             loadClass(classname);
@@ -383,6 +390,24 @@ public final class AuthorizationFramework {
         }
     }
 
+    /**
+     * Load a class into JVM with custom class loader. Call a non-parametric
+     * constructor to create a new instance of that class.
+     *
+     * <p>
+     * The classes implementing the {@link IAuthorizationPlugin} interface are
+     * automatically added among the discovered plugins.
+     * </p>
+     *
+     * @param classname the full name of the class to load
+     *
+     * @throws ClassNotFoundException when the class can not be found
+     * @throws SecurityException when it is prohibited to load such class
+     * @throws InstantiationException when it is impossible to create a new
+     * instance of that class
+     * @throws IllegalAccessException when the constructor of the class is not
+     * accessible
+     */
     private void loadClass(String classname) throws ClassNotFoundException,
             SecurityException,
             InstantiationException,
@@ -409,6 +434,19 @@ public final class AuthorizationFramework {
         }
     }
 
+    /**
+     * Traverse list of files which possibly contain a java class and then
+     * traverse a list of jar files to load all classes which are contained
+     * within them. Each class is loaded with {@link #handleLoadClass(String)}
+     * which delegates the loading to the custom class loader
+     * {@link #loadClass(String)}.
+     *
+     * @param classfiles list of files which possibly contain a java class
+     * @param jarfiles list of jar files containing java classes
+     *
+     * @see #handleLoadClass(String)
+     * @see #loadClass(String)
+     */
     private void loadClasses(List<File> classfiles, List<File> jarfiles) {
         for (File file : classfiles) {
             String classname = getClassName(file);

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
@@ -617,10 +617,19 @@ public final class AuthorizationFramework {
 
     private boolean performCheck(Nameable entity, Predicate<AuthorizationPluginWrapper> predicate) {
         boolean overallDecision = true;
+        LOGGER.log(Level.FINEST, "Authorization for \"{0}\"",
+                new Object[]{entity.getName()});
         for (AuthorizationPluginWrapper plugin : getPlugins()) {
             // run the plugin's test method
             try {
+                LOGGER.log(Level.FINEST, "Plugin \"{0}\" [{1}] testing a name \"{2}\"",
+                        new Object[]{plugin.getClassname(), plugin.getRole(), entity.getName()});
+
                 boolean pluginDecision = predicate.test(plugin);
+
+                LOGGER.log(Level.FINEST, "Plugin \"{0}\" [{1}] testing a name \"{2}\" => {3}",
+                        new Object[]{plugin.getClassname(), plugin.getRole(), entity.getName(),
+                            pluginDecision ? "true" : "false"});
 
                 if (!pluginDecision && plugin.isRequired()) {
                     // required sets a failure but still invokes all other plugins
@@ -642,6 +651,10 @@ public final class AuthorizationFramework {
                                 entity.getName()),
                         ex);
 
+                LOGGER.log(Level.FINEST, "Plugin \"{0}\" [{1}] testing a name \"{2}\" => {3}",
+                        new Object[]{plugin.getClassname(), plugin.getRole(), entity.getName(),
+                            "false (failed)"});
+
                 // set the return value to false for this faulty plugin
                 if (!plugin.isSufficient()) {
                     overallDecision = false;
@@ -652,6 +665,8 @@ public final class AuthorizationFramework {
                 }
             }
         }
+        LOGGER.log(Level.FINEST, "Authorization for \"{0}\" => {1}",
+                new Object[]{entity.getName(), overallDecision ? "true" : "false"});
         return overallDecision;
     }
 }

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
@@ -148,8 +148,8 @@ public final class AuthorizationFramework {
      *
      * This and couple of following methods are declared as synchronized because
      * <ol>
-     *  <li>plugins can be reloaded at anytime</li>
-     *  <li>requests are pretty asynchronous</li>
+     * <li>plugins can be reloaded at anytime</li>
+     * <li>requests are pretty asynchronous</li>
      * </ol>
      *
      * So this tries to ensure that there will be no

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
@@ -72,6 +72,20 @@ public final class AuthorizationFramework {
     List<AuthorizationPluginWrapper> plugins;
 
     /**
+     * Keeping track of the number of reloads in this framework. This can be
+     * used by the plugins to invalidate the session and force reload the
+     * authorization values.
+     *
+     * Starting at 0 and increases with every reload.
+     *
+     * The plugin should call RuntimeEnvironment.getPluginVersion() to get this
+     * number.
+     *
+     * @see RuntimeEnvironment#getPluginVersion()
+     */
+    private int pluginVersion = 0;
+
+    /**
      * Plugin directory is set through RuntimeEnvironment.
      *
      * @return an instance of AuthorizationFramework
@@ -483,6 +497,9 @@ public final class AuthorizationFramework {
         // clean all plugins
         removeAll();
 
+        // increase the current plugin version tracked by the framework
+        increasePluginVersion();
+
         // add spaces with configured plugins - leaving null just to obtain the correct order of execution
         for (AuthorizationCheck check : RuntimeEnvironment.getInstance().getPluginConfiguration()) {
             plugins.add(new AuthorizationPluginWrapper(check, null));
@@ -494,6 +511,39 @@ public final class AuthorizationFramework {
                 IOUtils.listFiles(pluginDirectory, ".jar"));
 
         loadAllPlugins();
+    }
+
+    /**
+     * Returns the current plugins version in this framework. This can be used
+     * by the plugins to invalidate the session and force reload the
+     * authorization values.
+     *
+     * This number changes with every plugin reload.
+     *
+     * The plugin should call RuntimeEnvironment.getPluginVersion() to get this
+     * number and act upon if it needs to renew the session.
+     *
+     * @return the current version number
+     * @see RuntimeEnvironment#getPluginVersion()
+     */
+    public int getPluginVersion() {
+        return pluginVersion;
+    }
+
+    /**
+     * Changes the plugin version to the next version.
+     */
+    public void increasePluginVersion() {
+        this.pluginVersion++;
+    }
+
+    /**
+     * Sets the plugin version to an arbitrary number.
+     *
+     * @param pluginVersion the number
+     */
+    public void setPluginVersion(int pluginVersion) {
+        this.pluginVersion = pluginVersion;
     }
 
     /**

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
@@ -37,7 +37,7 @@ import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
-import org.opensolaris.opengrok.authorization.AuthorizationCheck.AuthorizationRole;
+import org.opensolaris.opengrok.authorization.AuthorizationCheck.AuthControlFlag;
 import org.opensolaris.opengrok.configuration.Configuration;
 import org.opensolaris.opengrok.configuration.Group;
 import org.opensolaris.opengrok.configuration.Nameable;
@@ -238,7 +238,7 @@ public final class AuthorizationFramework {
      * @param plugin the authorization plugin
      */
     protected synchronized void addPlugin(IAuthorizationPlugin plugin) {
-        addPlugin(plugin, AuthorizationRole.REQUIRED);
+        addPlugin(plugin, AuthControlFlag.REQUIRED);
     }
 
     /**
@@ -260,7 +260,7 @@ public final class AuthorizationFramework {
      * @param plugin the authorization plugin
      * @param role the role for the new plugins
      */
-    public synchronized void addPlugin(IAuthorizationPlugin plugin, AuthorizationRole role) {
+    public synchronized void addPlugin(IAuthorizationPlugin plugin, AuthControlFlag role) {
         AuthorizationPluginWrapper wrapper;
         if ((wrapper = findPlugin(getClassName(plugin))) != null) {
             if (wrapper.hasPlugin()) {

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
@@ -321,6 +321,7 @@ public final class AuthorizationFramework {
         try {
             plugin.load();
             plugin.setWorking();
+
         } catch (Throwable ex) {
             LOGGER.log(Level.SEVERE, "Plugin \"" + plugin.getClassname() + "\" has failed while loading with exception:", ex);
             plugin.setFailed();
@@ -341,6 +342,12 @@ public final class AuthorizationFramework {
                 plugin.setFailed();
             }
             loadPlugin(plugin);
+            LOGGER.log(Level.INFO, "[{0}] Plugin \"{1}\" {2} and is {3}.",
+                    new Object[]{
+                        plugin.getRole().toString().toUpperCase(),
+                        plugin.getClassname(),
+                        plugin.hasPlugin() ? "loaded" : "not found",
+                        plugin.isWorking() ? "working" : "failed"});
         }
     }
 

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationPluginClassLoader.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationPluginClassLoader.java
@@ -118,7 +118,7 @@ public class AuthorizationPluginClassLoader extends ClassLoader {
                 byte[] bytes = loadBytes(in);
 
                 Class c = defineClass(classname, bytes, 0, bytes.length);
-                LOGGER.log(Level.INFO, "Class \"{0}\" found in file \"{1}\"",
+                LOGGER.log(Level.FINEST, "Class \"{0}\" found in file \"{1}\"",
                         new Object[]{
                             classname,
                             f.getAbsolutePath()

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationPluginClassLoader.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationPluginClassLoader.java
@@ -46,7 +46,7 @@ public class AuthorizationPluginClassLoader extends ClassLoader {
     private final Map<String, Class> cache = new HashMap<>();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizationPluginClassLoader.class);
-    private final static String[] classWhitelist = new String[]{
+    private final static String[] CLASS_WHITELIST = new String[]{
         "org.opensolaris.opengrok.configuration.Group",
         "org.opensolaris.opengrok.configuration.Project",
         "org.opensolaris.opengrok.configuration.RuntimeEnvironment",
@@ -55,7 +55,7 @@ public class AuthorizationPluginClassLoader extends ClassLoader {
         "org.opensolaris.opengrok.logger.*",
     };
 
-    private final static String[] packageBlacklist = new String[]{
+    private final static String[] PACKAGE_BLACKLIST = new String[]{
         "java",
         "javax",
         "org.w3c",
@@ -139,8 +139,8 @@ public class AuthorizationPluginClassLoader extends ClassLoader {
     }
 
     private boolean checkWhiteList(String name) {
-        for (int i = 0; i < classWhitelist.length; i++) {
-            String pattern = classWhitelist[i];
+        for (int i = 0; i < CLASS_WHITELIST.length; i++) {
+            String pattern = CLASS_WHITELIST[i];
             pattern = pattern.replaceAll("\\.", "\\\\.");
             pattern = pattern.replaceAll("\\*", ".*");
             if (name.matches(pattern)) {
@@ -155,18 +155,18 @@ public class AuthorizationPluginClassLoader extends ClassLoader {
                 && !checkWhiteList(name)) {
             throw new SecurityException("Tried to load a blacklisted class \"" + name + "\"\n"
                     + "Allowed classes from opengrok package are only: "
-                    + Arrays.toString(classWhitelist));
+                    + Arrays.toString(CLASS_WHITELIST));
         }
     }
 
     private void checkPackage(String name) throws SecurityException {
-        for (int i = 0; i < packageBlacklist.length; i++) {
-            if (name.startsWith(packageBlacklist[i] + ".")) {
+        for (int i = 0; i < PACKAGE_BLACKLIST.length; i++) {
+            if (name.startsWith(PACKAGE_BLACKLIST[i] + ".")) {
                 throw new SecurityException("Tried to load a class \"" + name
                         + "\" to a blacklisted package "
-                        + "\"" + packageBlacklist[i] + "\"\n"
+                        + "\"" + PACKAGE_BLACKLIST[i] + "\"\n"
                         + "Disabled packages are: "
-                        + Arrays.toString(packageBlacklist));
+                        + Arrays.toString(PACKAGE_BLACKLIST));
             }
         }
     }
@@ -182,8 +182,8 @@ public class AuthorizationPluginClassLoader extends ClassLoader {
      * <li>loading from .jar files</li>
      * </ol>
      *
-     * Package blacklist: {@link #packageBlacklist}.<br />
-     * Classes whitelist: {@link #classWhitelist}.
+     * Package blacklist: {@link #PACKAGE_BLACKLIST}.<br />
+     * Classes whitelist: {@link #CLASS_WHITELIST}.
      *
      * @param name class name
      * @return loaded class or null
@@ -206,8 +206,8 @@ public class AuthorizationPluginClassLoader extends ClassLoader {
      * <li>loading from .jar files</li>
      * </ol>
      *
-     * Package blacklist: {@link #packageBlacklist}.<br />
-     * Classes whitelist: {@link #classWhitelist}.
+     * Package blacklist: {@link #PACKAGE_BLACKLIST}.<br />
+     * Classes whitelist: {@link #CLASS_WHITELIST}.
      *
      * @param name class name
      * @param resolveIt if the class should be resolved

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationPluginClassLoader.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationPluginClassLoader.java
@@ -18,7 +18,7 @@
  */
 
  /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.authorization;
 
@@ -49,6 +49,7 @@ public class AuthorizationPluginClassLoader extends ClassLoader {
     private final static String[] classWhitelist = new String[]{
         "org.opensolaris.opengrok.configuration.Group",
         "org.opensolaris.opengrok.configuration.Project",
+        "org.opensolaris.opengrok.configuration.RuntimeEnvironment",
         "org.opensolaris.opengrok.authorization.IAuthorizationPlugin",
         "org.opensolaris.opengrok.util.*",
         "org.opensolaris.opengrok.logger.*",
@@ -173,16 +174,16 @@ public class AuthorizationPluginClassLoader extends ClassLoader {
     /**
      * Loads the class with given name.
      *
-     * Package blacklist:
+     * Order of lookup:
+     * <ol>
+     * <li>already loaded classes </li>
+     * <li>parent class loader</li>
+     * <li>loading from .class files</li>
+     * <li>loading from .jar files</li>
+     * </ol>
      *
-     * @see #packageBlacklist Classes whitelist:
-     * @see #classWhitelist
-     *
-     * Order of lookup: 
-     * 1) already loaded classes 
-     * 2) parent class loader 
-     * 3) loading from .class files 
-     * 4) loading from .jar files
+     * Package blacklist: {@link #packageBlacklist}.<br />
+     * Classes whitelist: {@link #classWhitelist}.
      *
      * @param name class name
      * @return loaded class or null
@@ -197,17 +198,16 @@ public class AuthorizationPluginClassLoader extends ClassLoader {
     /**
      * Loads the class with given name.
      *
-     * Package blacklist:
+     * Order of lookup:
+     * <ol>
+     * <li>already loaded classes </li>
+     * <li>parent class loader</li>
+     * <li>loading from .class files</li>
+     * <li>loading from .jar files</li>
+     * </ol>
      *
-
-     * @see #packageBlacklist Classes whitelist:
-     * @see #classWhitelist
-     *
-     * Order of lookup: 
-     * 1) already loaded classes 
-     * 2) parent class loader 
-     * 3) loading from .class files 
-     * 4) loading from .jar files
+     * Package blacklist: {@link #packageBlacklist}.<br />
+     * Classes whitelist: {@link #classWhitelist}.
      *
      * @param name class name
      * @param resolveIt if the class should be resolved

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationPluginWrapper.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationPluginWrapper.java
@@ -1,0 +1,215 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+ /*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.authorization;
+
+import javax.servlet.http.HttpServletRequest;
+import org.opensolaris.opengrok.authorization.AuthorizationCheck.AuthorizationRole;
+import org.opensolaris.opengrok.configuration.Group;
+import org.opensolaris.opengrok.configuration.Project;
+
+/**
+ * A wrapper for the plugin class delegating all plugin function to the
+ * underlying plugin and containing some useful information about the plugin
+ * itself - if it exists, if it is working.
+ *
+ * @author Krystof Tulinger
+ */
+public final class AuthorizationPluginWrapper {
+
+    private AuthorizationCheck check;
+    private IAuthorizationPlugin plugin;
+    private boolean working = true;
+
+    public AuthorizationPluginWrapper(AuthorizationCheck description, IAuthorizationPlugin plugin) {
+        this.check = description;
+        this.plugin = plugin;
+    }
+
+    public AuthorizationPluginWrapper(AuthorizationRole role, String classname, IAuthorizationPlugin plugin) {
+        this(new AuthorizationCheck(role, classname), plugin);
+    }
+
+    /**
+     * Check if the plugin exists and has not failed while loading.
+     *
+     * @return true if working, false otherwise
+     */
+    public boolean isWorking() {
+        return working && hasPlugin();
+    }
+
+    public synchronized void setWorking() {
+        working = true;
+    }
+
+    /**
+     * Check if this plugin has failed during loading or is missing.
+     *
+     * This method has the same effect as !{@link isWorking()}.
+     *
+     * @return true if failed, true otherwise
+     * @see #isWorking()
+     */
+    public boolean isFailed() {
+        return !isWorking();
+    }
+
+    /**
+     * Set this plugin as failed. This plugin will no more call the underlying
+     * plugin isAllowed methods.
+     *
+     * @see IAuthorizationPlugin#isAllowed(HttpServletRequest, Group)
+     * @see IAuthorizationPlugin#isAllowed(HttpServletRequest, Project)
+     */
+    public synchronized void setFailed() {
+        working = false;
+    }
+
+    /**
+     * Check if the plugin class was found for this plugin.
+     *
+     * @return true if was; false otherwise
+     */
+    public boolean hasPlugin() {
+        return plugin != null;
+    }
+
+    /**
+     * Check if this plugin is marked as required.
+     *
+     * @return true if is required; false otherwise
+     */
+    public boolean isRequired() {
+        return check.getRole().equals(AuthorizationRole.REQUIRED);
+    }
+
+    /**
+     * Check if this plugin is marked as sufficient.
+     *
+     * @return true if is sufficient; false otherwise
+     */
+    public boolean isSufficient() {
+        return check.getRole().equals(AuthorizationRole.SUFFICIENT);
+    }
+
+    /**
+     * Check if this plugin is marked as requisite.
+     *
+     * @return true if is requisite; false otherwise
+     */
+    public boolean isRequisite() {
+        return check.getRole().equals(AuthorizationRole.REQUISITE);
+    }
+
+    /**
+     * Call the load method on the underlying plugin if the plugin exists. Note
+     * that the load method can throw any throwable from its body and it should
+     * stop the application.
+     *
+     * @see IAuthorizationPlugin#load()
+     */
+    public synchronized void load() {
+        if (!hasPlugin()) {
+            setFailed();
+            return;
+        }
+        plugin.load();
+    }
+
+    /**
+     * Call the unload method on the underlying plugin if the plugin exists.
+     * Note that the unload method can throw any throwable from its body and it
+     * should stop the application.
+     *
+     * @see IAuthorizationPlugin#unload()
+     */
+    public synchronized void unload() {
+        if (hasPlugin()) {
+            plugin.unload();
+        }
+    }
+
+    /**
+     * Call the same method on the underlying plugin if and only if the plugin
+     * is not marked as failed.
+     *
+     * @param request current http request
+     * @param project a project to check
+     * @return true if the plugin is not failed and the project is allowed;
+     * false otherwise
+     * @see #isFailed()
+     * @see IAuthorizationPlugin#isAllowed(HttpServletRequest, Project)
+     */
+    public boolean isAllowed(HttpServletRequest request, Project project) {
+        if (isFailed()) {
+            return false;
+        }
+        return plugin.isAllowed(request, project);
+    }
+
+    /**
+     * Call the same method on the underlying plugin if and only if the plugin
+     * is not marked as failed.
+     *
+     *
+     * @param request current http request
+     * @param group a group to check
+     * @return true if the plugin is not failed and the group is allowed; false
+     * otherwise
+     * @see #isFailed()
+     * @see IAuthorizationPlugin#isAllowed(HttpServletRequest, Group)
+     */
+    public boolean isAllowed(HttpServletRequest request, Group group) {
+        if (isFailed()) {
+            return false;
+        }
+        return plugin.isAllowed(request, group);
+    }
+
+    /**
+     * Set the value of plugin
+     *
+     * @param plugin new value of plugin
+     */
+    public synchronized void setPlugin(IAuthorizationPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Get the value of classname
+     *
+     * @return the value of classname
+     */
+    public String getClassname() {
+        return check.getClassname();
+    }
+
+    /**
+     * Get the value of role
+     *
+     * @return the value of role
+     */
+    public AuthorizationRole getRole() {
+        return check.getRole();
+    }
+}

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationPluginWrapper.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationPluginWrapper.java
@@ -23,7 +23,7 @@
 package org.opensolaris.opengrok.authorization;
 
 import javax.servlet.http.HttpServletRequest;
-import org.opensolaris.opengrok.authorization.AuthorizationCheck.AuthorizationRole;
+import org.opensolaris.opengrok.authorization.AuthorizationCheck.AuthControlFlag;
 import org.opensolaris.opengrok.configuration.Group;
 import org.opensolaris.opengrok.configuration.Project;
 
@@ -45,7 +45,7 @@ public final class AuthorizationPluginWrapper {
         this.plugin = plugin;
     }
 
-    public AuthorizationPluginWrapper(AuthorizationRole role, String classname, IAuthorizationPlugin plugin) {
+    public AuthorizationPluginWrapper(AuthControlFlag role, String classname, IAuthorizationPlugin plugin) {
         this(new AuthorizationCheck(role, classname), plugin);
     }
 
@@ -100,7 +100,7 @@ public final class AuthorizationPluginWrapper {
      * @return true if is required; false otherwise
      */
     public boolean isRequired() {
-        return check.getRole().equals(AuthorizationRole.REQUIRED);
+        return check.getRole().equals(AuthControlFlag.REQUIRED);
     }
 
     /**
@@ -109,7 +109,7 @@ public final class AuthorizationPluginWrapper {
      * @return true if is sufficient; false otherwise
      */
     public boolean isSufficient() {
-        return check.getRole().equals(AuthorizationRole.SUFFICIENT);
+        return check.getRole().equals(AuthControlFlag.SUFFICIENT);
     }
 
     /**
@@ -118,7 +118,7 @@ public final class AuthorizationPluginWrapper {
      * @return true if is requisite; false otherwise
      */
     public boolean isRequisite() {
-        return check.getRole().equals(AuthorizationRole.REQUISITE);
+        return check.getRole().equals(AuthControlFlag.REQUISITE);
     }
 
     /**
@@ -209,7 +209,7 @@ public final class AuthorizationPluginWrapper {
      *
      * @return the value of role
      */
-    public AuthorizationRole getRole() {
+    public AuthControlFlag getRole() {
         return check.getRole();
     }
 }

--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -50,6 +50,7 @@ import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.opensolaris.opengrok.authorization.AuthorizationCheck;
 import org.opensolaris.opengrok.history.RepositoryInfo;
 import org.opensolaris.opengrok.index.Filter;
 import org.opensolaris.opengrok.index.IgnoredNames;
@@ -90,6 +91,7 @@ public final class Configuration {
      * for development.
      */
     private boolean authorizationWatchdogEnabled;
+    private List<AuthorizationCheck> pluginConfiguration;
     private List<Project> projects;
     private Set<Group> groups;
     private String sourceRoot;
@@ -334,6 +336,7 @@ public final class Configuration {
         setGroupsCollapseThreshold(4);
         setPluginDirectory(null);
         setAuthorizationWatchdogEnabled(false);
+        setPluginConfiguration(new ArrayList<>());
         setMaxSearchThreadCount(2 * Runtime.getRuntime().availableProcessors());
         setIndexRefreshPeriod(3600);
         setMessageLimit(500);
@@ -391,6 +394,14 @@ public final class Configuration {
 
     public void setAuthorizationWatchdogEnabled(boolean authorizationWatchdogEnabled) {
         this.authorizationWatchdogEnabled = authorizationWatchdogEnabled;
+    }
+
+    public List<AuthorizationCheck> getPluginConfiguration() {
+        return pluginConfiguration;
+    }
+
+    public void setPluginConfiguration(List<AuthorizationCheck> pluginConfiguration) {
+        this.pluginConfiguration = pluginConfiguration;
     }
 
     public void setCmds(Map<String, String> cmds) {
@@ -777,7 +788,7 @@ public final class Configuration {
     public Date getDateForLastIndexRun() {
         if (lastModified == null) {
             File timestamp = new File(getDataRoot(), "timestamp");
-            if(timestamp.exists()){
+            if (timestamp.exists()) {
                 lastModified = new Date(timestamp.lastModified());
             }
         }

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -1534,6 +1534,16 @@ public final class RuntimeEnvironment {
         }
     }
 
+    /**
+     * Return the current plugin version tracked by the authorization framework.
+     *
+     * @return the version
+     * @see AuthorizationFramework#getPluginVersion()
+     */
+    public int getPluginVersion() {
+        return AuthorizationFramework.getInstance().getPluginVersion();
+    }
+
     private ServerSocket configServerSocket;
 
     /**

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -79,6 +79,7 @@ import org.apache.lucene.store.FSDirectory;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.opensolaris.opengrok.authorization.AuthorizationCheck;
 import org.opensolaris.opengrok.authorization.AuthorizationFramework;
 import org.opensolaris.opengrok.configuration.messages.Message;
 import org.opensolaris.opengrok.history.HistoryGuru;
@@ -736,6 +737,14 @@ public final class RuntimeEnvironment {
 
     public void setAuthorizationWatchdog(boolean authorizationWatchdogEnabled) {
         threadConfig.get().setAuthorizationWatchdogEnabled(authorizationWatchdogEnabled);
+    }
+
+    public List<AuthorizationCheck> getPluginConfiguration() {
+        return threadConfig.get().getPluginConfiguration();
+    }
+
+    public void setPluginConfiguration(List<AuthorizationCheck> pluginConfiguration) {
+        threadConfig.get().setPluginConfiguration(pluginConfiguration);
     }
 
     /**
@@ -1584,6 +1593,7 @@ public final class RuntimeEnvironment {
             // Force timestamp to update itself upon new config arrival.
             config.refreshDateForLastIndexRun();
         }
+
         AuthorizationFramework.getInstance().setPluginDirectory(config.getPluginDirectory());
         AuthorizationFramework.getInstance().reload();
     }

--- a/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkTest.java
+++ b/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkTest.java
@@ -27,7 +27,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.opensolaris.opengrok.authorization.AuthorizationCheck.AuthorizationRole;
+import org.opensolaris.opengrok.authorization.AuthorizationCheck.AuthControlFlag;
 import org.opensolaris.opengrok.configuration.Group;
 import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
@@ -53,8 +53,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugins() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthControlFlag.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.REQUIRED);
 
         // sufficient is ok
         Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
@@ -67,8 +67,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugins1() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
-        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.SUFFICIENT);
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthControlFlag.REQUIRED);
 
         // sufficient fails and required is ok
         Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
@@ -81,8 +81,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin2() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthControlFlag.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.SUFFICIENT);
 
         // all are sufficient - success
         Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
@@ -94,8 +94,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin3() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthControlFlag.REQUIRED);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.SUFFICIENT);
 
         // required fails
         Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedProject()));
@@ -108,8 +108,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin4() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.REQUIRED);
 
         // same instance is not added twice in the plugins so
         // there is only one plugin set as sufficient thus everything is true
@@ -122,8 +122,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin5() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.REQUIRED);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.REQUIRED);
 
         // same instance is not added twice in the plugins so
         // there is only one plugin set as required
@@ -137,8 +137,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin6() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUISITE);
-        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.REQUISITE);
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthControlFlag.SUFFICIENT);
 
         // requisite is ok and the other plugin is sufficient
         Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
@@ -151,8 +151,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin7() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUISITE);
-        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.REQUISITE);
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthControlFlag.REQUIRED);
 
         // requisite is ok however required fails
         Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedProject()));
@@ -164,8 +164,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin8() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.REQUISITE);
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthControlFlag.REQUISITE);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.REQUIRED);
 
         // requisite fails
         Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedProject()));
@@ -178,8 +178,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugins9() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.SUFFICIENT);
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createLoadFailingPlugin(), AuthControlFlag.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.REQUIRED);
         instance.loadAllPlugins();
 
         // sufficient fails and required fails as well
@@ -193,8 +193,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin10() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.SUFFICIENT);
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createLoadFailingPlugin(), AuthControlFlag.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.SUFFICIENT);
         instance.loadAllPlugins();
 
         // all are sufficient - success
@@ -207,8 +207,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin11() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.REQUIRED);
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createLoadFailingPlugin(), AuthControlFlag.REQUIRED);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.SUFFICIENT);
         instance.loadAllPlugins();
 
         // required load fails
@@ -221,8 +221,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin12() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.SUFFICIENT);
-        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createLoadFailingPlugin(), AuthControlFlag.SUFFICIENT);
+        instance.addPlugin(createLoadFailingPlugin(), AuthControlFlag.REQUIRED);
         instance.loadAllPlugins();
 
         // same instance is not added twice in the plugins
@@ -236,8 +236,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin13() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.REQUIRED);
-        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createLoadFailingPlugin(), AuthControlFlag.REQUIRED);
+        instance.addPlugin(createLoadFailingPlugin(), AuthControlFlag.SUFFICIENT);
         instance.loadAllPlugins();
 
         // same instance is not added twice in the plugins
@@ -252,8 +252,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugins14() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.SUFFICIENT);
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createTestFailingPlugin(), AuthControlFlag.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.REQUIRED);
         instance.loadAllPlugins();
 
         // sufficient is ok
@@ -268,8 +268,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin15() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.SUFFICIENT);
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createTestFailingPlugin(), AuthControlFlag.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.SUFFICIENT);
         instance.loadAllPlugins();
 
         // all are sufficient - success
@@ -282,8 +282,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin16() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.REQUIRED);
-        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createTestFailingPlugin(), AuthControlFlag.REQUIRED);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthControlFlag.SUFFICIENT);
         instance.loadAllPlugins();
 
         // required test fails (exception when group is not allowed)
@@ -296,8 +296,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin17() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.SUFFICIENT);
-        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createTestFailingPlugin(), AuthControlFlag.SUFFICIENT);
+        instance.addPlugin(createTestFailingPlugin(), AuthControlFlag.REQUIRED);
         instance.loadAllPlugins();
 
         // same instance is not added twice in the plugins and the plugin stays sufficient
@@ -311,8 +311,8 @@ public class AuthorizationFrameworkTest {
     @Test
     public void testRolePlugin18() {
         AuthorizationFramework instance = getInstance();
-        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.REQUIRED);
-        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createTestFailingPlugin(), AuthControlFlag.REQUIRED);
+        instance.addPlugin(createTestFailingPlugin(), AuthControlFlag.SUFFICIENT);
         instance.loadAllPlugins();
 
         // same instance is not added twice in the plugins and this instance allows all projects

--- a/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkTest.java
+++ b/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkTest.java
@@ -22,12 +22,12 @@
  */
 package org.opensolaris.opengrok.authorization;
 
-import java.lang.reflect.Method;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.opensolaris.opengrok.authorization.AuthorizationCheck.AuthorizationRole;
 import org.opensolaris.opengrok.configuration.Group;
 import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
@@ -39,37 +39,287 @@ public class AuthorizationFrameworkTest {
 
     private static String pluginDirectory;
 
-    /**
-     * Test of isAllowed method.
-     *
-     * 2 test plugins loaded
-     */
     @Test
     public void test2Plugins() {
         AuthorizationFramework instance = getInstance();
-        invokeAddPlugin(createSample2Plugin());
-        invokeAddPlugin(createSamplePlugin());
+        instance.addPlugin(createNotAllowedPrefixPlugin());
+        instance.addPlugin(createAllowedPrefixPlugin());
 
         Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedProject()));
         Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedGroup()));
     }
 
-    /**
-     * Test of isAllowed method.
-     *
-     * Test plugin loaded
-     */
+    /* TEST ROLE PLUGINS */
     @Test
-    public void testPlugin() {
+    public void testRolePlugins() {
         AuthorizationFramework instance = getInstance();
-        invokeAddPlugin(createSamplePlugin());
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
 
+        // sufficient is ok
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedGroup()));
+        // sufficient fails and required is ok
         Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
-
-        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedProject()));
-
         Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+    }
 
+    @Test
+    public void testRolePlugins1() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+
+        // sufficient fails and required is ok
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedGroup()));
+        // sufficient is ok
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin2() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+
+        // all are sufficient - success
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedGroup()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin3() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+
+        // required fails
+        Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedGroup()));
+        // required is ok
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin4() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+
+        // same instance is not added twice in the plugins so
+        // there is only one plugin set as sufficient thus everything is true
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin5() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+
+        // same instance is not added twice in the plugins so
+        // there is only one plugin set as required
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+        // required fails
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin6() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUISITE);
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+
+        // requisite is ok and the other plugin is sufficient
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+        // requisite fails
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin7() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUISITE);
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+
+        // requisite is ok however required fails
+        Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedGroup()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin8() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createNotAllowedPrefixPlugin(), AuthorizationRole.REQUISITE);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+
+        // requisite fails
+        Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedGroup()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedGroup()));
+    }
+
+    /* TESTING LOAD FAILING PLUGINS */
+    @Test
+    public void testRolePlugins9() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+        instance.loadAllPlugins();
+
+        // sufficient fails and required fails as well
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedGroup()));
+        // sufficient fails and required is ok
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin10() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.loadAllPlugins();
+
+        // all are sufficient - success
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedGroup()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin11() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.loadAllPlugins();
+
+        // required load fails
+        Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedGroup()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin12() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.REQUIRED);
+        instance.loadAllPlugins();
+
+        // same instance is not added twice in the plugins
+        // and the sufficient was added first therefore all are success
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin13() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createLoadFailingPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.loadAllPlugins();
+
+        // same instance is not added twice in the plugins
+        // and this instance fails all the time
+        Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createAllowedGroup()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedGroup()));
+    }
+
+    /* TESTING TEST FAILING PLUGINS */
+    @Test
+    public void testRolePlugins14() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.REQUIRED);
+        instance.loadAllPlugins();
+
+        // sufficient is ok
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
+        // sufficient fails and required fails as well
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedGroup()));
+        // sufficient fails and required is ok
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin15() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.loadAllPlugins();
+
+        // all are sufficient - success
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedGroup()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin16() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createAllowedPrefixPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.loadAllPlugins();
+
+        // required test fails (exception when group is not allowed)
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin17() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.REQUIRED);
+        instance.loadAllPlugins();
+
+        // same instance is not added twice in the plugins and the plugin stays sufficient
+        // therefore all tests are true
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedGroup()));
+    }
+
+    @Test
+    public void testRolePlugin18() {
+        AuthorizationFramework instance = getInstance();
+        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.REQUIRED);
+        instance.addPlugin(createTestFailingPlugin(), AuthorizationRole.SUFFICIENT);
+        instance.loadAllPlugins();
+
+        // same instance is not added twice in the plugins and this instance allows all projects
+        // and throws an exception when the group is unallowed
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedProject()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createAllowedGroup()));
+        Assert.assertTrue(instance.isAllowed(createRequest(), createUnallowedProject()));
         Assert.assertFalse(instance.isAllowed(createRequest(), createUnallowedGroup()));
     }
 
@@ -105,28 +355,8 @@ public class AuthorizationFrameworkTest {
         RuntimeEnvironment.getInstance().getConfiguration().setPluginDirectory(pluginDirectory);
     }
 
-    private void invokeRemoveAll() {
-        try {
-            Method method = AuthorizationFramework.class.getDeclaredMethod("removeAll");
-            method.setAccessible(true);
-            method.invoke(AuthorizationFramework.getInstance());
-        } catch (Exception ex) {
-            Assert.fail("invokeRemoveAll should not throw an exception");
-        }
-    }
-
-    private void invokeAddPlugin(IAuthorizationPlugin plugin) {
-        try {
-            Method method = AuthorizationFramework.class.getDeclaredMethod("addPlugin", new Class[]{IAuthorizationPlugin.class});
-            method.setAccessible(true);
-            method.invoke(AuthorizationFramework.getInstance(), new Object[]{plugin});
-        } catch (Exception ex) {
-            Assert.fail("invokeAddPlugin should not throw an exception");
-        }
-    }
-
     private AuthorizationFramework getInstance() {
-        invokeRemoveAll();
+        AuthorizationFramework.getInstance().removeAll();
         return AuthorizationFramework.getInstance();
     }
 
@@ -158,7 +388,7 @@ public class AuthorizationFrameworkTest {
         return new DummyHttpServletRequest();
     }
 
-    private IAuthorizationPlugin createSamplePlugin() {
+    private IAuthorizationPlugin createAllowedPrefixPlugin() {
         return new TestPlugin() {
             @Override
             public boolean isAllowed(HttpServletRequest request, Project project) {
@@ -172,7 +402,7 @@ public class AuthorizationFrameworkTest {
         };
     }
 
-    private IAuthorizationPlugin createSample2Plugin() {
+    private IAuthorizationPlugin createNotAllowedPrefixPlugin() {
         return new TestPlugin() {
             @Override
             public boolean isAllowed(HttpServletRequest request, Project project) {
@@ -182,6 +412,43 @@ public class AuthorizationFrameworkTest {
             @Override
             public boolean isAllowed(HttpServletRequest request, Group group) {
                 return group.getName().startsWith("not_allowed");
+            }
+        };
+    }
+
+    private IAuthorizationPlugin createLoadFailingPlugin() {
+        return new TestPlugin() {
+            @Override
+            public void load() {
+                throw new NullPointerException("This plugin failed while loading.");
+            }
+
+            @Override
+            public boolean isAllowed(HttpServletRequest request, Project project) {
+                return true;
+            }
+
+            @Override
+            public boolean isAllowed(HttpServletRequest request, Group group) {
+                return true;
+            }
+
+        };
+    }
+
+    private IAuthorizationPlugin createTestFailingPlugin() {
+        return new TestPlugin() {
+            @Override
+            public boolean isAllowed(HttpServletRequest request, Project project) {
+                return true;
+            }
+
+            @Override
+            public boolean isAllowed(HttpServletRequest request, Group group) {
+                if (group.getName().contains("not_allowed")) {
+                    throw new NullPointerException("This group is not allowed.");
+                }
+                return true;
             }
         };
     }

--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -465,13 +465,13 @@ public class RuntimeEnvironmentTest {
         assertNotNull(conf.getPluginConfiguration());
         List<AuthorizationCheck> pluginConfiguration = conf.getPluginConfiguration();
         assertEquals(4, pluginConfiguration.size());
-        assertEquals(AuthorizationCheck.AuthorizationRole.SUFFICIENT, pluginConfiguration.get(0).getRole());
+        assertEquals(AuthorizationCheck.AuthControlFlag.SUFFICIENT, pluginConfiguration.get(0).getRole());
         assertEquals("Plugin", pluginConfiguration.get(0).getClassname());
-        assertEquals(AuthorizationCheck.AuthorizationRole.REQUIRED, pluginConfiguration.get(1).getRole());
+        assertEquals(AuthorizationCheck.AuthControlFlag.REQUIRED, pluginConfiguration.get(1).getRole());
         assertEquals("OtherPlugin", pluginConfiguration.get(1).getClassname());
-        assertEquals(AuthorizationCheck.AuthorizationRole.REQUISITE, pluginConfiguration.get(2).getRole());
+        assertEquals(AuthorizationCheck.AuthControlFlag.REQUISITE, pluginConfiguration.get(2).getRole());
         assertEquals("AnotherPlugin", pluginConfiguration.get(2).getClassname());
-        assertEquals(AuthorizationCheck.AuthorizationRole.REQUIRED, pluginConfiguration.get(3).getRole());
+        assertEquals(AuthorizationCheck.AuthControlFlag.REQUIRED, pluginConfiguration.get(3).getRole());
         assertEquals("DifferentPlugin", pluginConfiguration.get(3).getClassname());
     }
 

--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -44,6 +44,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opensolaris.opengrok.analysis.plain.PlainXref;
+import org.opensolaris.opengrok.authorization.AuthorizationCheck;
 import org.opensolaris.opengrok.configuration.messages.Message;
 import org.opensolaris.opengrok.configuration.messages.NormalMessage;
 import org.opensolaris.opengrok.history.RepositoryInfo;
@@ -409,6 +410,91 @@ public class RuntimeEnvironmentTest {
             fail("makeXmlStringsAsConfiguration should throw exception");
         } catch (Throwable t) {
         }
+    }
+
+    @Test
+    public void testAuthorizationRoleDecode() throws IOException {
+        String confString = "<?xml version='1.0' encoding='UTF-8'?>\n"
+                + "<java class=\"java.beans.XMLDecoder\" version=\"1.8.0_65\">\n"
+                + " <object class=\"org.opensolaris.opengrok.configuration.Configuration\">\n"
+                + "	<void property=\"pluginConfiguration\">\n"
+                + "		<void method=\"add\">\n"
+                + "			<object class=\"org.opensolaris.opengrok.authorization.AuthorizationCheck\">\n"
+                + "				<void property=\"role\">\n"
+                + "					<string>sufficient</string>\n"
+                + "				</void>\n"
+                + "				<void property=\"classname\">\n"
+                + "					<string>Plugin</string>\n"
+                + "				</void>\n"
+                + "			</object>\n"
+                + "		</void>\n"
+                + "		<void method=\"add\">\n"
+                + "			<object class=\"org.opensolaris.opengrok.authorization.AuthorizationCheck\">\n"
+                + "				<void property=\"role\">\n"
+                + "					<string>required</string>\n"
+                + "				</void>\n"
+                + "				<void property=\"classname\">\n"
+                + "					<string>OtherPlugin</string>\n"
+                + "				</void>\n"
+                + "			</object>\n"
+                + "		</void>\n"
+                + "		<void method=\"add\">\n"
+                + "			<object class=\"org.opensolaris.opengrok.authorization.AuthorizationCheck\">\n"
+                + "				<void property=\"role\">\n"
+                + "					<string>REQUISITE</string>\n"
+                + "				</void>\n"
+                + "				<void property=\"classname\">\n"
+                + "					<string>AnotherPlugin</string>\n"
+                + "				</void>\n"
+                + "			</object>\n"
+                + "		</void>\n"
+                + "		<void method=\"add\">\n"
+                + "			<object class=\"org.opensolaris.opengrok.authorization.AuthorizationCheck\">\n"
+                + "				<void property=\"role\">\n"
+                + "					<string>reQuIrEd</string>\n"
+                + "				</void>\n"
+                + "				<void property=\"classname\">\n"
+                + "					<string>DifferentPlugin</string>\n"
+                + "				</void>\n"
+                + "			</object>\n"
+                + "		</void>\n"
+                + "	</void>\n"
+                + " </object>\n"
+                + "</java>";
+        Configuration conf = Configuration.makeXMLStringAsConfiguration(confString);
+        assertNotNull(conf.getPluginConfiguration());
+        List<AuthorizationCheck> pluginConfiguration = conf.getPluginConfiguration();
+        assertEquals(4, pluginConfiguration.size());
+        assertEquals(AuthorizationCheck.AuthorizationRole.SUFFICIENT, pluginConfiguration.get(0).getRole());
+        assertEquals("Plugin", pluginConfiguration.get(0).getClassname());
+        assertEquals(AuthorizationCheck.AuthorizationRole.REQUIRED, pluginConfiguration.get(1).getRole());
+        assertEquals("OtherPlugin", pluginConfiguration.get(1).getClassname());
+        assertEquals(AuthorizationCheck.AuthorizationRole.REQUISITE, pluginConfiguration.get(2).getRole());
+        assertEquals("AnotherPlugin", pluginConfiguration.get(2).getClassname());
+        assertEquals(AuthorizationCheck.AuthorizationRole.REQUIRED, pluginConfiguration.get(3).getRole());
+        assertEquals("DifferentPlugin", pluginConfiguration.get(3).getClassname());
+    }
+
+    @Test(expected = IOException.class)
+    public void testAuthorizationRoleDecodeInvalid() throws IOException {
+        String confString = "<?xml version='1.0' encoding='UTF-8'?>\n"
+                + "<java class=\"java.beans.XMLDecoder\" version=\"1.8.0_65\">\n"
+                + " <object class=\"org.opensolaris.opengrok.configuration.Configuration\">\n"
+                + "	<void property=\"pluginConfiguration\">\n"
+                + "		<void method=\"add\">\n"
+                + "			<object class=\"org.opensolaris.opengrok.authorization.AuthorizationCheck\">\n"
+                + "				<void property=\"role\">\n"
+                + "					<string>norole</string>\n"
+                + "				</void>\n"
+                + "				<void property=\"classname\">\n"
+                + "					<string>Plugin</string>\n"
+                + "				</void>\n"
+                + "			</object>\n"
+                + "		</void>\n"
+                + "	</void>\n"
+                + " </object>\n"
+                + "</java>";
+        Configuration.makeXMLStringAsConfiguration(confString);
     }
 
     @Test


### PR DESCRIPTION
Adding a little bit of control to how the authorization is performed in opengrok.

Introducing three new plugin roles:
 - required
 - requisite
 - sufficient

I'll include more detailed description of these in the wiki page once this is merged. These roles should copy the characeristics of the same roles in pam list.

Also the order of plugin execution is determined by their order in the configuration and these three keywords control how to deal with the returned value of the authorization check.

**NOTE: This change is backward compatible with the previous version of auth framework as it adds all discovered plugins as `required`.** The system still remains plug-and-play when using just one plugin as the only action is to put it in the plugin directory.

The configuration entry (in read-only configuration) can look like this:
```xml
<void property="pluginConfiguration">
	<void method="add">
		<object class="org.opensolaris.opengrok.authorization.AuthorizationCheck">
			<void property="role">
				<string>requisite</string>
			</void>
			<void property="classname">
				<string>tulinkry.my.RequisitePlugin</string>
			</void>
		</object>
	</void>	
	<void method="add">
		<object class="org.opensolaris.opengrok.authorization.AuthorizationCheck">
			<void property="role">
				<string>sufficient</string>
			</void>
			<void property="classname">
				<string>Plugin</string>
			</void>
		</object>
	</void>
	<void method="add">
		<object class="org.opensolaris.opengrok.authorization.AuthorizationCheck">
			<void property="role">
				<string>required</string>
			</void>
			<void property="classname">
				<string>ExamplePlugin</string>
			</void>
		</object>
	</void>		
</void>
```