### PR TITLE
bugs and reviews are replaced in both short and long summary

### DIFF
--- a/web/history.jsp
+++ b/web/history.jsp
@@ -324,12 +324,10 @@ document.domReady.push(function() {domReadyHistory();});
                 String cout = Util.htmlize(entry.getMessage());
 
                 if (bugPage != null && bugPage.length() > 0) {
-                    cout = bugPattern.matcher(cout).replaceAll("<a href=\""
-                        + bugPage + "$1\">$1</a>");
+                    cout = Util.linkifyPattern(cout, bugPattern, "$1", bugPage + "$1");
                 }
                 if (reviewPage != null && reviewPage.length() > 0) {
-                    cout = reviewPattern.matcher(cout).replaceAll("<a href=\""
-                        + reviewPage + "$1\">$1</a>");
+                    cout = Util.linkifyPattern(cout, reviewPattern, "$1", reviewPage + "$1");
                 }
                 
                 boolean showSummary = false;
@@ -338,6 +336,12 @@ document.domReady.push(function() {domReadyHistory();});
                     showSummary = true;
                     coutSummary = coutSummary.substring(0, summaryLength - 1);
                     coutSummary = Util.htmlize(coutSummary);
+                    if (bugPage != null && bugPage.length() > 0) {
+                        coutSummary = Util.linkifyPattern(coutSummary, bugPattern, "$1", bugPage + "$1");
+                    }
+                    if (reviewPage != null && reviewPage.length() > 0) {
+                        coutSummary = Util.linkifyPattern(coutSummary, reviewPattern, "$1", reviewPage + "$1");
+                    }
                 }
 
                 if (showSummary) {


### PR DESCRIPTION
Reported in internal environment. When there is a bug id (or a review number) which matches the `bugRegex` the commit message is replaced with the link to it. However this happened only for the "long" (original) summary not for the "short" summary. When user clicked "show more" the links disappeared.

Now the code supports both ways.