### PR TITLE
more robust handling of merging history entries for files

### DIFF
--- a/src/org/opensolaris/opengrok/history/FileHistoryCache.java
+++ b/src/org/opensolaris/opengrok/history/FileHistoryCache.java
@@ -129,7 +129,7 @@ class FileHistoryCache implements HistoryCache {
 
         File file = new File(root, filename);
         if (!file.isDirectory()) {
-            storeFile(hist, file, repository);
+            storeFile(hist, file, repository, !renamed);
         }
     }
 
@@ -262,26 +262,19 @@ class FileHistoryCache implements HistoryCache {
     }
 
     /**
-     * Store history object (encoded as XML and compressed with gzip) in a file.
+     * Read history from cacheFile and merge it with histNew, return merged history.
      *
-     * @param history history object to store
-     * @param file file to store the history object into
-     * @param repo repository for the file
+     * @param cacheFile file to where the history object will be stored
+     * @param histNew history object with new history entries
+     * @param repo repository to where pre pre-image of the cacheFile belong
+     * @return merged history
      * @throws HistoryException
      */
-    private void storeFile(History histNew, File file, Repository repo) throws HistoryException {
-
-        File cacheFile = getCachedFile(file);
-        History history = histNew;
-
-        File dir = cacheFile.getParentFile();
-        if (!dir.isDirectory() && !dir.mkdirs()) {
-            throw new HistoryException(
-                    "Unable to create cache directory '" + dir + "'.");
-        }
-
+    private History mergeOldAndNewHistory(File cacheFile, History histNew, Repository repo) throws HistoryException {
         // Incremental update of the history for this file.
         History histOld;
+        History history = null;
+
         try {
             histOld = readCache(cacheFile);
             // Merge old history with the new history.
@@ -309,9 +302,35 @@ class FileHistoryCache implements HistoryCache {
                 }
             }
         } catch (IOException ex) {
-            // Ideally we would want to catch the case when incremental update
-            // is done but the cached file is not there however we do not have
-            // the data to do it here.
+            LOGGER.log(Level.SEVERE, "Cannot open history cache file " + cacheFile.getPath());
+        }
+
+        return history;
+    }
+
+    /**
+     * Store history object (encoded as XML and compressed with gzip) in a file.
+     *
+     * @param history history object to store
+     * @param file file to store the history object into
+     * @param repo repository for the file
+     * @param mergeHistory whether to merge the history with existing or store the histNew as is
+     * @throws HistoryException
+     */
+    private void storeFile(History histNew, File file, Repository repo,
+            boolean mergeHistory) throws HistoryException {
+
+        File cacheFile = getCachedFile(file);
+        History history = histNew;
+
+        File dir = cacheFile.getParentFile();
+        if (!dir.isDirectory() && !dir.mkdirs()) {
+            throw new HistoryException(
+                    "Unable to create cache directory '" + dir + "'.");
+        }
+
+        if (mergeHistory && cacheFile.exists()) {
+            history = mergeOldAndNewHistory(cacheFile, histNew, repo);
         }
 
         writeHistoryToFile(dir, history, cacheFile);
@@ -529,7 +548,7 @@ class FileHistoryCache implements HistoryCache {
                         (cache.exists() ||
                              (time > env.getHistoryReaderTimeLimit()))) {
                 // retrieving the history takes too long, cache it!
-                storeFile(history, file, repository);
+                storeFile(history, file, repository, false);
             }
         }
         return history;

--- a/src/org/opensolaris/opengrok/history/FileHistoryCache.java
+++ b/src/org/opensolaris/opengrok/history/FileHistoryCache.java
@@ -303,7 +303,8 @@ class FileHistoryCache implements HistoryCache {
                 }
             }
         } catch (IOException ex) {
-            LOGGER.log(Level.SEVERE, "Cannot open history cache file " + cacheFile.getPath());
+            LOGGER.log(Level.SEVERE,
+                String.format("Cannot open history cache file %s", cacheFile.getPath()), ex);
         }
 
         return history;

--- a/test/org/opensolaris/opengrok/history/FileHistoryCacheTest.java
+++ b/test/org/opensolaris/opengrok/history/FileHistoryCacheTest.java
@@ -81,6 +81,11 @@ public class FileHistoryCacheTest {
         repositories = null;
 
         cache = null;
+
+        // testStoreAndGetIncrementalTags() enables tags. In case any of its
+        // assertions fail, the tags will remain enabled which might affect
+        // the run of other tests so unset it after each test for a good measure.
+        RuntimeEnvironment.getInstance().setTagsEnabled(false);
     }
 
     /**
@@ -225,8 +230,6 @@ public class FileHistoryCacheTest {
         History retrievedUpdatedHistoryMainC = cache.get(main, repo, true);
         assertSameEntries(retrievedHistoryMainC.getHistoryEntries(),
                 retrievedUpdatedHistoryMainC.getHistoryEntries(), false);
-
-        RuntimeEnvironment.getInstance().setTagsEnabled(false);
     }
 
     /**
@@ -307,13 +310,17 @@ public class FileHistoryCacheTest {
         HistoryEntry newEntry1 = new HistoryEntry(
                 "10:1e392ef0b0ed",
                 new Date(1245446973L / 60 * 60 * 1000), // whole minutes only
-                "xyz", null, "Return failure when executed with no arguments",
+                "xyz",
+                null,
+                "Return failure when executed with no arguments",
                 true);
         newEntry1.addFile("/mercurial/main.c");
         HistoryEntry newEntry2 = new HistoryEntry(
                 "11:bbb3ce75e1b8",
                 new Date(1245447973L / 60 * 60 * 1000), // whole minutes only
-                "xyz", null, "Do something else",
+                "xyz",
+                null,
+                "Do something else",
                 true);
         newEntry2.addFile("/mercurial/main.c");
 
@@ -359,14 +366,19 @@ public class FileHistoryCacheTest {
     @Test
     public void testRenameFileThenDoIncrementalReindex() throws Exception {
         File reposRoot = new File(repositories.getSourceRoot(), "mercurial");
-        Repository repo = RepositoryFactory.getRepository(reposRoot);
         History updatedHistory;
 
         // The test expects support for renamed files.
         RuntimeEnvironment.getInstance().setHandleHistoryOfRenamedFiles(true);
 
-        History historyToStore = repo.getHistory(reposRoot);
+        // Use tags for better coverage.
+        RuntimeEnvironment.getInstance().setTagsEnabled(true);
 
+        // Generate history index.
+        // It is necessary to call getRepository() only after tags were enabled
+        // to produce list of tags.
+        Repository repo = RepositoryFactory.getRepository(reposRoot);
+        History historyToStore = repo.getHistory(reposRoot);
         cache.store(historyToStore, repo);
 
         // Import changesets which rename one of the files in the repository.
@@ -388,32 +400,44 @@ public class FileHistoryCacheTest {
         HistoryEntry e0 = new HistoryEntry(
                 "13:e55a793086da",
                 new Date(1245447973L / 60 * 60 * 1000), // whole minutes only
-                "xyz", null, "Do something else",
+                "xyz",
+                null, 
+                "Do something else",
                 true);
         HistoryEntry e1 = new HistoryEntry(
                 "12:97b5392fec0d",
                 new Date(1393515253L / 60 * 60 * 1000), // whole minutes only
-                "Vladimir Kotal <Vladimir.Kotal@oracle.com>", null, "rename2",
+                "Vladimir Kotal <Vladimir.Kotal@oracle.com>",
+                null,
+                "rename2",
                 true);
         HistoryEntry e2 = new HistoryEntry(
                 "11:5c203a0bc12b",
                 new Date(1393515291L / 60 * 60 * 1000), // whole minutes only
-                "Vladimir Kotal <Vladimir.Kotal@oracle.com>", null, "rename1",
+                "Vladimir Kotal <Vladimir.Kotal@oracle.com>",
+                null,
+                "rename1",
                 true);
         HistoryEntry e3 = new HistoryEntry(
                 "10:1e392ef0b0ed",
                 new Date(1245446973L / 60 * 60 * 1000), // whole minutes only
-                "xyz", null, "Return failure when executed with no arguments",
+                "xyz",
+                null,
+                "Return failure when executed with no arguments",
                 true);
         HistoryEntry e4 = new HistoryEntry(
                 "2:585a1b3f2efb",
                 new Date(1218571989L / 60 * 60 * 1000), // whole minutes only
-                "Trond Norbye <trond.norbye@sun.com>", null, "Add lint make target and fix lint warnings",
+                "Trond Norbye <trond.norbye@sun.com>",
+                "start_of_novel",
+                "Add lint make target and fix lint warnings",
                 true);
         HistoryEntry e5 = new HistoryEntry(
                 "1:f24a5fd7a85d",
                 new Date(1218571413L / 60 * 60 * 1000), // whole minutes only
-                "Trond Norbye <trond.norbye@sun.com>", null, "Created a small dummy program",
+                "Trond Norbye <trond.norbye@sun.com>",
+                null,
+                "Created a small dummy program",
                 true);
 
         History histConstruct = new History();
@@ -476,6 +500,9 @@ public class FileHistoryCacheTest {
         // The test expects support for renamed files.
         RuntimeEnvironment.getInstance().setHandleHistoryOfRenamedFiles(true);
 
+        // Use tags for better coverage.
+        RuntimeEnvironment.getInstance().setTagsEnabled(true);
+
         // Branch the repo and add one changeset.
         runHgCommand("unbundle",
             reposRoot, getClass().getResource("hg-branch.bundle").getPath());
@@ -488,6 +515,8 @@ public class FileHistoryCacheTest {
         runHgCommand("update", reposRoot, "mybranch");
 
         // Generate history index.
+        // It is necessary to call getRepository() only after tags were enabled
+        // to produce list of tags.
         Repository repo = RepositoryFactory.getRepository(reposRoot);
         History historyToStore = repo.getHistory(reposRoot);
         cache.store(historyToStore, repo);
@@ -514,42 +543,58 @@ public class FileHistoryCacheTest {
         HistoryEntry e0 = new HistoryEntry(
                 "15:709c7a27f9fa",
                 new Date(1489160275L / 60 * 60 * 1000), // whole minutes only
-                "Vladimir Kotal <Vladimir.Kotal@oracle.com>", null, "novels are so last century. Let's write a blog !",
+                "Vladimir Kotal <Vladimir.Kotal@oracle.com>",
+                null,
+                "novels are so last century. Let's write a blog !",
                 true);
         HistoryEntry e1 = new HistoryEntry(
                 "10:c4518ca0c841",
                 new Date(1415483555L / 60 * 60 * 1000), // whole minutes only
-                "Vladimir Kotal <Vladimir.Kotal@oracle.com>", null, "branched",
+                "Vladimir Kotal <Vladimir.Kotal@oracle.com>",
+                null,
+                "branched",
                 true);
         HistoryEntry e2 = new HistoryEntry(
                 "8:6a8c423f5624",
                 new Date(1362586899L / 60 * 60 * 1000), // whole minutes only
-                "Vladimir Kotal <vlada@devnull.cz>", null, "first words of the novel",
+                "Vladimir Kotal <vlada@devnull.cz>",
+                null,
+                "first words of the novel",
                 true);
         HistoryEntry e3 = new HistoryEntry(
                 "7:db1394c05268",
                 new Date(1362586862L / 60 * 60 * 1000), // whole minutes only
-                "Vladimir Kotal <vlada@devnull.cz>", null, "book sounds too boring, let's do a novel !",
+                "Vladimir Kotal <vlada@devnull.cz>",
+                "start_of_novel",
+                "book sounds too boring, let's do a novel !",
                 true);
         HistoryEntry e4 = new HistoryEntry(
                 "6:e386b51ddbcc",
                 new Date(1362586839L / 60 * 60 * 1000), // whole minutes only
-                "Vladimir Kotal <vlada@devnull.cz>", null, "stub of chapter 1",
+                "Vladimir Kotal <vlada@devnull.cz>",
+                null,
+                "stub of chapter 1",
                 true);
         HistoryEntry e5 = new HistoryEntry(
                 "5:8706402863c6",
                 new Date(1362586805L / 60 * 60 * 1000), // whole minutes only
-                "Vladimir Kotal <vlada@devnull.cz>", null, "I decided to actually start writing a book based on the first plaintext file.",
+                "Vladimir Kotal <vlada@devnull.cz>",
+                null,
+                "I decided to actually start writing a book based on the first plaintext file.",
                 true);
         HistoryEntry e6 = new HistoryEntry(
                 "4:e494d67af12f",
                 new Date(1362586747L / 60 * 60 * 1000), // whole minutes only
-                "Vladimir Kotal <vlada@devnull.cz>", null, "first change",
+                "Vladimir Kotal <vlada@devnull.cz>",
+                null,
+                "first change",
                 true);
         HistoryEntry e7 = new HistoryEntry(
                 "3:2058725c1470",
                 new Date(1362586483L / 60 * 60 * 1000), // whole minutes only
-                "Vladimir Kotal <vlada@devnull.cz>", null, "initial checking of text files",
+                "Vladimir Kotal <vlada@devnull.cz>",
+                null,
+                "initial checking of text files",
                 true);
 
         History histConstruct = new History();


### PR DESCRIPTION
Sometimes in our deployment I saw some files having history entries twice - the history is formed by 2 identical history entry sequences. It's not clear to me how this can happen, it has to be caused by invalid merging of old and new history. It seems this happens for renamed files. This PR makes the area more robust by avoiding the merge for renamed files.