### PR TITLE
Messages: adding an option 'set' for config message

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -137,7 +137,7 @@ Currently supported message types:
 4) ConfigMessage (config)
     This message retrieves or sends a configuration to the webapp,
     depending on tag. "setconf" tag sends config to webapp and requires
-    file as argument.
+    file as argument. "set" tag sets particular configuration option in the webapp.
 5) RefreshMesssage (refresh)
     Sent at the end of partial reindex to trigger refresh of SearcherManagers.
 

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -1529,12 +1529,14 @@ public final class RuntimeEnvironment {
     private Thread configurationListenerThread;
 
     /**
-     * Set configuration from a message. The message could have come from
-     * the Indexer (in which case some extra work is needed) or is it just
-     * a request to set new configuration in place.
+     * Set configuration from a message. The message could have come from the
+     * Indexer (in which case some extra work is needed) or is it just a request
+     * to set new configuration in place.
      *
      * @param m message containing the configuration
      * @param reindex is the message result of reindex
+     * @see #applyConfig(org.opensolaris.opengrok.configuration.Configuration,
+     * boolean) applyConfig(config, reindex)
      */
     public void applyConfig(Message m, boolean reindex) {
         Configuration config;
@@ -1544,6 +1546,20 @@ public final class RuntimeEnvironment {
             LOGGER.log(Level.WARNING, "Configuration decoding failed" + ex);
             return;
         }
+
+        applyConfig(config, reindex);
+    }
+
+    /**
+     * Set configuration from the incoming parameter. The configuration could
+     * have come from the Indexer (in which case some extra work is needed) or
+     * is it just a request to set new configuration in place.
+     *
+     * @param config the incoming configuration
+     * @param reindex is the message result of reindex
+     *
+     */
+    public void applyConfig(Configuration config, boolean reindex) {
 
         setConfiguration(config);
         LOGGER.log(Level.INFO, "Configuration updated: {0}",

--- a/src/org/opensolaris/opengrok/configuration/messages/ConfigMessage.java
+++ b/src/org/opensolaris/opengrok/configuration/messages/ConfigMessage.java
@@ -22,19 +22,56 @@
  */
 package org.opensolaris.opengrok.configuration.messages;
 
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.opensolaris.opengrok.configuration.Configuration;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 
 /**
  *
  * @author Vladimir Kotal
+ * @author Krystof Tulinger
  */
 public class ConfigMessage extends Message {
+
+    /**
+     * Pattern describes the java variable name and the assigned value.
+     * Examples:
+     * <ul>
+     * <li>variable = true</li>
+     * <li>stopOnClose = 10</li>
+     * </ul>
+     */
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("([a-z_]\\w*) = (.*)");
 
     @Override
     protected byte[] applyMessage(RuntimeEnvironment env) throws IOException {
         if (hasTag("getconf")) {
             return env.getConfiguration().getXMLRepresentationAsString().getBytes();
+        } else if (hasTag("set")) {
+            Matcher matcher = VARIABLE_PATTERN.matcher(getText());
+            if (matcher.find()) {
+                // set the property
+                invokeSetter(
+                        env.getConfiguration(),
+                        matcher.group(1), // field
+                        matcher.group(2) // value
+                );
+                // apply the configuration - let the environment reload the configuration if necessary
+                env.applyConfig(env.getConfiguration(), false);
+                return String.format("Variable \"%s\" set to \"%s\".", matcher.group(1), matcher.group(2)).getBytes();
+            } else {
+                // invalid pattern
+                throw new IOException(
+                        String.format("The pattern \"%s\" does not match \"%s\".",
+                                VARIABLE_PATTERN.toString(),
+                                getText()));
+            }
         } else if (hasTag("setconf")) {
             env.applyConfig(this, hasTag("reindex"));
         }
@@ -42,25 +79,147 @@ public class ConfigMessage extends Message {
         return null;
     }
 
+    /**
+     * Invokes a setter on the configuration object and passes a value to that
+     * setter.
+     *
+     * The value is passed as string and the function will automatically try to
+     * convert it to the parameter type in the setter. These conversion are
+     * available only for
+     * <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html">java
+     * primitive datatypes</a>:
+     * <ul>
+     * <li>Boolean or boolean</li>
+     * <li>Short or short</li>
+     * <li>Integer or integer</li>
+     * <li>Long or long</li>
+     * <li>Float or float</li>
+     * <li>Double or double</li>
+     * <li>Byte or byte</li>
+     * <li>Character or char</li>
+     * <li>String</li>
+     * </ul>
+     * Any other parameter type will cause an exception.
+     *
+     * @param config the configuration object
+     * @param field name of the field which will be changed
+     * @param value desired value
+     * @throws IOException if any error occurs (no suitable method, bad
+     * conversion, ...)
+     */
+    protected void invokeSetter(Configuration config, String field, String value) throws IOException {
+        try {
+            PropertyDescriptor desc = new PropertyDescriptor(field, Configuration.class);
+            Method setter = desc.getWriteMethod();
+
+            if (setter == null) {
+                // no setter
+                throw new IOException(
+                        String.format("No setter for the name \"%s\".",
+                                field));
+            }
+
+            if (setter.getParameterCount() != 1) {
+                // not a setter
+                throw new IOException(
+                        String.format("The setter \"%s\" for the name \"%s\" does not take exactly 1 parameter.",
+                                setter.getName(), field));
+            }
+
+            Class c = setter.getParameterTypes()[0];
+
+            String name = c.getName();
+            /**
+             * Java primitive types as per
+             * <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html">java
+             * datatypes</a>.
+             */
+            if (c.getName().equals("boolean") || c.getName().equals(Boolean.class.getName())) {
+                Boolean v = Boolean.valueOf(value);
+                if (!v) {
+                    /**
+                     * The Boolean.valueOf() returns true only for "true" case
+                     * insensitive. These are convenient shortcuts for "on", "1"
+                     * to be interpreted as booleans.
+                     */
+                    v = v || value.equalsIgnoreCase("on");
+                    v = v || value.equals("1");
+                }
+                setter.invoke(config, v);
+            } else if (c.getName().equals("short") || c.getName().equals(Short.class.getName())) {
+                setter.invoke(config, Short.valueOf(value));
+            } else if (c.getName().equals("int") || c.getName().equals(Integer.class.getName())) {
+                setter.invoke(config, Integer.valueOf(value));
+            } else if (c.getName().equals("long") || c.getName().equals(Long.class.getName())) {
+                setter.invoke(config, Long.valueOf(value));
+            } else if (c.getName().equals("float") || c.getName().equals(Float.class.getName())) {
+                setter.invoke(config, Float.valueOf(value));
+            } else if (c.getName().equals("double") || c.getName().equals(Double.class.getName())) {
+                setter.invoke(config, Double.valueOf(value));
+            } else if (c.getName().equals("byte") || c.getName().equals(Byte.class.getName())) {
+                setter.invoke(config, Byte.valueOf(value));
+            } else if (c.getName().equals("char") || c.getName().equals(Character.class.getName())) {
+                setter.invoke(config, value.charAt(0));
+            } else if (c.getName().equals(String.class.getName())) {
+                setter.invoke(config, value);
+            } else {
+                // error uknown type
+                throw new IOException(
+                        String.format("Unsupported type conversion for the name \"%s\". Expecting \"%s\".",
+                                field, c.getName()));
+            }
+        } catch (NumberFormatException ex) {
+            throw new IOException(
+                    String.format("Unsupported type conversion from String to Integer for name \"%s\" - %s.",
+                            field, ex.getLocalizedMessage()), ex);
+        } catch (IntrospectionException
+                | IllegalAccessException
+                | InvocationTargetException
+                | IllegalArgumentException ex) {
+            throw new IOException(
+                    String.format("Unsupported operation with the configuration for name \"%s\" - %s.",
+                            field, ex.getLocalizedMessage()), ex);
+        }
+    }
+
+    /**
+     * Cast a boolean value to integer.
+     *
+     * @param b boolean value
+     * @return 0 for false and 1 for true
+     */
+    protected int toInteger(boolean b) {
+        return b ? 1 : 0;
+    }
+
     @Override
     public void validate() throws Exception {
+        if (toInteger(hasTag("setconf"))
+                + toInteger(hasTag("getconf"))
+                + toInteger(hasTag("set")) > 1) {
+            throw new Exception("The message tag must be either setconf, getconf or set");
+        }
+
         if (hasTag("setconf")) {
             if (getText() == null) {
                 throw new Exception("The setconf message must contain a text.");
             }
         } else if (hasTag("getconf")) {
-            if (getText() !=  null) {
+            if (getText() != null) {
                 throw new Exception("The getconf message should not contain a text.");
             }
             if (getTags().size() != 1) {
                 throw new Exception("The getconf message should be the only tag.");
             }
+        } else if (hasTag("set")) {
+            if (getText() == null) {
+                throw new Exception("The set message must contain a text.");
+            }
+            if (getTags().size() != 1) {
+                throw new Exception("The set message should be the only tag.");
+            }
         } else {
-            throw new Exception("The message tag must be either setconf or getconf");
-        }
-
-        if (hasTag("setconf") && hasTag("getconf")) {
-            throw new Exception("The message tag must be either setconf or getconf");
+            throw new Exception("The message tag must be either setconf, getconf or set");
         }
 
         super.validate();

--- a/src/org/opensolaris/opengrok/configuration/messages/ConfigMessage.java
+++ b/src/org/opensolaris/opengrok/configuration/messages/ConfigMessage.java
@@ -121,6 +121,10 @@ public class ConfigMessage extends Message {
 
             if (setter.getParameterCount() != 1) {
                 // not a setter
+                /**
+                 * Actually should not happen as it is not considered as a
+                 * writer method so an exception would be thrown earlier.
+                 */
                 throw new IOException(
                         String.format("The setter \"%s\" for the name \"%s\" does not take exactly 1 parameter.",
                                 setter.getName(), field));

--- a/src/org/opensolaris/opengrok/configuration/messages/Messages.java
+++ b/src/org/opensolaris/opengrok/configuration/messages/Messages.java
@@ -167,6 +167,7 @@ public final class Messages {
             byte[] out = m.write(server, port);
             if (out != null) {
                 System.out.write(out);
+                System.out.println();
             }
         } catch (IOException ex) {
             System.err.println(ex.getMessage());

--- a/tools/Messages
+++ b/tools/Messages
@@ -55,6 +55,13 @@ Usage()
     echo "                      Requires input file as argument."
     echo "       - \"getconf\"  retrieves configuration from webapp."
     echo "                      Prints the configuration in XML to stdout."
+    echo "       - \"set\"      sets the particular configuration option (only primitive types)"
+    echo "                    in the webapp."
+    echo "                      Examples:"
+    echo "                          histPerPage = 10"
+    echo "                          authorizationWatchdogEnabled = true"
+    echo "                      Returns text describing the action."
+    echo "                      The change is NOT persistent when reindex or redeploy!"
     echo "    normal:"
     echo "     - assign a <text> to the main page or a project"
     echo "     - can be more precise with <tags> (for specific project)"
@@ -335,12 +342,11 @@ do
             echo "Uknown option \"$opt\"" && Usage && exit 5
         ;;
         *)
-	    if [ $MESSAGE_TYPE == "config" ]; then
-		MESSAGE_TAGS=(-g "$1")
-		if [[ $1 == "setconf" ]]; then
-			shift
-			MESSAGE_FILE="$@"
-		fi
+	    if [ "$MESSAGE_TYPE" = "config" -a "$1" = "setconf" ]
+            then
+                MESSAGE_TAGS+=(-g "setconf")
+                shift
+                MESSAGE_FILE="$@"
 	    else
                 if [ $# -ne 1 ]
                 then


### PR DESCRIPTION
Mentioned in #1479 this implements the possibility to set a webapp option at runtime. It's not really necessary but appears to be quite handy with some options to test them out, like
 - `authorizationWatchdogEnabled` (#1465) 
 - `hitsPerPage`
 - `chattyStatusPage`
 - `revisionMessageCollapseThreshold`
 - `groupsCollapseThreshold`
 - `messageLimit`
and a couple of others. Not every option in `Configuration.java` has a meaning for the webapplication.

**The change is not persistent when server was restarted or webapp was redeployed or when the reindex was run.** For persistent configuration when reindexing use the `OPENGROK_READ_XML_CONFIGURATION` environment variable pointing to a xml file with changed options.