### PR TITLE
fixed header instead of javascript content height resize action

### DIFF
--- a/src/org/opensolaris/opengrok/web/Scripts.java
+++ b/src/org/opensolaris/opengrok/web/Scripts.java
@@ -125,9 +125,9 @@ public class Scripts implements Iterable<Scripts.Script> {
         SCRIPTS.put("jquery-tablesorter", new FileScript("js/jquery-tablesorter-2.26.6.min.js", 12));
         SCRIPTS.put("tablesorter-parsers", new FileScript("js/tablesorter-parsers-0.0.1.js", 13));
         SCRIPTS.put("searchable-option-list", new FileScript("js/searchable-option-list-2.0.3.min.js", 14));
-        SCRIPTS.put("utils", new FileScript("js/utils-0.0.11.js", 15));
+        SCRIPTS.put("utils", new FileScript("js/utils-0.0.12.js", 15));
         SCRIPTS.put("repos", new FileScript("js/repos-0.0.1.js", 20));
-        SCRIPTS.put("diff", new FileScript("js/diff-0.0.1.js", 20));
+        SCRIPTS.put("diff", new FileScript("js/diff-0.0.2.js", 20));
     }
 
     /**

--- a/web/default/style.css
+++ b/web/default/style.css
@@ -3,7 +3,7 @@ body {
     background-color: #ffffff;
     color: black;
     font-family: sans-serif;
-    margin: 1ex 1ex 0 1ex;
+    margin: 0;
 }
 
 a {
@@ -243,6 +243,18 @@ label {
 /* ############### start of header ############## */
 #whole_header { }
 
+html.xref #whole_header,
+html.history #whole_header,
+html.more #whole_header,
+html.diff #whole_header {
+    position: fixed;
+    top: 0;
+    background: #ddd;
+    border-bottom: 5px solid #ddd;
+    height: 85px;
+    width: 100%;
+}
+
 /* *** banner/deco above navbar *** */
 #header { }
 
@@ -270,6 +282,9 @@ label {
     font-family: monospace; /* ala <kbd> */
     clear: left;
     margin-bottom: 1ex;
+    margin-left: 1ex;
+    margin-top: 1ex;
+    margin-right: 1ex;
 }
 
 #Masthead tt { /* slashes in the xref: line */
@@ -430,14 +445,13 @@ input.submit { /* start search button , clear button */
 
 /* ############### end of header ############## */
 
-
 /* ############### start of content ############## */
-#content {
-    position: fixed;
-    left: 0;
-    right: 0;
-    overflow: auto;
-    padding: 0 1ex 1ex 1ex; /* should be the same as body's margin */
+
+html.xref #content,
+html.diff #content,
+html.more #content,
+html.history #content{
+    margin-top: 90px;
 }
 
 /* *** help page *** */
@@ -821,7 +835,7 @@ a.scope            { /* scope              */ color: steelblue; font-weight: bol
 }
 
 .window {
-    position: absolute;
+    position: fixed;
     font-size: 12px;
     font-family: monospace;
     overflow: auto;

--- a/web/httpheader.jspf
+++ b/web/httpheader.jspf
@@ -47,7 +47,8 @@ org.opensolaris.opengrok.web.PageConfig"
 %><?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
+      class="<%= request.getServletPath().length() > 0 ? request.getServletPath().substring(1) : "" %>">
 <head>
 <meta name="robots" content="noindex,nofollow" />
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/web/js/diff-0.0.2.js
+++ b/web/js/diff-0.0.2.js
@@ -152,7 +152,7 @@
                  *  animationDuration: // duration of toggling the jumper window
                  * }
                  */
-                $parent: $("#difftable"),
+                $parent: $("#content"),
                 $content: $("#content"), // first scrollable div
                 chunkSelector: ".chunk",
                 addSelector: ".a",
@@ -186,8 +186,8 @@
                     if (this.options.scrollTop) {
                         this.options.scrollTop($el)
                     } else {
-                        $("#content").stop().animate({
-                            scrollTop: $el.offset().top - this.options.$parent.offset().top
+                        $('html, body').stop().animate({
+                            scrollTop: $el.position().top - this.options.$parent.offset().top
                         }, 500);
                     }
                     return this;

--- a/web/offwhite/style.css
+++ b/web/offwhite/style.css
@@ -3,7 +3,7 @@ body {
     background-color: #ededd5;
     color: black;
     font-family: sans-serif;
-    margin: 1ex 1ex 0 1ex;
+    margin: 0;
 }
 
 a {
@@ -244,6 +244,18 @@ label {
 /* ############### start of header ############## */
 #whole_header { }
 
+html.xref #whole_header,
+html.history #whole_header,
+html.more #whole_header,
+html.diff #whole_header {
+    position: fixed;
+    top: 0;
+    background: #FFFFE5;
+    border-bottom: 5px solid #FFFFE5;
+    height: 85px;
+    width: 100%;
+}
+
 /* *** banner/deco above navbar *** */
 #header { }
 
@@ -270,6 +282,9 @@ label {
     font-family: monospace; /* ala <kbd> */
     clear: left;
     margin-bottom: 1ex;
+    margin-left: 1ex;
+    margin-top: 1ex;
+    margin-right: 1ex;
 }
 
 #Masthead tt { /* slashes in the xref: line */
@@ -277,11 +292,14 @@ label {
 }
 
 #sbar, #bar { /* full search and default navbar */
-    border-bottom: 1px solid #bba;
     border-top: 1px solid #bba;
     background-color: #FFFFE5;
     margin: 0;
     clear: both;
+}
+
+#sbar { /* full search */
+    border-bottom: 1px solid #bba;
 }
 
 /* *** full search navbar *** */
@@ -469,14 +487,13 @@ input.submit { /* start search button */
 
 
 /* ############### start of content ############## */
-#content {
-    position: fixed;
-    left: 0;
-    right: 0;
-    overflow: auto;
-    padding: 0 1ex 1ex 1ex; /* should be the same as body's margin */
-}
 
+html.xref #content,
+html.diff #content,
+html.more #content,
+html.history #content{
+    margin-top: 90px;
+}
 
 /* *** help page *** */
 #help h4 {
@@ -866,7 +883,7 @@ a.scope            { /* scope              */ color: steelblue; font-weight: bol
 }
 
 .window {
-    position: absolute;
+    position: fixed;
     font-size: 12px;
     font-family: monospace;
     overflow: auto;

--- a/web/polished/style.css
+++ b/web/polished/style.css
@@ -3,7 +3,7 @@ body {
     background-color: #d8dbd7;
     color: black;
     font-family: sans-serif;
-    margin: 1ex 1ex 0 1ex;
+    margin: 0;
 }
 
 a {
@@ -264,9 +264,20 @@ label {
     background-color: white;
 }
 
+html.xref #whole_header,
+html.history #whole_header,
+html.more #whole_header,
+html.diff #whole_header {
+    position: fixed;
+    top: 0;
+    background: #e9ede8;
+    border-bottom: 5px solid #e9ede8;
+    height: 85px;
+    width: 100%;
+}
+
 /* *** banner/deco above navbar *** */
 #header {
-    display: inline-block;
     width: 100%;
     background-image: -webkit-gradient(
         linear, left bottom, left top,
@@ -304,7 +315,9 @@ label {
     clear: left;
     background-color: #426477;
     border: 1px solid #bbb;
-    margin-bottom: 1ex;
+    margin-left: 1ex;
+    margin-right: 1ex;
+    margin-top: 1ex;
 }
 
 #Masthead tt { /* slashes in the xref: line */
@@ -316,12 +329,15 @@ label {
 }
 
 #sbar, #bar { /* full search and default navbar */
-    border-bottom: 1px solid #bba;
     border-top: 1px solid #bba;
     background-color: #e9ede8;
     margin: 0;
     padding: 1ex 0;
     clear: both;
+}
+
+#sbar { /* full search */
+    border-bottom: 1px solid #bba;
 }
 
 /* *** full search navbar *** */
@@ -415,7 +431,8 @@ label {
 
 /* *** default navbar *** */
 #bar {
-    padding: 0.2em 0.5em;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
 }
 
 #bar ul { /* every list item is displayed as a "menu" item */
@@ -518,14 +535,13 @@ button.help {
 
 
 /* ############### start of content ############## */
-#content {
-    position: fixed;
-    left: 0;
-    right: 0;
-    overflow: auto;
-    padding: 0 1ex 1ex 1ex; /* should be the same as body's margin */
-}
 
+html.xref #content,
+html.diff #content,
+html.more #content,
+html.history #content{
+    margin-top: 90px;
+}
 
 /* *** help page *** */
 #help h4 {
@@ -921,7 +937,7 @@ a.scope            { /* scope              */ color: steelblue; font-weight: bol
 }
 
 .window {
-    position: absolute;
+    position: fixed;
     font-size: 12px;
     font-family: monospace;
     overflow: auto;


### PR DESCRIPTION
fixes #1488
might fix #1288

I removed the silly content resize javascript and introduced a fixed header for all code related pages. The rest of the changes in the js code are just changes to make it work with the new fixed header.

The result of this change is that viewing a file is still available even if any of our javascript beauty fails when executing.

Anyway I had to introduce a new color for the header because it looks quite ugly when it's white and there is a space between the line number (the header must have a fixed height).

![screenshot from 2017-07-07 14-18-37](https://user-images.githubusercontent.com/6997160/27957563-3ae855a8-631f-11e7-8375-4e73f2712dab.png)
![screenshot from 2017-07-07 14-18-51](https://user-images.githubusercontent.com/6997160/27957562-3ae5a0ba-631f-11e7-88e1-1f5fbf2b7025.png)


