### PR TITLE
Two plugin classes implemented in OpenGrok - groups and projects restrictions

### DIFF
--- a/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
@@ -38,6 +38,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
 import org.opensolaris.opengrok.authorization.AuthorizationCheck.AuthControlFlag;
+import org.opensolaris.opengrok.authorization.plugins.GroupPlugin;
+import org.opensolaris.opengrok.authorization.plugins.ProjectPlugin;
 import org.opensolaris.opengrok.configuration.Configuration;
 import org.opensolaris.opengrok.configuration.Group;
 import org.opensolaris.opengrok.configuration.Nameable;
@@ -555,6 +557,10 @@ public final class AuthorizationFramework {
                 IOUtils.listFilesRec(pluginDirectory, ".class"),
                 IOUtils.listFiles(pluginDirectory, ".jar"));
 
+        stack.setPlugin(new GroupPlugin());
+        stack.setPlugin(new ProjectPlugin());
+
+        // fire load events
         loadAllPlugins();
     }
 

--- a/src/org/opensolaris/opengrok/authorization/plugins/GroupPlugin.java
+++ b/src/org/opensolaris/opengrok/authorization/plugins/GroupPlugin.java
@@ -1,0 +1,94 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+ /*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.authorization.plugins;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import org.opensolaris.opengrok.authorization.IAuthorizationPlugin;
+import org.opensolaris.opengrok.configuration.Group;
+import org.opensolaris.opengrok.configuration.Project;
+
+/**
+ *
+ * @author Krystof Tulinger
+ */
+public class GroupPlugin implements IAuthorizationPlugin {
+
+    private List<String> groups = new ArrayList<>();
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void load(Map<String, Object> parameters) {
+        Object group = parameters.get("groups");
+        if (group == null) {
+            throw new NullPointerException("No group given in configuration. Use \"groups\" in setup.");
+        }
+
+        IllegalArgumentException e = new IllegalArgumentException("Unable to detect the group configuration.");
+        Exception last = e;
+
+        try {
+            groups.add((String) group);
+            return;
+        } catch (ClassCastException ex) {
+            last.initCause(ex);
+            last = ex;
+        }
+
+        try {
+            groups = (List) group;
+            return;
+        } catch (ClassCastException ex) {
+            last.initCause(ex);
+            last = ex;
+        }
+
+        try {
+            groups = new ArrayList<>(Arrays.asList((String[]) group));
+            return;
+        } catch (ClassCastException ex) {
+            last.initCause(ex);
+            last = ex;
+        }
+
+        throw e;
+    }
+
+    @Override
+    public void unload() {
+    }
+
+    @Override
+    public boolean isAllowed(HttpServletRequest request, Project project) {
+        return false;
+    }
+
+    @Override
+    public boolean isAllowed(HttpServletRequest request, Group group) {
+        return this.groups.contains(group.getName());
+    }
+
+}

--- a/src/org/opensolaris/opengrok/authorization/plugins/ProjectPlugin.java
+++ b/src/org/opensolaris/opengrok/authorization/plugins/ProjectPlugin.java
@@ -1,0 +1,94 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+ /*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.authorization.plugins;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import org.opensolaris.opengrok.authorization.IAuthorizationPlugin;
+import org.opensolaris.opengrok.configuration.Group;
+import org.opensolaris.opengrok.configuration.Project;
+
+/**
+ *
+ * @author Krystof Tulinger
+ */
+public class ProjectPlugin implements IAuthorizationPlugin {
+
+    private List<String> projects = new ArrayList<>();
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void load(Map<String, Object> parameters) {
+        Object project = parameters.get("projects");
+        if (project == null) {
+            throw new NullPointerException("No group given in configuration. Use \"groups\" in setup.");
+        }
+
+        IllegalArgumentException e = new IllegalArgumentException("Unable to detect the group configuration.");
+        Exception last = e;
+
+        try {
+            projects.add((String) project);
+            return;
+        } catch (ClassCastException ex) {
+            last.initCause(ex);
+            last = ex;
+        }
+
+        try {
+            projects = (List) project;
+            return;
+        } catch (ClassCastException ex) {
+            last.initCause(ex);
+            last = ex;
+        }
+
+        try {
+            projects = new ArrayList<>(Arrays.asList((String[]) project));
+            return;
+        } catch (ClassCastException ex) {
+            last.initCause(ex);
+            last = ex;
+        }
+
+        throw e;
+    }
+
+    @Override
+    public void unload() {
+    }
+
+    @Override
+    public boolean isAllowed(HttpServletRequest request, Project project) {
+        return this.projects.contains(project.getName());
+    }
+
+    @Override
+    public boolean isAllowed(HttpServletRequest request, Group group) {
+        return false;
+    }
+
+}

--- a/test/org/opensolaris/opengrok/authorization/plugins/GroupPluginTest.java
+++ b/test/org/opensolaris/opengrok/authorization/plugins/GroupPluginTest.java
@@ -1,0 +1,161 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+ /*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.authorization.plugins;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.Test;
+import org.opensolaris.opengrok.configuration.Group;
+import org.opensolaris.opengrok.configuration.Project;
+import org.opensolaris.opengrok.web.DummyHttpServletRequest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ * @author Krystof Tulinger
+ */
+public class GroupPluginTest {
+
+    /**
+     * Test of load method, of class GroupPlugin.
+     */
+    @Test(expected = Exception.class)
+    public void testLoad1() {
+        Map<String, Object> parameters = null;
+        GroupPlugin instance = new GroupPlugin();
+        instance.load(null);
+    }
+
+    /**
+     * Test of load method, of class GroupPlugin.
+     */
+    @Test(expected = Exception.class)
+    public void testLoad2() {
+        Map<String, Object> parameters = new TreeMap<>();
+        GroupPlugin instance = new GroupPlugin();
+        instance.load(parameters);
+    }
+
+    /**
+     * Test of load method, of class GroupPlugin.
+     */
+    @Test(expected = Exception.class)
+    public void testLoad3() {
+        Map<String, Object> parameters = new TreeMap<>();
+        parameters.put("xxxx", "some");
+        GroupPlugin instance = new GroupPlugin();
+        instance.load(parameters);
+    }
+
+    /**
+     * Test of load method, of class GroupPlugin.
+     */
+    @Test
+    public void testLoad4() {
+        Map<String, Object> parameters = new TreeMap<>();
+        parameters.put("groups", "Awesome group");
+        GroupPlugin instance = new GroupPlugin();
+        instance.load(parameters);
+    }
+
+    /**
+     * Test of load method, of class GroupPlugin.
+     */
+    @Test
+    public void testLoad5() {
+        Map<String, Object> parameters = new TreeMap<>();
+        parameters.put("groups", new String[]{"Awesome group", "God group"});
+        parameters.put("xxx", new Object());
+        GroupPlugin instance = new GroupPlugin();
+        instance.load(parameters);
+    }
+
+    /**
+     * Test of load method, of class GroupPlugin.
+     */
+    @Test
+    public void testLoad6() {
+        Map<String, Object> parameters = new TreeMap<>();
+        parameters.put("groups", Arrays.asList(new String[]{"Awesome group", "God group"}));
+        parameters.put("xxx", new Object());
+        GroupPlugin instance = new GroupPlugin();
+        instance.load(parameters);
+    }
+
+    /**
+     * Test of isAllowed method, of class GroupPlugin.
+     */
+    @Test
+    public void testIsAllowedProject() {
+        Map<String, Object> parameters = new TreeMap<>();
+        parameters.put("groups", new String[]{"Awesome group", "God group"});
+
+        GroupPlugin instance = new GroupPlugin();
+        instance.load(parameters);
+
+        Project p = new Project();
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Awesome project");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("God project");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Not an awesome project");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Awesome group");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("God group");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Not an awesome group");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+    }
+
+    /**
+     * Test of isAllowed method, of class GroupPlugin.
+     */
+    @Test
+    public void testIsAllowedGroup() {
+        Map<String, Object> parameters = new TreeMap<>();
+        parameters.put("groups", new String[]{"Awesome group", "God group"});
+
+        GroupPlugin instance = new GroupPlugin();
+        instance.load(parameters);
+
+        Group p = new Group();
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Awesome project");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("God project");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Not an awesome project");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Awesome group");
+        assertTrue(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("God group");
+        assertTrue(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Not an awesome group");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+    }
+}

--- a/test/org/opensolaris/opengrok/authorization/plugins/ProjectPluginTest.java
+++ b/test/org/opensolaris/opengrok/authorization/plugins/ProjectPluginTest.java
@@ -1,0 +1,162 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+ /*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.authorization.plugins;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.Test;
+import org.opensolaris.opengrok.configuration.Group;
+import org.opensolaris.opengrok.configuration.Project;
+import org.opensolaris.opengrok.web.DummyHttpServletRequest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ * @author Krystof Tulinger
+ */
+public class ProjectPluginTest {
+
+    /**
+     * Test of load method, of class ProjectPlugin.
+     */
+    @Test(expected = Exception.class)
+    public void testLoad1() {
+        Map<String, Object> parameters = null;
+        ProjectPlugin instance = new ProjectPlugin();
+        instance.load(null);
+    }
+
+    /**
+     * Test of load method, of class ProjectPlugin.
+     */
+    @Test(expected = Exception.class)
+    public void testLoad2() {
+        Map<String, Object> parameters = new TreeMap<>();
+        ProjectPlugin instance = new ProjectPlugin();
+        instance.load(parameters);
+    }
+
+    /**
+     * Test of load method, of class ProjectPlugin.
+     */
+    @Test(expected = Exception.class)
+    public void testLoad3() {
+        Map<String, Object> parameters = new TreeMap<>();
+        parameters.put("xxxx", "some");
+        ProjectPlugin instance = new ProjectPlugin();
+        instance.load(parameters);
+    }
+
+    /**
+     * Test of load method, of class ProjectPlugin.
+     */
+    @Test
+    public void testLoad4() {
+        Map<String, Object> parameters = new TreeMap<>();
+        parameters.put("projects", "Awesome project");
+        ProjectPlugin instance = new ProjectPlugin();
+        instance.load(parameters);
+    }
+
+    /**
+     * Test of load method, of class ProjectPlugin.
+     */
+    @Test
+    public void testLoad5() {
+        Map<String, Object> parameters = new TreeMap<>();
+        parameters.put("projects", new String[]{"Awesome project", "God project"});
+        parameters.put("xxx", new Object());
+        ProjectPlugin instance = new ProjectPlugin();
+        instance.load(parameters);
+    }
+
+    /**
+     * Test of load method, of class ProjectPlugin.
+     */
+    @Test
+    public void testLoad6() {
+        Map<String, Object> parameters = new TreeMap<>();
+        parameters.put("projects", Arrays.asList(new String[]{"Awesome project", "God project"}));
+        parameters.put("xxx xxx", new Object());
+        ProjectPlugin instance = new ProjectPlugin();
+        instance.load(parameters);
+    }
+
+    /**
+     * Test of isAllowed method, of class GroupPlugin.
+     */
+    @Test
+    public void testIsAllowedProject() {
+        Map<String, Object> parameters = new TreeMap<>();
+        parameters.put("projects", new String[]{"Awesome project", "God project"});
+
+        ProjectPlugin instance = new ProjectPlugin();
+        instance.load(parameters);
+
+        Project p = new Project();
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Awesome project");
+        assertTrue(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("God project");
+        assertTrue(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Not an awesome project");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Awesome group");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("God group");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Not an awesome group");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+    }
+
+    /**
+     * Test of isAllowed method, of class GroupPlugin.
+     */
+    @Test
+    public void testIsAllowedGroup() {
+        Map<String, Object> parameters = new TreeMap<>();
+        parameters.put("projects", new String[]{"Awesome project", "God project"});
+
+        ProjectPlugin instance = new ProjectPlugin();
+        instance.load(parameters);
+
+        Group p = new Group();
+
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Awesome project");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("God project");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Not an awesome project");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Awesome group");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("God group");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+        p.setName("Not an awesome group");
+        assertFalse(instance.isAllowed(new DummyHttpServletRequest(), p));
+    }
+}


### PR DESCRIPTION
**This expects the #1525 to be merged as it already implements the new interface.**

This change provides two simple plugins to statically enforce some authorization for groups or projects.

 - [GroupPlugin.java](https://github.com/tulinkry/OpenGrok/blob/0f16fa25ccb45e1412b1c1790bf3a96774334f65/src/org/opensolaris/opengrok/authorization/plugins/GroupPlugin.java)
 - [ProjectPlugin.java](https://github.com/tulinkry/OpenGrok/blob/0f16fa25ccb45e1412b1c1790bf3a96774334f65/src/org/opensolaris/opengrok/authorization/plugins/ProjectPlugin.java)

Both performing authorization for groups (or projects) based on statically initialized set of groups (projects) which are allowed. The initialization can be one of
 - a single string instance
 - a string array (the example bellow)
 - a list of strings

Example:
(note the `<string>1</string>` is real group name in my setup)

```xml
<object class="org.opensolaris.opengrok.authorization.AuthorizationPlugin">
 <void property="name">
  <string>org.opensolaris.opengrok.authorization.plugins.GroupPlugin</string>
 </void>
 <void property="role">
  <string>SUFFICIENT</string>
 </void>
 <void property="setup">
    <void method="put">
      <string>groups</string>
      <array class="java.lang.String" length="2">
       <void index="0">
         <string>1</string>
       </void>
       <void index="1">
         <string>2</string>
       </void>
      </array>
    </void>
 </void>
</object
```

**There are also the changes for #1525 which I'll merge manually after the PR gets merged**
