### PR TITLE
use ctags binary from RuntimeEnvironment in IndexerRepoTest.java

### DIFF
--- a/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
@@ -87,7 +87,7 @@ public class IndexerRepoTest {
             Indexer.main(argv);
             checkNumberOfThreads();
         } else {
-            System.out.println("Skipping test. Could not find a ctags I could use in path.");
+            System.out.println("Skipping test. Could not find a ctags I could use.");
         }
     }
 
@@ -102,7 +102,7 @@ public class IndexerRepoTest {
             Indexer.main(argv);
             checkNumberOfThreads();
         } else {
-            System.out.println("Skipping test. Could not find a ctags I could use in path.");
+            System.out.println("Skipping test. Could not find a ctags I could use.");
         }
     }
 }

--- a/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
@@ -69,7 +69,7 @@ public class IndexerRepoTest {
         Thread[] threads = new Thread[mainGroup.activeCount()];
         mainGroup.enumerate(threads);
         for (int i = 0; i < threads.length; i++) {
-            if (threads[i].getName() == null) {
+            if (threads[i] == null || threads[i].getName() == null) {
                 continue;
             }
             assertEquals(false, threads[i].getName().contains("renamed-handling"));

--- a/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
@@ -46,16 +46,6 @@ public class IndexerRepoTest {
     TestRepository repository;
     private final String ctagsProperty = "org.opensolaris.opengrok.analysis.Ctags";
 
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-        assertTrue("No point in running indexer tests without valid ctags",
-                RuntimeEnvironment.getInstance().validateExuberantCtags());
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-
     @Before
     public void setUp() throws IOException {
         repository = new TestRepository();
@@ -93,7 +83,7 @@ public class IndexerRepoTest {
         env.setCtags(System.getProperty(ctagsProperty, "ctags"));
         if (env.validateExuberantCtags()) {
             String[] argv = {"-S", "-H", "-s", repository.getSourceRoot(),
-                "-d", repository.getDataRoot(), "-v"};
+                "-d", repository.getDataRoot(), "-v", "-c", env.getCtags()};
             Indexer.main(argv);
             checkNumberOfThreads();
         } else {
@@ -108,7 +98,7 @@ public class IndexerRepoTest {
         env.setCtags(System.getProperty(ctagsProperty, "ctags"));
         if (env.validateExuberantCtags()) {
             String[] argv = {"-S", "-P", "-s", repository.getSourceRoot(),
-                "-d", repository.getDataRoot(), "-v"};
+                "-d", repository.getDataRoot(), "-v", "-c", env.getCtags()};
             Indexer.main(argv);
             checkNumberOfThreads();
         } else {


### PR DESCRIPTION
When investigating #1666 I found out that ctags binary executed by tests in  IndexerRepoTest.java is not necessarily the one set by `setCtags()` in these tests. This is because the indexer is run via `Indexer.main()` with distinct set of args that are supplied directly so settings in RuntimeEnvironment such as ctags binary do not get into effect unless specified as these args.

Also, given ctags are checked in individual tests, the `@BeforeClass` check is unnecessary.