### PR TITLE
removing the size for a directory in directory listing

### DIFF
--- a/src/org/opensolaris/opengrok/web/DirectoryListing.java
+++ b/src/org/opensolaris/opengrok/web/DirectoryListing.java
@@ -81,9 +81,11 @@ public class DirectoryListing {
             out.write(dateFormatter.format(lastm));
         }
         out.write("</td><td>");
-        // if (isDir) {
+        if (child.isDirectory()) {
+            out.write("-");
+        } else {
             out.write(Util.readableSize(child.length()));
-        // }
+        }
         out.write("</td>");
     }
 

--- a/src/org/opensolaris/opengrok/web/DirectoryListing.java
+++ b/src/org/opensolaris/opengrok/web/DirectoryListing.java
@@ -44,6 +44,7 @@ import org.opensolaris.opengrok.index.IgnoredNames;
  */
 public class DirectoryListing {
 
+    protected final static String DIRECTORY_SIZE_PLACEHOLDER = "-";
     private final EftarFileReader desc;
     private final long now;
 
@@ -82,7 +83,7 @@ public class DirectoryListing {
         }
         out.write("</td><td>");
         if (child.isDirectory()) {
-            out.write("-");
+            out.write(DIRECTORY_SIZE_PLACEHOLDER);
         } else {
             out.write(Util.readableSize(child.length()));
         }

--- a/test/org/opensolaris/opengrok/web/DirectoryListingTest.java
+++ b/test/org/opensolaris/opengrok/web/DirectoryListingTest.java
@@ -85,7 +85,7 @@ public class DirectoryListingTest {
             assertTrue("Failed to set modification time",
                        file.setLastModified(val));
 
-            try {
+            if (!"-".equals(size)) {
                 int s = Integer.parseInt(size);
                 if (s > 0) {
                     FileOutputStream out = new FileOutputStream(file);
@@ -93,7 +93,6 @@ public class DirectoryListingTest {
                     out.write(buffer);
                     out.close();
                 }
-            } catch (NumberFormatException e) {
             }
         }
 


### PR DESCRIPTION
fixes #1552

Replaced with '-'.

![screenshot from 2017-05-29 15-56-30](https://cloud.githubusercontent.com/assets/6997160/26552440/6b9d94e4-4487-11e7-8b09-9d1f21d0dc77.png)
![screenshot from 2017-05-29 15-56-36](https://cloud.githubusercontent.com/assets/6997160/26552441/6ba1e0da-4487-11e7-8ebc-6f58f9465bce.png)

Tablesorters return 0 for all directories (unparseable size):
```
        if (parts === null || parts.length < 3) {
            return 0;
        }
```