### PR TITLE
using the project from URL if possible

### DIFF
--- a/src/org/opensolaris/opengrok/web/PageConfig.java
+++ b/src/org/opensolaris/opengrok/web/PageConfig.java
@@ -827,6 +827,15 @@ public final class PageConfig {
         if (projects == null) {
             return set;
         }
+
+        /**
+         * If the project was determined from the URL, use this project.
+         */
+        if (getProject() != null) {
+            set.add(getProject().getName());
+            return set;
+        }
+
         if (projects.size() == 1 && authFramework.isAllowed(req, projects.get(0))) {
             set.add(projects.get(0).getName());
             return set;


### PR DESCRIPTION
Behaviour discovered in #1556 if user visits an URL like http://localhost:8080/source/diff/OpenGrok/random/url then the project can be clearly determined from the URL however the code in the question bubbles down to calling the authorization framework for every project in the cookie (or even after for the default projects). That is not necessary I think.