### PR TITLE
speeding up the scopes window

### DIFF
--- a/web/foot.jspf
+++ b/web/foot.jspf
@@ -62,7 +62,7 @@ org.opensolaris.opengrok.web.Prefix"
 <script type="text/javascript" src="<%= ctxPath %>/js/jquery.tablesorter-2.26.6.min.js"></script>
 <script type="text/javascript" src="<%= ctxPath %>/js/tablesorter.parsers-0.0.1.js"></script>
 <script type="text/javascript" src="<%= ctxPath %>/js/searchable-option-list-2.0.3.min.js"></script>
-<script type="text/javascript" src="<%= ctxPath %>/js/utils-0.0.7.js"></script>
+<script type="text/javascript" src="<%= ctxPath %>/js/utils-0.0.8.js"></script>
 </body>
 </html>
 <%


### PR DESCRIPTION
As suggested by @mrate I don't update the scopes window when it's not visible.

The whole change here is about this at the very bottom in `scopes_on_scroll()`:
```javascript
if($.scopesWindow && $.scopesWindow.initialized && !$.scopesWindow.is(':visible')) {
     return;
}
```

The rest is just to fully support this behaviour without any visible delay. I tested the results in a big file https://github.com/svn2github/valgrind-vex/blob/master/priv/guest_arm_toIR.c.