### PR TITLE
filtering the xref of '/' based on authorization

### DIFF
--- a/src/org/opensolaris/opengrok/web/PageConfig.java
+++ b/src/org/opensolaris/opengrok/web/PageConfig.java
@@ -380,8 +380,8 @@ public final class PageConfig {
      * that directory, sorted alphabetically
      *
      * <p>
-     * For the root directory (/xref/) an authorization is performed for each of
-     * the project in case that projects are used in OpenGrok.</p>
+     * For the root directory (/xref/) an authorization is performed for each
+     * project in case that projects are used.</p>
      *
      * @see #getResourceFile()
      * @see #isDir()


### PR DESCRIPTION
fixes #1610

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
