### PR TITLE
getLatestRevision() fix

### DIFF
--- a/src/org/opensolaris/opengrok/web/PageConfig.java
+++ b/src/org/opensolaris/opengrok/web/PageConfig.java
@@ -1210,7 +1210,16 @@ public final class PageConfig {
             return null;
         }
 
-        HistoryEntry he = hist.getHistoryEntries().get(0);
+        List<HistoryEntry> hlist = hist.getHistoryEntries();
+        if (hlist == null) {
+            return null;
+        }
+
+        if (hlist.size() == 0) {
+            return null;
+        }
+
+        HistoryEntry he = hlist.get(0);
         if (he == null) {
             return null;
         }
@@ -1234,12 +1243,17 @@ public final class PageConfig {
      */
     public String getLatestRevisionLocation() {
         StringBuilder sb = new StringBuilder();
+        String revStr;
+
+        if ((revStr = getLatestRevision()) == null) {
+            return null;
+        }
 
         sb.append(req.getContextPath());
         sb.append(Prefix.XREF_P);
         sb.append(Util.URIEncodePath(path));
         sb.append("?r=");
-        sb.append(Util.URIEncode(getLatestRevision()));
+        sb.append(Util.URIEncode(revStr));
 
         return sb.toString();
     }

--- a/src/org/opensolaris/opengrok/web/PageConfig.java
+++ b/src/org/opensolaris/opengrok/web/PageConfig.java
@@ -1193,15 +1193,15 @@ public final class PageConfig {
                 path, env.isCompressXref());
     }
 
-    private String getLatestRevision() {
-        if (!env.isHistoryEnabled()) {
+    protected String getLatestRevision() {
+        if (!getEnv().isHistoryEnabled()) {
             return null;
         }
 
         History hist;
         try {
             hist = HistoryGuru.getInstance().
-                    getHistory(new File(env.getSourceRootFile(), path));
+                    getHistory(new File(getEnv().getSourceRootFile(), getPath()));
         } catch (HistoryException ex) {
             return null;
         }

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -242,6 +242,36 @@ public class PageConfigTest {
     }
 
     @Test
+    public void testGetLatestRevisionValid() {
+        DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
+            @Override
+                public String getPathInfo() {
+                    return "/git/main.c";
+            }
+        };
+
+        PageConfig cfg = PageConfig.get(req1);
+        String rev = cfg.getLatestRevision();
+
+        assertEquals("aa35c258", rev);
+    }
+
+    @Test
+    public void testGetLatestRevisionNotValid() {
+        DummyHttpServletRequest req2 = new DummyHttpServletRequest() {
+            @Override
+                public String getPathInfo() {
+                    return "/git/nonexistent_file";
+            }
+        };
+
+        PageConfig cfg = PageConfig.get(req2);
+        String rev = cfg.getLatestRevision();
+
+        assertNull(rev);
+    }
+
+    @Test
     public void testGetRequestedRevision() {
         final String[] params = {"r", "h", "r", "r", "r"};
         final String[] revisions = {

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -267,8 +267,10 @@ public class PageConfigTest {
 
         PageConfig cfg = PageConfig.get(req2);
         String rev = cfg.getLatestRevision();
-
         assertNull(rev);
+
+        String location = cfg.getLatestRevisionLocation();
+        assertNull(location);
     }
 
     @Test


### PR DESCRIPTION
getLatestRevision() was not careful enough with checking `HistoryEntry` list and its called did not fullfil its promise to return `null` when `getLatestRevision()` fails.