### PR TITLE
Support for nested Git repositories (#1512)

### DIFF
--- a/src/org/opensolaris/opengrok/history/GitRepository.java
+++ b/src/org/opensolaris/opengrok/history/GitRepository.java
@@ -488,6 +488,11 @@ public class GitRepository extends Repository {
     }
 
     @Override
+    boolean supportsSubRepositories() {
+        return true;
+    }
+
+    @Override
     public boolean isWorking() {
         if (working == null) {
             ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

Fixes #1512, adds `supportsSubRepositories()` to Git.

And I accept the Oracle Contributor Agreement. I haven't signed it and sent it back, but apparently it is enough to specify it in the pull request comment.
