### PR TITLE
do not rely on readlink

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -134,8 +134,8 @@ else
 	exit 1
 fi
 
-SCRIPT_FILE=`readlink -f "${0}"`
-SCRIPT_DIRECTORY=`dirname "${SCRIPT_FILE}"`
+SCRIPT_DIRECTORY=`dirname "${0}"`
+export SCRIPT_DIRECTORY=`cd "${SCRIPT_DIRECTORY}"; pwd -P`
 
 #
 # Default Instance Configuration


### PR DESCRIPTION
@nerakhon complained that stock macOS cannot run the `OpenGrok` script because it is missing `readlink` (which is from GNU utilities). Reverting to the previous version except added the `-P` option to `pwd` which is not POSIX compliant however should be omnipresent in today's Unices.

The difference between the `pwd -P` and `readlink -f` approach is that the latter resolves symlinks in the basename while the former does not, i.e. if both `bar` and `OpenGrok` components are symlinks in `/tmp/bar/OpenGrok`, and the canonical path is `/tmp/foo/blah`, the result from the proposed approach will be `/tmp/foo/OpenGrok` while `readlink -f` will output `/tmp/foo/blah`. That said, for the script itself it should not matter, I am just including it for completeness.