### PR TITLE
Replace long-defunct example of OpenGrok user

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 	<p>
 	Some of OpenGrok users:
 	<a href="http://nxr.netbsd.org/">NetBSD</a>,
-	<a href="http://svn.services.openoffice.org/opengrok/">OpenOffice</a>,
+	<a href="https://opengrok.libreoffice.org">LibreOffice</a>,
 	<a href="http://lxr.php.net/">PHP</a>,
 	<a href="http://grok.openkomodo.com/">Openkomodo</a>,
 	<a href="http://src.illumos.org/source/">Illumos</a>


### PR DESCRIPTION
I release this trivial patch to the public domain.