### PR TITLE
targeting stacks for particular groups or projects

### DIFF
--- a/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
@@ -151,14 +151,14 @@ public final class AuthorizationFramework {
             }
         }, new AuthorizationEntity.PluginSkippingPredicate() {
             @Override
-            public boolean shouldSkip(AuthorizationEntity entity) {
+            public boolean shouldSkip(AuthorizationEntity authEntity) {
                 // shouldn't skip if there is no setup
-                if (entity.forProjects().isEmpty() && entity.forGroups().isEmpty()) {
+                if (authEntity.forProjects().isEmpty() && authEntity.forGroups().isEmpty()) {
                     return false;
                 }
 
                 // shouldn't skip if the project is contained in the setup
-                if (entity.forProjects().contains(project.getName())) {
+                if (authEntity.forProjects().contains(project.getName())) {
                     return false;
                 }
 
@@ -189,14 +189,14 @@ public final class AuthorizationFramework {
             }
         }, new AuthorizationEntity.PluginSkippingPredicate() {
             @Override
-            public boolean shouldSkip(AuthorizationEntity entity) {
+            public boolean shouldSkip(AuthorizationEntity authEntity) {
                 // shouldn't skip if there is no setup
-                if (entity.forProjects().isEmpty() && entity.forGroups().isEmpty()) {
+                if (authEntity.forProjects().isEmpty() && authEntity.forGroups().isEmpty()) {
                     return false;
                 }
 
                 // shouldn't skip if the group is contained in the setup
-                return !entity.forGroups().contains(group.getName());
+                return !authEntity.forGroups().contains(group.getName());
             }
         });
     }

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationPlugin.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationPlugin.java
@@ -24,7 +24,6 @@ package org.opensolaris.opengrok.authorization;
 
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
@@ -99,6 +98,12 @@ public class AuthorizationPlugin extends AuthorizationStack {
                     + "This can cause the authorization to fail always.",
                     getName());
             setFailed();
+            LOGGER.log(Level.INFO, "[{0}] Plugin \"{1}\" {2} and is {3}.",
+                    new Object[]{
+                        getFlag().toString().toUpperCase(),
+                        getName(),
+                        hasPlugin() ? "found" : "not found",
+                        isWorking() ? "working" : "failed"});
             return;
         }
 
@@ -147,9 +152,11 @@ public class AuthorizationPlugin extends AuthorizationStack {
      *
      * @param entity the given entity - this is either group or project and is
      * passed just for the logging purposes.
-     * @param predicate predicate returning true or false for the given entity
-     * which determines if the authorization for such entity is successful or
-     * failed for particular request and plugin
+     * @param pluginPredicate predicate returning true or false for the given
+     * entity which determines if the authorization for such entity is
+     * successful or failed for particular request and plugin
+     * @param skippingPredicate predicate returning true if this authorization
+     * entity should be omitted from the authorization process
      * @return true if the plugin is not failed and the project is allowed;
      * false otherwise
      *
@@ -158,11 +165,15 @@ public class AuthorizationPlugin extends AuthorizationStack {
      * @see IAuthorizationPlugin#isAllowed(HttpServletRequest, Group)
      */
     @Override
-    public boolean isAllowed(Nameable entity, Predicate<IAuthorizationPlugin> predicate) {
+    public boolean isAllowed(Nameable entity,
+            AuthorizationEntity.PluginDecisionPredicate pluginPredicate,
+            AuthorizationEntity.PluginSkippingPredicate skippingPredicate) {
+
         if (isFailed()) {
             return false;
         }
-        return predicate.test(plugin);
+
+        return pluginPredicate.decision(this.plugin);
     }
 
     /**

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationPlugin.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationPlugin.java
@@ -168,6 +168,13 @@ public class AuthorizationPlugin extends AuthorizationStack {
     public boolean isAllowed(Nameable entity,
             AuthorizationEntity.PluginDecisionPredicate pluginPredicate,
             AuthorizationEntity.PluginSkippingPredicate skippingPredicate) {
+        /**
+         * We don't check the skippingPredicate here as this instance is
+         * <b>always</b> a part of some stack (may be the default stack) and the
+         * stack checks the skipping predicate before invoking this method.
+         *
+         * @see AuthorizationStack#processStack
+         */
 
         if (isFailed()) {
             return false;


### PR DESCRIPTION
Allow user to specify target groups/projects for particular stack (or even a plugin).

When the authorization traverses the stack of plugins/stacks it checks if the plugin/stack is targeted only for some groups/projects and does not execute if it that is not the case.

The syntax is pretty straight-forward (note the section forGroups):

```xml
<void method="add">
    <object class="org.opensolaris.opengrok.authorization.AuthorizationPlugin">
        <void property="forGroups"> <!-- or forProjects -->
             <string>Group 1</string>
        </void>
        <!-- or for more groups -->
        <void property="forGroups"> <!-- or forProjects -->
              <void method="add">
                   <string>Group 1</string>
              </void>
              <void method="add">
                   <string>Group 2</string>
              </void>
        </void>
        <void property="name">
            <string>opengrok.auth.plugin.SomePlugin</string>
        </void>
        <void property="flag">
            <string>REQUISITE</string>
        </void>
                <void property="setup">
                        <void method="put">
                                <string>config</string>
                                <string>/home/my.xml</string>
                        </void>
                 </void>
    </object>
</void>
```