### PR TITLE
Improve UTF-8/16 BOM handling.

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/TextAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/TextAnalyzer.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import org.opensolaris.opengrok.util.IOUtils;
 
 public abstract class TextAnalyzer extends FileAnalyzer {
 
@@ -36,33 +37,6 @@ public abstract class TextAnalyzer extends FileAnalyzer {
     }
 
     protected Reader getReader(InputStream stream) throws IOException {
-        InputStream in = stream.markSupported() ?
-                stream : new BufferedInputStream(stream);
-
-        String charset = null;
-
-        in.mark(3);
-
-        byte[] head = new byte[3];
-        int br = in.read(head, 0, 3);
-
-        if (br >= 2
-                && (head[0] == (byte) 0xFE && head[1] == (byte) 0xFF)
-                || (head[0] == (byte) 0xFF && head[1] == (byte) 0xFE)) {
-            charset = "UTF-16";
-            in.reset();
-        } else if (br >= 3 && head[0] == (byte) 0xEF && head[1] == (byte) 0xBB
-                && head[2] == (byte) 0xBF) {
-            // InputStreamReader does not properly discard BOM on UTF8 streams,
-            // so don't reset the stream.
-            charset = "UTF-8";
-        }
-
-        if (charset == null) {
-            in.reset();
-            charset = Charset.defaultCharset().name();
-        }
-
-        return new InputStreamReader(in, charset);
+        return IOUtils.createBOMStrippedReader(stream);
     }
 }

--- a/src/org/opensolaris/opengrok/search/Results.java
+++ b/src/org/opensolaris/opengrok/search/Results.java
@@ -55,6 +55,7 @@ import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.history.HistoryException;
 import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.util.IOUtils;
 import org.opensolaris.opengrok.web.Prefix;
 import org.opensolaris.opengrok.web.SearchHelper;
 import org.opensolaris.opengrok.web.Util;
@@ -118,10 +119,11 @@ public final class Results {
                     File basedir, String path, boolean compressed)
             throws IOException {
         if (compressed) {
-            return new BufferedReader(new InputStreamReader(new GZIPInputStream(
-                    new FileInputStream(new File(basedir, path + ".gz")))));
+            return new BufferedReader(IOUtils.createBOMStrippedReader(
+                    new GZIPInputStream(new FileInputStream(new File(basedir, path + ".gz")))));
         } else {
-            return new BufferedReader(new FileReader(new File(basedir, path)));
+            return new BufferedReader(IOUtils.createBOMStrippedReader(
+                    new FileInputStream(new File(basedir, path))));
         }
     }
 
@@ -233,8 +235,8 @@ public final class Results {
                         String htags = getTags(sh.sourceRoot, rpath, false);
                         out.write(sh.summarizer.getSummary(htags).toString());
                     } else {
-                        FileReader r = genre == Genre.PLAIN
-                                ? new FileReader(new File(sh.sourceRoot, rpath))
+                        Reader r = genre == Genre.PLAIN
+                                ? IOUtils.createBOMStrippedReader(new FileInputStream(new File(sh.sourceRoot, rpath)))
                                 : null;
                         sh.sourceContext.getContext(r, out, xrefPrefix, morePrefix, 
                                 rpath, tags, true, sh.builder.isDefSearch(), null, scopes);

--- a/src/org/opensolaris/opengrok/web/PageConfig.java
+++ b/src/org/opensolaris/opengrok/web/PageConfig.java
@@ -267,7 +267,7 @@ public final class PageConfig {
                 Project p = getProject();
                 for (int i = 0; i < 2; i++) {
                     try (BufferedReader br = new BufferedReader(
-                            ExpandTabsReader.wrap(new InputStreamReader(in[i]), p))) {
+                            ExpandTabsReader.wrap(IOUtils.createBOMStrippedReader(in[i]), p))) {
                         String line;
                         while ((line = br.readLine()) != null) {
                             lines.add(line);

--- a/web/list.jsp
+++ b/web/list.jsp
@@ -45,6 +45,7 @@ org.opensolaris.opengrok.analysis.FileAnalyzer.Genre,
 org.opensolaris.opengrok.analysis.FileAnalyzerFactory,
 org.opensolaris.opengrok.history.Annotation,
 org.opensolaris.opengrok.index.IndexDatabase,
+org.opensolaris.opengrok.util.IOUtils,
 org.opensolaris.opengrok.web.DirectoryListing"
 %><%
 {
@@ -180,7 +181,7 @@ Binary file [Click <a href="<%= rawPath %>?r=<%= Util.URIEncode(rev) %>">here</a
                             Annotation annotation = cfg.getAnnotation();
                             //not needed yet
                             //annotation.writeTooltipMap(out);
-                            r = new InputStreamReader(in);
+                            r = IOUtils.createBOMStrippedReader(in);
                             AnalyzerGuru.writeXref(a, r, out, defs,
                                 annotation, Project.getProject(resourceFile));
                         } else if (g == Genre.IMAGE) {
@@ -267,7 +268,7 @@ Binary file [Click <a href="<%= rawPath %>?r=<%= Util.URIEncode(rev) %>">here</a
                     // find the definitions in the index.
                     Definitions defs = IndexDatabase.getDefinitions(resourceFile);
                     Annotation annotation = cfg.getAnnotation();
-                    r = new InputStreamReader(bin);
+                    r = IOUtils.createBOMStrippedReader(bin);
                     AnalyzerGuru.writeXref(a, r, out, defs, annotation,
                         Project.getProject(resourceFile));
     %></pre>

--- a/web/more.jsp
+++ b/web/more.jsp
@@ -23,14 +23,16 @@ Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 
 --%><%@page errorPage="error.jsp" import="
-java.io.FileReader,
+java.io.FileInputStream,
+java.io.Reader,
 java.util.logging.Level,
 java.util.logging.Logger,
 
 org.apache.lucene.search.Query,
 org.opensolaris.opengrok.search.QueryBuilder,
 org.opensolaris.opengrok.search.context.Context,
-org.opensolaris.opengrok.logger.LoggerFactory"
+org.opensolaris.opengrok.logger.LoggerFactory,
+org.opensolaris.opengrok.util.IOUtils"
 %>
 <%
 {
@@ -54,7 +56,9 @@ file="mast.jsp"
 %><p><span class="pagetitle">Lines Matching <b><%= tquery %></b></span></p>
 <div id="more" style="line-height:1.5em;">
     <pre><%
-            sourceContext.getContext(new FileReader(cfg.getResourceFile()), out,
+            Reader r = IOUtils.createBOMStrippedReader(
+                    new FileInputStream(cfg.getResourceFile()));
+            sourceContext.getContext(r, out,
                 request.getContextPath() + Prefix.XREF_P, null, cfg.getPath(),
                 null, false, false, null, null);
     %></pre>


### PR DESCRIPTION
Currently OpenGrok recognizes UTF-8/16 BOM only in `/xref` without parameter such as revision or annotate.
This patch enable to handle it in `/xref` (with any parameter),  `/search` and `/diff` in same way.

I have already signed OCA.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
