### PR TITLE
checking source root existence in the top level jsps

### DIFF
--- a/web/diff.jsp
+++ b/web/diff.jsp
@@ -21,7 +21,7 @@ CDDL HEADER END
 Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
 
 Portions Copyright 2011 Jens Elkner.
---%><%@page import="
+--%><%@page errorPage="error.jsp" import="
 java.io.ByteArrayInputStream,
 java.io.OutputStream,
 java.io.BufferedReader,
@@ -53,6 +53,8 @@ private String getAnnotateRevision(DiffData data) {
 %>
 <%
 {
+    PageConfig cfg = PageConfig.get(request);
+    cfg.checkSourceRootExistence();
     /**
      * This block must be the first block before any other output in the
      * response.
@@ -62,7 +64,6 @@ private String getAnnotateRevision(DiffData data) {
      * a collision with the response streams and the "getOutputStream() has
      * already been called" exception occurs.
      */
-    PageConfig cfg = PageConfig.get(request);
     DiffData data = cfg.getDiffData();
     request.setAttribute("diff.jsp-data", data);
     if (data.type == DiffType.TEXT

--- a/web/enoent.jsp
+++ b/web/enoent.jsp
@@ -54,7 +54,7 @@ include file="menu.jspf"
 {
     PageConfig cfg = PageConfig.get(request);
     String configError = "";
-    if (cfg.getSourceRootPath().isEmpty()) {
+    if (cfg.getSourceRootPath() == null || cfg.getSourceRootPath().isEmpty()) {
         configError = "CONFIGURATION parameter has not been configured in "
             + "web.xml! Please configure your webapp.";
     } else if (!cfg.getEnv().getSourceRootFile().isDirectory()) {

--- a/web/enoent.jsp
+++ b/web/enoent.jsp
@@ -19,13 +19,14 @@ CDDL HEADER END
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 
---%><%@page session="false" isErrorPage="true" import="
+--%><%@page session="false" errorPage="error.jsp" isErrorPage="true" import="
 org.opensolaris.opengrok.web.Prefix,
 org.opensolaris.opengrok.configuration.RuntimeEnvironment"
  %><%
 /* ---------------------- enoent.jsp start --------------------- */
 {
     PageConfig cfg = PageConfig.get(request);
+    cfg.checkSourceRootExistence();
     cfg.setTitle("File not found");
 
     String context = request.getContextPath();
@@ -54,7 +55,7 @@ include file="menu.jspf"
 {
     PageConfig cfg = PageConfig.get(request);
     String configError = "";
-    if (cfg.getSourceRootPath() == null || cfg.getSourceRootPath().isEmpty()) {
+    if (cfg.getSourceRootPath().isEmpty()) {
         configError = "CONFIGURATION parameter has not been configured in "
             + "web.xml! Please configure your webapp.";
     } else if (!cfg.getEnv().getSourceRootFile().isDirectory()) {

--- a/web/help.jsp
+++ b/web/help.jsp
@@ -27,6 +27,7 @@ org.opensolaris.opengrok.search.SearchEngine"
 /* ---------------------- help.jsp start --------------------- */
 {
     PageConfig cfg = PageConfig.get(request);
+    cfg.checkSourceRootExistence();
     cfg.setTitle("OpenGrok Help");
 }
 %><%@

--- a/web/history.jsp
+++ b/web/history.jsp
@@ -25,7 +25,7 @@ Portions Copyright 2011 Jens Elkner.
 --%><%@page import="org.opensolaris.opengrok.web.Util"%>
 <%@page import="org.opensolaris.opengrok.history.HistoryGuru"%>
 <%@page import="java.io.File"%>
-<%@page import="
+<%@page errorPage="error.jsp" import="
 java.text.Format,
 java.text.SimpleDateFormat,
 java.util.Date,
@@ -40,6 +40,8 @@ org.opensolaris.opengrok.configuration.RuntimeEnvironment"
 <%/* ---------------------- history.jsp start --------------------- */
 {
     PageConfig cfg = PageConfig.get(request);
+
+    cfg.checkSourceRootExistence();
 
     // Need to set the title before inlcuding httpheader.jspf
     cfg.setTitle(cfg.getHistoryTitle());

--- a/web/index.jsp
+++ b/web/index.jsp
@@ -20,7 +20,13 @@ Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
 
 Portions Copyright 2011 Jens Elkner.
 
---%><%@ page session="false" errorPage="error.jsp" %><%@
+--%><%@ page session="false" errorPage="error.jsp" %>
+<%
+{
+    PageConfig cfg = PageConfig.get(request);
+    cfg.checkSourceRootExistence();
+}
+%><%@
 
 include file="projects.jspf"
 
@@ -29,7 +35,6 @@ include file="projects.jspf"
 {
     PageConfig cfg = PageConfig.get(request);
     cfg.setTitle("Search");
-    cfg.checkSourceRootExistence();
 }
 %><%@
 

--- a/web/list.jsp
+++ b/web/list.jsp
@@ -23,7 +23,7 @@ Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 
 --%>
-<%@page import="
+<%@page errorPage="error.jsp" import="
 java.io.BufferedInputStream,
 java.io.BufferedReader,
 java.io.FileInputStream,
@@ -52,7 +52,10 @@ org.opensolaris.opengrok.web.DirectoryListing"
     if (request.getCharacterEncoding() == null) {
         request.setCharacterEncoding("UTF-8");
     }
+
     PageConfig cfg = PageConfig.get(request);
+    cfg.checkSourceRootExistence();
+
     Annotation annotation = cfg.getAnnotation();
     if (annotation != null) {
         int r = annotation.getWidestRevision();

--- a/web/mast.jsp
+++ b/web/mast.jsp
@@ -52,6 +52,7 @@ org.opensolaris.opengrok.web.Util"%><%
         }
         return;
     }
+
     // jel: hmmm - questionable for dynamic content
     long flast = cfg.getLastModified();
     if (request.getDateHeader("If-Modified-Since") >= flast) {

--- a/web/more.jsp
+++ b/web/more.jsp
@@ -22,7 +22,7 @@ Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
 
 Portions Copyright 2011 Jens Elkner.
 
---%><%@page import="
+--%><%@page errorPage="error.jsp" import="
 java.io.FileReader,
 java.util.logging.Level,
 java.util.logging.Logger,
@@ -31,6 +31,12 @@ org.apache.lucene.search.Query,
 org.opensolaris.opengrok.search.QueryBuilder,
 org.opensolaris.opengrok.search.context.Context,
 org.opensolaris.opengrok.logger.LoggerFactory"
+%>
+<%
+{
+    PageConfig cfg = PageConfig.get(request);
+    cfg.checkSourceRootExistence();
+}
 %><%@include
 
 file="mast.jsp"

--- a/web/opensearch.jsp
+++ b/web/opensearch.jsp
@@ -26,6 +26,12 @@ Portions Copyright 2011 Jens Elkner.
 java.util.Set,
 
 org.opensolaris.opengrok.web.Util"
+%>
+<%
+{
+    PageConfig cfg = PageConfig.get(request);
+    cfg.checkSourceRootExistence();
+}
 %><%@
 
 include file="projects.jspf"

--- a/web/raw.jsp
+++ b/web/raw.jsp
@@ -22,7 +22,7 @@ Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
 
 Portions Copyright 2011 Jens Elkner.
 
---%><%@page import="
+--%><%@page errorPage="error.jsp" import="
 java.io.File,
 java.io.FileInputStream,
 java.io.FileNotFoundException,
@@ -37,6 +37,8 @@ org.opensolaris.opengrok.web.Prefix"
 /* ---------------------- raw.jsp start --------------------- */
 {
     PageConfig cfg = PageConfig.get(request);
+    cfg.checkSourceRootExistence();
+
     String redir = cfg.canProcess();
     if (redir == null || redir.length() > 0) {
         if (redir != null) {

--- a/web/rss.jsp
+++ b/web/rss.jsp
@@ -38,6 +38,8 @@ org.opensolaris.opengrok.web.PageConfig"
 /* ---------------------- rss.jsp start --------------------- */
 {
     PageConfig cfg = PageConfig.get(request);
+    cfg.checkSourceRootExistence();
+
     String redir = cfg.canProcess();
     if (redir == null || redir.length() > 0) {
         if (redir != null) {

--- a/web/search.jsp
+++ b/web/search.jsp
@@ -28,6 +28,11 @@ org.opensolaris.opengrok.search.Results,
 org.opensolaris.opengrok.web.SearchHelper,
 org.opensolaris.opengrok.web.SortOrder,
 org.opensolaris.opengrok.web.Suggestion"
+%><%
+{
+    PageConfig cfg = PageConfig.get(request);
+    cfg.checkSourceRootExistence();
+}
 %><%@
 
 include file="projects.jspf"

--- a/web/status.jsp
+++ b/web/status.jsp
@@ -25,6 +25,11 @@ Portions Copyright 2011 Jens Elkner.
 --%><%@page session="false" errorPage="error.jsp" import="
 org.opensolaris.opengrok.configuration.RuntimeEnvironment,
 org.opensolaris.opengrok.web.Util"
+%><%
+{
+    PageConfig cfg = PageConfig.get(request);
+    cfg.checkSourceRootExistence();
+}
 %><%@
 
 include file="projects.jspf"


### PR DESCRIPTION
After changes in #1453 not all pages are affected with the source root check.

The error page is not set in every case when the configuration is missing. This PR should set it everywhere.

Actual output when the configuration.xml does not exist (status 200 OK):
![screenshot from 2017-03-27 15-33-09](https://cloud.githubusercontent.com/assets/6997160/24359861/e9201328-1305-11e7-980a-745d874e6ee5.png)
![screenshot from 2017-03-27 15-33-18](https://cloud.githubusercontent.com/assets/6997160/24359862/e9215382-1305-11e7-843c-a51dcf2a92fd.png)

Expected output:
![screenshot from 2017-03-27 15-35-46](https://cloud.githubusercontent.com/assets/6997160/24359876/f09a611c-1305-11e7-9532-7d1b87327961.png)
![screenshot from 2017-03-27 15-35-59](https://cloud.githubusercontent.com/assets/6997160/24359874/f096ece4-1305-11e7-85b9-9b3341640684.png)
![screenshot from 2017-03-27 15-35-38](https://cloud.githubusercontent.com/assets/6997160/24359875/f0977100-1305-11e7-8c5e-65b59c511eb0.png)
