### PR TITLE
filename should be the last argument of Mercurial history executor

### DIFF
--- a/src/org/opensolaris/opengrok/history/MercurialRepository.java
+++ b/src/org/opensolaris/opengrok/history/MercurialRepository.java
@@ -195,15 +195,15 @@ public class MercurialRepository extends Repository {
             cmd.add("--follow");
         }
 
-        if (!filename.isEmpty()) {
-            cmd.add(filename);
-        }
-
         cmd.add("--template");
         if (file.isDirectory()) {
             cmd.add(env.isHandleHistoryOfRenamedFiles() ? DIR_TEMPLATE_RENAMED : DIR_TEMPLATE);
         } else {
             cmd.add(FILE_TEMPLATE);
+        }
+
+        if (!filename.isEmpty()) {
+            cmd.add(filename);
         }
 
         return new Executor(cmd, new File(directoryName), sinceRevision != null);


### PR DESCRIPTION
seeing that the history log triggers this sort of command (thanks to Solaris `pargs` command):

26891:  /usr/bin/python2.7 /usr/bin/hg log -r reverse(0::'bar') foo
argv[0]: /usr/bin/python2.7
argv[1]: /usr/bin/hg
argv[2]: log
argv[3]: -r
argv[4]: reverse(0::'bar')
argv[5]: foo
argv[6]: --template
argv[7]: changeset: {rev}:{node|short}\\nuser: {author}\\ndate: {date|isodate}\\ndescription: {desc|strip|obfuscate}\\nfiles: {files}\\nfile_copies: {file_copies}\\nmercurial_history_end_of_entry\\n

which works however does not really follow `hg log` usage.