### PR TITLE
relaxing the constraint of non-empty pattern

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/Groups.java
+++ b/src/org/opensolaris/opengrok/configuration/Groups.java
@@ -168,7 +168,10 @@ public final class Groups {
             deleteGroup(cfg.getGroups(), groupname);
             out = prepareOutput(outFile);
             printOut(list, cfg, out);
-        } else if (groupname != null && grouppattern != null) {
+        } else if (groupname != null) {
+            if (grouppattern == null) {
+                grouppattern = "";
+            }
             // perform insert/update. parent may be null
             if (!modifyGroup(cfg.getGroups(), groupname, grouppattern, parent)) {
                 System.err.println("Parent group does not exist \"" + parent + "\"");

--- a/tools/Groups
+++ b/tools/Groups
@@ -448,7 +448,6 @@ Add ()
     done
 
     [ -z "$NAME" ] && echo "name must be specified" && LocalUsage && exit 5
-    [ -z "$PATTERN" ] && echo "pattern must be specified" && LocalUsage && exit 5
 
     CheckInputFile
     Info


### PR DESCRIPTION
fixes #1626

The constraint prevents user from creating a parent group without any pattern (a group which won't match anything).

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
