### PR TITLE
returning copy of the repository list

### DIFF
--- a/src/org/opensolaris/opengrok/web/ProjectHelper.java
+++ b/src/org/opensolaris/opengrok/web/ProjectHelper.java
@@ -104,10 +104,12 @@ public final class ProjectHelper {
     }
 
     /**
-     * Get repository info for particular project
+     * Get repository info list for particular project. A copy of the list is
+     * returned always to allow concurrent modifications of the list in the
+     * caller. The items in the list shall not be modified concurrently, though.
      *
-     * @param p Project
-     * @return Copy of a list of repository info or empty List if no info is
+     * @param p the project for which we find the repository info list
+     * @return Copy of a list of repository info or empty list if no info is
      * found
      */
     public List<RepositoryInfo> getRepositoryInfo(Project p) {

--- a/src/org/opensolaris/opengrok/web/ProjectHelper.java
+++ b/src/org/opensolaris/opengrok/web/ProjectHelper.java
@@ -107,7 +107,8 @@ public final class ProjectHelper {
      * Get repository info for particular project
      *
      * @param p Project
-     * @return List of repository info or empty List if no info is found
+     * @return Copy of a list of repository info or empty List if no info is
+     * found
      */
     public List<RepositoryInfo> getRepositoryInfo(Project p) {
         if (!cfg.isAllowed(p)) {
@@ -115,7 +116,7 @@ public final class ProjectHelper {
         }
         Map<Project, List<RepositoryInfo>> map = cfg.getEnv().getProjectRepositoriesMap();
         List<RepositoryInfo> info = map.get(p);
-        return info == null ? new ArrayList<>() : info;
+        return info == null ? new ArrayList<>() : new ArrayList<>(info);
     }
 
     /**
@@ -249,7 +250,7 @@ public final class ProjectHelper {
         }
         return cacheProjects(PROJECT_HELPER_GROUPED_PROJECT_GROUP + g.getName().toLowerCase(), g.getProjects());
     }
-    
+
     /**
      * @param g group
      * @return filtered group's repositories
@@ -421,7 +422,7 @@ public final class ProjectHelper {
         cfg.setRequestAttribute(PROJECT_HELPER_FAVOURITE_GROUP, p);
         return val;
     }
-    
+
     /**
      * Checks if the project is a favourite project
      *


### PR DESCRIPTION
 - avoiding concurrent modification exception (when the list is modified later)

This piece of code in repos.jsp produces an CME when modifying the list of repositories (which is taken directly from the RE). Returning a copy solves the problem, the objects in the list are not modified.

```java
List<RepositoryInfo> repos = pHelper.getRepositoryInfo(project);
String projDesc = project.getName();
Integer cnt = 0;
Collections.sort(repos, comparatorRepo); <!-- HERE -->
%>
<%
for (RepositoryInfo ri : repos) {
    if (cnt > 0 && ri.getParent() == null)
        // discard repositories without a parent url
        continue;
    if (cnt != 0) {
        projDesc = ri.getDirectoryName()
                     .replace(cfg.getSourceRootPath() + File.separator, "");
    }
    %>
```