### PR TITLE
refresh current version of project's repositories upon "indexed" message

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/messages/ProjectMessage.java
+++ b/src/org/opensolaris/opengrok/configuration/messages/ProjectMessage.java
@@ -34,6 +34,8 @@ import java.util.stream.Collectors;
 import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.history.HistoryGuru;
+import org.opensolaris.opengrok.history.Repository;
+import static org.opensolaris.opengrok.history.RepositoryFactory.getRepository;
 import org.opensolaris.opengrok.history.RepositoryInfo;
 import org.opensolaris.opengrok.index.IndexDatabase;
 import org.opensolaris.opengrok.logger.LoggerFactory;
@@ -204,6 +206,19 @@ public class ProjectMessage extends Message {
                     Project project;
                     if ((project = env.getProjects().get(projectName)) != null) {
                         project.setIndexed(true);
+
+                        // Refresh current version of the project's repositories.
+                        for (RepositoryInfo ri : env.getProjectRepositoriesMap().get(project)) {
+                            Repository repo = getRepository(ri);
+
+                            if (repo != null && repo.getCurrentVersion() != null &&
+                                repo.getCurrentVersion().length() > 0) {
+                                    // getRepository() always creates fresh instance
+                                    // of the Repository object so there is no need
+                                    // to call setCurrentVersion() on it.
+                                    ri.setCurrentVersion(repo.determineCurrentVersion());
+                            }
+                        }
                     } else {
                         LOGGER.log(Level.WARNING, "cannot find project " +
                                projectName + " to mark as indexed");

--- a/src/org/opensolaris/opengrok/history/GitRepository.java
+++ b/src/org/opensolaris/opengrok/history/GitRepository.java
@@ -707,7 +707,7 @@ public class GitRepository extends Repository {
     private static final SimpleDateFormat outputDateFormat = new SimpleDateFormat("YYYY-MM-dd HH:mm");
 
     @Override
-    String determineCurrentVersion() throws IOException {
+    public String determineCurrentVersion() throws IOException {
         File directory = new File(directoryName);
         List<String> cmd = new ArrayList<>();
         // The delimiter must not be contained in the date format emitted by

--- a/src/org/opensolaris/opengrok/history/MercurialRepository.java
+++ b/src/org/opensolaris/opengrok/history/MercurialRepository.java
@@ -702,7 +702,7 @@ public class MercurialRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion() throws IOException {
+    public String determineCurrentVersion() throws IOException {
         String line = null;
         File directory = new File(directoryName);
 

--- a/src/org/opensolaris/opengrok/history/Repository.java
+++ b/src/org/opensolaris/opengrok/history/Repository.java
@@ -400,7 +400,7 @@ public abstract class Repository extends RepositoryInfo {
      *
      * @return the version
      */
-    String determineCurrentVersion() throws IOException {
+    public String determineCurrentVersion() throws IOException {
         return null;
     }
 

--- a/src/org/opensolaris/opengrok/history/RepositoryFactory.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryFactory.java
@@ -89,35 +89,34 @@ public final class RepositoryFactory {
      */
     public static Repository getRepository(File file) throws InstantiationException, IllegalAccessException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        Repository res = null;
+        Repository repo = null;
         for (Repository rep : repositories) {
             if (rep.isRepositoryFor(file)) {
-                res = rep.getClass().newInstance();
+                repo = rep.getClass().newInstance();
                 try {
-                    res.setDirectoryName(file.getCanonicalPath());
+                    repo.setDirectoryName(file.getCanonicalPath());
                 } catch (IOException e) {
                     LOGGER.log(Level.SEVERE,
                             "Failed to get canonical path name for "
                             + file.getAbsolutePath(), e);
                 }
 
-                if (!res.isWorking()) {
-                    LOGGER.log(
-                            Level.WARNING,
+                if (!repo.isWorking()) {
+                    LOGGER.log(Level.WARNING,
                             "{0} not working (missing binaries?): {1}",
                             new Object[]{
-                                res.getClass().getSimpleName(),
+                                repo.getClass().getSimpleName(),
                                 file.getPath()
                             });
                 }
 
-                if (res.getType() == null || res.getType().length() == 0) {
-                    res.setType(res.getClass().getSimpleName());
+                if (repo.getType() == null || repo.getType().length() == 0) {
+                    repo.setType(repo.getClass().getSimpleName());
                 }
 
-                if (res.getParent() == null || res.getParent().length() == 0) {
+                if (repo.getParent() == null || repo.getParent().length() == 0) {
                     try {
-                        res.setParent(res.determineParent());
+                        repo.setParent(repo.determineParent());
                     } catch (IOException ex) {
                         LOGGER.log(Level.WARNING,
                                 "Failed to get parent for {0}: {1}",
@@ -125,9 +124,9 @@ public final class RepositoryFactory {
                     }
                 }
 
-                if (res.getBranch() == null || res.getBranch().length() == 0) {
+                if (repo.getBranch() == null || repo.getBranch().length() == 0) {
                     try {
-                        res.setBranch(res.determineBranch());
+                        repo.setBranch(repo.determineBranch());
                     } catch (IOException ex) {
                         LOGGER.log(Level.WARNING,
                                 "Failed to get branch for {0}: {1}",
@@ -135,9 +134,9 @@ public final class RepositoryFactory {
                     }
                 }
 
-                if (res.getCurrentVersion() == null || res.getCurrentVersion().length() == 0) {
+                if (repo.getCurrentVersion() == null || repo.getCurrentVersion().length() == 0) {
                     try {
-                        res.setCurrentVersion(res.determineCurrentVersion());
+                        repo.setCurrentVersion(repo.determineCurrentVersion());
                     } catch (IOException ex) {
                         LOGGER.log(Level.WARNING,
                                 "Failed to determineCurrentVersion for {0}: {1}",
@@ -147,14 +146,14 @@ public final class RepositoryFactory {
 
                 // If this repository displays tags only for files changed by tagged
                 // revision, we need to prepare list of all tags in advance.
-                if (env.isTagsEnabled() && res.hasFileBasedTags()) {
-                    res.buildTagList(file);
+                if (env.isTagsEnabled() && repo.hasFileBasedTags()) {
+                    repo.buildTagList(file);
                 }
 
                 break;
             }
         }
-        return res;
+        return repo;
     }
 
     /**


### PR DESCRIPTION
I contemplated a bit whether to add another message to trigger the `RepositoryInfo` refresh however was concerned that there might be too many messages in the system when reindexing many projects in parallel.

Also, there is a problem when webapp is running for a while and configuration is not stored persistently after each reindex cycle that the webapp will have more fresh configuration - with refreshed RepositoryInfo objects. This is left to be solved by whatever wrapper script is used to run the indexing (not the `OpenGrok` shell script but something which is wrapping around it).