### PR TITLE
removing an extra div - valid main page

### DIFF
--- a/web/index.jsp
+++ b/web/index.jsp
@@ -57,7 +57,6 @@ include file="menu.jspf"
         </div>
         <div id="results">
             <%= PageConfig.get(request).getEnv().getConfiguration().getBodyIncludeFileContent() %>
-        </div>
         <%@
 
 include file="repos.jspf"


### PR DESCRIPTION
fixes #1509 

There was an extra div added in cset dc26274 by an accident making the main page invalid.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
