### PR TITLE
project customizations in read-only configuration

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -39,7 +39,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -358,6 +357,9 @@ public final class Configuration {
      * Creates a new instance of Configuration
      */
     public Configuration() {
+        /**
+         * This list of calls is sorted alphabetically so please keep it.
+         */
         // defaults for an opengrok instance configuration
         cmds = new HashMap<>();
         setAllowedSymlinks(new HashSet<>());

--- a/src/org/opensolaris/opengrok/configuration/Project.java
+++ b/src/org/opensolaris/opengrok/configuration/Project.java
@@ -63,9 +63,9 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     private boolean navigateWindowEnabled = false;
 
     /**
-     * This marks the project as (not)ready before initial index is done.
-     * this is to avoid all/multi-project searches referencing this project
-     * from failing.
+     * This marks the project as (not)ready before initial index is done. this
+     * is to avoid all/multi-project searches referencing this project from
+     * failing.
      */
     private boolean indexed = false;
 
@@ -78,13 +78,38 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     public Project() {
     }
 
+    /**
+     * Create a project with given name.
+     *
+     * @param name the name of the project
+     */
     public Project(String name) {
         this.name = name;
     }
 
+    /**
+     * Create a project with given name and path
+     *
+     * @param name the name of the project
+     * @param path the path of the project relative to the source root
+     */
     public Project(String name, String path) {
         this.name = name;
         this.path = path;
+    }
+
+    /**
+     * Create a project with given name and path and default configuration
+     * values.
+     *
+     * @param name the name of the project
+     * @param path the path of the project relative to the source root
+     * @param cfg configuration containing the default values for project
+     * properties
+     */
+    public Project(String name, String path, Configuration cfg) {
+        this(name, path);
+        completeWithDefaults(cfg);
     }
 
     /**
@@ -220,6 +245,29 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
         while (group != null) {
             this.groups.add(group);
             group = group.getParent();
+        }
+    }
+
+    /**
+     * Fill the project with the current configuration where the applicable
+     * project property has a default value.
+     *
+     * @param cfg configuration with default values if applicable
+     */
+    final public void completeWithDefaults(Configuration cfg) {
+        Configuration defaultCfg = new Configuration();
+        /**
+         * Choosing strategy for properties (tabSize here):
+         * <pre>
+         * this       cfg        defaultCfg
+         * ===========================================
+         *  |5|        4             0
+         *   0        |4|            0
+         *   0         0            |0|
+         * </pre>
+         */
+        if (getTabSize() == defaultCfg.getTabSize()) {
+            setTabSize(cfg.getTabSize());
         }
     }
 

--- a/src/org/opensolaris/opengrok/configuration/Project.java
+++ b/src/org/opensolaris/opengrok/configuration/Project.java
@@ -259,12 +259,15 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
         /**
          * Choosing strategy for properties (tabSize here):
          * <pre>
-         * this       cfg        defaultCfg
-         * ===========================================
-         *  |5|        4             0
-         *   0        |4|            0
-         *   0         0            |0|
+         * this       cfg        defaultCfg   chosen value
+         * ===============================================
+         *  |5|        4             0             5
+         *   0        |4|            0             4
          * </pre>
+         *
+         * The strategy is:
+         * 1) if the project has some non-default value; use that
+         * 2) if the project has a default value; use the provided configuration
          */
         if (getTabSize() == defaultCfg.getTabSize()) {
             setTabSize(cfg.getTabSize());

--- a/src/org/opensolaris/opengrok/index/Indexer.java
+++ b/src/org/opensolaris/opengrok/index/Indexer.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
@@ -172,6 +173,16 @@ public final class Indexer {
             for (int optind=0; optind< argv.length; optind++) {
                 String path = Paths.get(cfg.getSourceRoot(), argv[optind]).toString();
                 subFilesList.add(path);
+            }
+
+            // If an user used customizations for projects he perhaps just
+            // used the key value for project without a name but the code
+            // expects a name for the project. Therefore we fill the name
+            // according to the project key which is the same.
+            for (Entry<String, Project> entry : cfg.getProjects().entrySet()) {
+                if (entry.getValue().getName() == null) {
+                    entry.getValue().setName(entry.getKey());
+                }
             }
 
             // Set updated configuration in RuntimeEnvironment.
@@ -884,13 +895,15 @@ public final class Indexer {
                     // This is an existing object. Reuse the old project,
                     // possibly with customizations, instead of creating a
                     // new with default values.
-                    projects.put(name, oldProjects.get(name));
+                    Project p = oldProjects.get(name);
+                    p.setPath(path);
+                    p.setName(name);
+                    p.completeWithDefaults(env.getConfiguration());
+                    projects.put(name, p);
                 } else if (!name.startsWith(".") && file.isDirectory()) {
                     // Found a new directory with no matching project, so
                     // create a new project with default properties.
-                    Project p = new Project(name, path);
-                    p.setTabSize(env.getConfiguration().getTabSize());
-                    projects.put(p.getName(), p);
+                    projects.put(name, new Project(name, path, env.getConfiguration()));
                 }
             }
         }

--- a/test/org/opensolaris/opengrok/configuration/ProjectTest.java
+++ b/test/org/opensolaris/opengrok/configuration/ProjectTest.java
@@ -17,10 +17,9 @@
  * CDDL HEADER END
  */
 
-/*
+ /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
  */
-
 package org.opensolaris.opengrok.configuration;
 
 import java.beans.ExceptionListener;
@@ -28,8 +27,6 @@ import java.beans.XMLDecoder;
 import java.beans.XMLEncoder;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -39,9 +36,10 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class ProjectTest {
+
     /**
-     * Test that a {@code Project} instance can be encoded and decoded
-     * without errors. Bug #3077.
+     * Test that a {@code Project} instance can be encoded and decoded without
+     * errors. Bug #3077.
      */
     @Test
     public void testEncodeDecode() {
@@ -96,7 +94,7 @@ public class ProjectTest {
         Project bar = new Project("Project foo-bar", "/foo-bar");
 
         // Make the runtime environment aware of these two projects.
-        HashMap<String,Project> projects = new HashMap<>();
+        HashMap<String, Project> projects = new HashMap<>();
         projects.put("foo", foo);
         projects.put("bar", bar);
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
@@ -122,7 +120,7 @@ public class ProjectTest {
         Project bar = new Project("bar", "/bar");
 
         // Make the runtime environment aware of these two projects.
-        HashMap<String,Project> projects = new HashMap<>();
+        HashMap<String, Project> projects = new HashMap<>();
         projects.put("foo", foo);
         projects.put("bar", bar);
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
@@ -133,5 +131,53 @@ public class ProjectTest {
         assertTrue(descs.contains("bar"));
         assertFalse(descs.contains("foobar"));
         assertEquals(2, descs.size());
+    }
+
+    /**
+     * Insert the value from configuration.
+     */
+    @Test
+    public void testMergeProjects1() {
+        Configuration cfg = new Configuration();
+        cfg.setTabSize(8);
+
+        Project p1 = new Project();
+        p1.setNavigateWindowEnabled(true);
+
+        p1.completeWithDefaults(cfg);
+
+        assertNotNull(p1);
+        assertTrue("Navigate window should be turned on", p1.isNavigateWindowEnabled());
+        assertEquals(8, p1.getTabSize());
+    }
+
+    /**
+     * Do not overwrite customized project property.
+     */
+    @Test
+    public void testMergeProjects2() {
+        Configuration cfg = new Configuration();
+        cfg.setTabSize(4);
+
+        Project p1 = new Project();
+        p1.setTabSize(5);
+
+        p1.completeWithDefaults(cfg);
+
+        assertNotNull(p1);
+        assertEquals(5, p1.getTabSize());
+    }
+
+    /**
+     * Create a project fill with defaults from the configuration.
+     */
+    @Test
+    public void testCreateProjectWithConfiguration() {
+        Configuration cfg = new Configuration();
+        cfg.setTabSize(4);
+
+        Project p1 = new Project("a", "/a", cfg);
+
+        assertEquals(cfg.getTabSize(), p1.getTabSize());
     }
 }

--- a/test/org/opensolaris/opengrok/configuration/ProjectTest.java
+++ b/test/org/opensolaris/opengrok/configuration/ProjectTest.java
@@ -139,7 +139,7 @@ public class ProjectTest {
     @Test
     public void testMergeProjects1() {
         Configuration cfg = new Configuration();
-        cfg.setTabSize(8);
+        cfg.setTabSize(new Configuration().getTabSize() + 3731);
 
         Project p1 = new Project();
         p1.setNavigateWindowEnabled(true);
@@ -148,7 +148,7 @@ public class ProjectTest {
 
         assertNotNull(p1);
         assertTrue("Navigate window should be turned on", p1.isNavigateWindowEnabled());
-        assertEquals(8, p1.getTabSize());
+        assertEquals(new Configuration().getTabSize() + 3731, p1.getTabSize());
     }
 
     /**
@@ -157,15 +157,15 @@ public class ProjectTest {
     @Test
     public void testMergeProjects2() {
         Configuration cfg = new Configuration();
-        cfg.setTabSize(4);
+        cfg.setTabSize(new Configuration().getTabSize() + 3731);
 
         Project p1 = new Project();
-        p1.setTabSize(5);
+        p1.setTabSize(new Project().getTabSize() + 9737);
 
         p1.completeWithDefaults(cfg);
 
         assertNotNull(p1);
-        assertEquals(5, p1.getTabSize());
+        assertEquals(new Project().getTabSize() + 9737, p1.getTabSize());
     }
 
     /**


### PR DESCRIPTION
User can specify project customizations in read only configuration by opening the `projects` property and filling the map entry according to the project name and desired customizations.

```xml
  <void property="projects">
   <void method="put">
    <string>OpenGrok</string>
    <object class="org.opensolaris.opengrok.configuration.Project">
     <void property="navigateWindowEnabled">
      <boolean>true</boolean>
     </void>
    </object>
   </void>
  </void>
```