### PR TITLE
cache history for top-level directory in repository

### DIFF
--- a/src/org/opensolaris/opengrok/history/HistoryEntry.java
+++ b/src/org/opensolaris/opengrok/history/HistoryEntry.java
@@ -209,10 +209,24 @@ public class HistoryEntry {
     }
 
     /**
-     * Remove "unneeded" info such as multiline history and files list
+     * Remove list of files and tags.
      */
     public void strip() {
+        stripFiles();
+        stripTags();
+    }
+
+    /**
+     * Remove list of files.
+     */
+    public void stripFiles() {
         files.clear();
+    }
+
+    /**
+     * Remove tags.
+     */
+    public void stripTags() {
         tags = null;
     }
 }


### PR DESCRIPTION
This change caches history of the top-level directory of repository. This is easy to do since the history is available anyway to generate per-file history cache. New history will be incrementally merged with existing cache upon reindex.