### PR TITLE
defaulting the cvs repository to automatically decide whether it is i…

### DIFF
--- a/src/org/opensolaris/opengrok/history/CVSRepository.java
+++ b/src/org/opensolaris/opengrok/history/CVSRepository.java
@@ -67,6 +67,17 @@ public class CVSRepository extends RCSRepository {
             = Pattern.compile("([\\.\\d]+)\\W+\\((\\w+)");
 
     public CVSRepository() {
+        /**
+         * This variable is set in the anchestor to TRUE which has a side effect
+         * that this repository is always marked as working even though it does
+         * not have the binary available on the system.
+         *
+         * Setting this to null does restores the default behavior (as java
+         * default for reference is null) for this repository - detecting the
+         * binary and act upon that.
+         *
+         * @see #isWorking
+         */
         working = null;
         setType("CVS");
         datePatterns = new String[]{

--- a/src/org/opensolaris/opengrok/history/CVSRepository.java
+++ b/src/org/opensolaris/opengrok/history/CVSRepository.java
@@ -67,7 +67,7 @@ public class CVSRepository extends RCSRepository {
             = Pattern.compile("([\\.\\d]+)\\W+\\((\\w+)");
 
     public CVSRepository() {
-        working = Boolean.FALSE;
+        working = null;
         setType("CVS");
         datePatterns = new String[]{
             "yyyy-MM-dd hh:mm:ss"

--- a/src/org/opensolaris/opengrok/history/RepositoryInfo.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryInfo.java
@@ -82,7 +82,7 @@ public class RepositoryInfo implements Serializable {
 
     /**
      * Returns true if this repository is usable in this context (for SCM
-     * systems that use external binaries, the binary must be availabe etc)
+     * systems that use external binaries, the binary must be available etc)
      *
      * @return true if the HistoryGuru may use the repository
      */


### PR DESCRIPTION
…nstalled or not

I don't know how it was supposed to work but with the previous settings (introduced in d8a4ee9) it always skips the tests for this repository even if the binary is installed on the system.