### PR TITLE
avoid unnecessary calls to authorization framework

### DIFF
--- a/src/org/opensolaris/opengrok/web/ProjectHelper.java
+++ b/src/org/opensolaris/opengrok/web/ProjectHelper.java
@@ -145,8 +145,8 @@ public final class ProjectHelper {
 
         // populate all grouped
         for (Group g : getGroups()) {
-            all_projects.addAll(getProjects(g));
-            all_repositories.addAll(getRepositories(g));
+            all_projects.addAll(g.getProjects());
+            all_repositories.addAll(g.getRepositories());
         }
     }
 


### PR DESCRIPTION
The projects/repositories are filtered always through the getter so this was just needlessly calling the authorization framework for all projects and repositories without any specific gain.