### PR TITLE
removing the input file from empty subcommand 

### DIFF
--- a/tools/Groups
+++ b/tools/Groups
@@ -249,25 +249,18 @@ Empty ()
     LocalUsage()
     {
         echo "Usage:"
-        echo "${PROGNAME} empty [-i|--input <file>] [-v|--verbose] [-d]"
+        echo "${PROGNAME} empty [-v|--verbose] [-d]"
         echo ""
-        echo "  Creates an empty configuration. If the input file is specified"
-        echo "  it directly outputs the given file."
+        echo "  Creates an empty configuration."
         echo ""
         echo "Options:"
         echo " -d option performs dry run with verbose mode"
-        echo " -i option can be used for specifying the input file"
     }
 
     while [ $# -gt 0 ]
     do
         opt="$1"
         case $opt in
-            -i|--input)
-                ExpectOption "$@"
-                shift
-                INPUT_FILE=$(OneArgument "$@")
-            ;;
             -d)
                 DO=echo
                 VERBOSE=true
@@ -292,6 +285,7 @@ Empty ()
     done
 
     EMPTY=true
+    unset INPUT_FILE
 
     CheckInputFile
     Info


### PR DESCRIPTION
The input file does not really make sense for the empty subcommand so I decided to remove it

fixes #1624

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
