### PR TITLE
obfuscating sensitive svn login credentials when running subcommands

### DIFF
--- a/src/org/opensolaris/opengrok/util/Executor.java
+++ b/src/org/opensolaris/opengrok/util/Executor.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Timer;
@@ -144,8 +145,21 @@ public class Executor {
      */
     public int exec(final boolean reportExceptions, StreamHandler handler) {
         int ret = -1;
-        ProcessBuilder processBuilder = new ProcessBuilder(cmdList);
-        final String cmd_str = processBuilder.command().toString();
+        List<String> cmd = new ArrayList<>(cmdList);
+        ProcessBuilder processBuilder = new ProcessBuilder(cmd);
+
+        List<String> cmd_list = processBuilder.command();
+        if (LOGGER.isLoggable(Level.FINE)) {
+            /**
+             * Obfuscate sensitive information in the command.
+             *
+             * Perform only when the log level is FINE because all of the logs
+             * below are set up to level FINE.
+             */
+            cmd_list = StringUtils.obfuscateCommand(processBuilder.command());
+        }
+
+        final String cmd_str = cmd_list.toString();
         final String dir_str;
         Timer t = null; // timer for timeouting the process
 

--- a/src/org/opensolaris/opengrok/util/StringUtils.java
+++ b/src/org/opensolaris/opengrok/util/StringUtils.java
@@ -23,7 +23,10 @@
 
 package org.opensolaris.opengrok.util;
 
+import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.opensolaris.opengrok.history.SubversionRepository;
 
 /**
  * Various String utility methods.
@@ -130,5 +133,26 @@ public final class StringUtils {
             n--;
         }
         return pos;
+    }
+
+    /**
+     * Obfuscate sensitive information in the command list. Current sensitive
+     * information are:
+     * <ul>
+     * <li>--username .*</li>
+     * <li>--password .*</li>
+     * </ul>
+     *
+     * @param cmdList the cmd list to be obfuscated
+     * @return the obfuscated cmd list
+     *
+     * @see SubversionRepository#getAuthCommandLineParams()
+     */
+    public static List<String> obfuscateCommand(List<String> cmdList) {
+        return cmdList.stream().map((t) -> {
+            t = t.replaceAll("--username \\S*", "--username ******");
+            t = t.replaceAll("--password \\S*", "--password ******");
+            return t;
+        }).collect(Collectors.toList());
     }
 }

--- a/src/org/opensolaris/opengrok/web/AuthorizationFilter.java
+++ b/src/org/opensolaris/opengrok/web/AuthorizationFilter.java
@@ -44,6 +44,8 @@ public class AuthorizationFilter implements Filter {
     public void init(FilterConfig fc) throws ServletException {
     }
 
+    private int id = 0; 
+
     @Override
     public void doFilter(ServletRequest sr, ServletResponse sr1, FilterChain fc) throws IOException, ServletException {
         HttpServletRequest httpReq = (HttpServletRequest) sr;
@@ -51,6 +53,8 @@ public class AuthorizationFilter implements Filter {
 
         PageConfig config = PageConfig.get(httpReq);
         long processTime = System.currentTimeMillis();
+
+        // LOGGER.log(Level.INFO, "request nr. " + (++id));
 
         Project p = config.getProject();
         if (p != null && !config.isAllowed(p)) {

--- a/test/org/opensolaris/opengrok/util/StringUtilsTest.java
+++ b/test/org/opensolaris/opengrok/util/StringUtilsTest.java
@@ -22,6 +22,7 @@
  */
 package org.opensolaris.opengrok.util;
 
+import java.util.Arrays;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -107,5 +108,37 @@ public class StringUtilsTest {
                     new Object[]{tests[i][2], tests[i][1], tests[i][0], indices[i], index}),
                     index, indices[i]);
         }
+    }
+
+    @Test
+    public void testObfuscateEmail() {
+        assertEquals(StringUtils.obfuscateCommand(Arrays.asList(new String[]{
+            "git", "log", "--username 007", "/var/xml/opengrok"
+        })), Arrays.asList(new String[]{
+            "git", "log", "--username ******", "/var/xml/opengrok"
+        }));
+        assertEquals(StringUtils.obfuscateCommand(Arrays.asList(new String[]{
+            "git", "log", "--password 007", "/var/xml/opengrok"
+        })), Arrays.asList(new String[]{
+            "git", "log", "--password ******", "/var/xml/opengrok"
+        }));
+
+        assertEquals(StringUtils.obfuscateCommand(Arrays.asList(new String[]{
+            "git", "log", "--password 007", "--username 008", "/var/xml/opengrok"
+        })), Arrays.asList(new String[]{
+            "git", "log", "--password ******", "--username ******", "/var/xml/opengrok"
+        }));
+
+        assertEquals(StringUtils.obfuscateCommand(Arrays.asList(new String[]{
+            "git", "log", "--username 008", "--password 007", "/var/xml/opengrok"
+        })), Arrays.asList(new String[]{
+            "git", "log", "--username ******", "--password ******", "/var/xml/opengrok"
+        }));
+
+        assertEquals(StringUtils.obfuscateCommand(Arrays.asList(new String[]{
+            "git", "log", "--username 008 --password 007", "/var/xml/opengrok"
+        })), Arrays.asList(new String[]{
+            "git", "log", "--username ****** --password ******", "/var/xml/opengrok"
+        }));
     }
 }


### PR DESCRIPTION
fixes #1561

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
