### PR TITLE
Added support for paginating the JSONSearchServlet

### DIFF
--- a/src/org/opensolaris/opengrok/web/JSONSearchServlet.java
+++ b/src/org/opensolaris/opengrok/web/JSONSearchServlet.java
@@ -124,15 +124,12 @@ public class JSONSearchServlet extends HttpServlet {
 
             int pageStart = getIntParameter(req, PARAM_START, 0);
 
-            int maxResults = MAX_RESULTS;
-            String maxResultsParam = req.getParameter(PARAM_MAXRESULTS);
+            Integer maxResultsParam = getIntParameter(req, PARAM_MAXRESULTS, null);
+            int maxResults = maxResultsParam == null ? MAX_RESULTS : maxResultsParam;
             if (maxResultsParam != null) {
-                try {
-                    maxResults = Integer.parseInt(maxResultsParam);
-                    result.put(PARAM_MAXRESULTS, maxResults);
-                } catch (NumberFormatException ex) {
-                }
+                result.put(PARAM_MAXRESULTS, maxResults);
             }
+
             List<Hit> results = new ArrayList<>(maxResults);
             engine.results(pageStart,
                     numResults > maxResults ? maxResults : numResults, results);
@@ -175,7 +172,7 @@ public class JSONSearchServlet extends HttpServlet {
      * @return The integer value of the request param if present or the
      *         defaultValue if none is present.
      */
-    private static int getIntParameter(final HttpServletRequest request, final String paramName, final int defaultValue) {
+    private static Integer getIntParameter(final HttpServletRequest request, final String paramName, final Integer defaultValue) {
         final String paramValue = request.getParameter(paramName);
         if (paramValue == null) {
             return defaultValue;

--- a/src/org/opensolaris/opengrok/web/JSONSearchServlet.java
+++ b/src/org/opensolaris/opengrok/web/JSONSearchServlet.java
@@ -46,6 +46,7 @@ public class JSONSearchServlet extends HttpServlet {
     private static final String PARAM_SYMBOL = "symbol";
     private static final String PARAM_PATH = "path";
     private static final String PARAM_HIST = "hist";
+    private static final String PARAM_START = "start";
     private static final String PARAM_MAXRESULTS = "maxresults";
     private static final String PARAM_PROJECT = "project";
     private static final String ATTRIBUTE_DIRECTORY = "directory";
@@ -120,6 +121,9 @@ public class JSONSearchServlet extends HttpServlet {
             } else {
                 numResults = engine.search(req, projects);
             }
+
+            int pageStart = getIntParameter(req, PARAM_START, 0);
+
             int maxResults = MAX_RESULTS;
             String maxResultsParam = req.getParameter(PARAM_MAXRESULTS);
             if (maxResultsParam != null) {
@@ -130,7 +134,7 @@ public class JSONSearchServlet extends HttpServlet {
                 }
             }
             List<Hit> results = new ArrayList<>(maxResults);
-            engine.results(0,
+            engine.results(pageStart,
                     numResults > maxResults ? maxResults : numResults, results);
             JSONArray resultsArray = new JSONArray();
             for (Hit hit : results) {
@@ -158,5 +162,29 @@ public class JSONSearchServlet extends HttpServlet {
         } finally {
             engine.destroy();
         }
+    }
+
+    /**
+     * Convenience utility for consistently getting and parsing an integer
+     * parameter from the provided {@link HttpServletRequest}.
+     *
+     * @param request The request to extract the parameter from
+     * @param paramName The name of the parameter on the request.
+     * @param defaultValue The default value to use when no value is
+     *                     provided or parsing fails.
+     * @return The integer value of the request param if present or the
+     *         defaultValue if none is present.
+     */
+    private static int getIntParameter(final HttpServletRequest request, final String paramName, final int defaultValue) {
+        final String paramValue = request.getParameter(paramName);
+        if (paramValue == null) {
+            return defaultValue;
+        }
+
+        try {
+            return Integer.valueOf(paramValue);
+        } catch (final NumberFormatException ignored) {}
+
+        return defaultValue;
     }
 }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

Right now, this search servlet doesn't support paginating results. This can be problematic for large code bases that have more then the hard configured limit of MAXRESULTS. Paginating will keep the endpoint performant and allow these larger companies to get at data easily.