### PR TITLE
Ignore files generated by IntelliJ IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ cov-int.zip
 cov-int/*
 egrok/bin
 pmd.bat
+*.iml
+.idea


### PR DESCRIPTION
Ignore the files that has been generated by IntelliJ IDEA. These files are typically specific to the device where the IDE has been opened on.

I have accepted the OCA agreement and have mailed Oracle the signed copy.
