### PR TITLE
directory name of RepositoryInfo should be stored as relative path

### DIFF
--- a/src/org/opensolaris/opengrok/history/BazaarRepository.java
+++ b/src/org/opensolaris/opengrok/history/BazaarRepository.java
@@ -82,8 +82,8 @@ public class BazaarRepository extends Repository {
             throws IOException {
         String abs = file.getCanonicalPath();
         String filename = "";
-        if (abs.length() > directoryName.length()) {
-            filename = abs.substring(directoryName.length() + 1);
+        if (abs.length() > getDirectoryName().length()) {
+            filename = abs.substring(getDirectoryName().length() + 1);
         }
 
         List<String> cmd = new ArrayList<String>();
@@ -108,12 +108,12 @@ public class BazaarRepository extends Repository {
     public InputStream getHistoryGet(String parent, String basename, String rev) {
         InputStream ret = null;
 
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
 
         Process process = null;
         try {
             String filename = (new File(parent, basename)).getCanonicalPath()
-                    .substring(directoryName.length() + 1);
+                    .substring(getDirectoryName().length() + 1);
             ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
             String argv[] = {RepoCommand, "cat", "-r", rev, filename};
             process = Runtime.getRuntime().exec(argv, null, directory);
@@ -354,7 +354,7 @@ public class BazaarRepository extends Repository {
 
     @Override
     String determineParent() throws IOException {
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);

--- a/src/org/opensolaris/opengrok/history/BitKeeperRepository.java
+++ b/src/org/opensolaris/opengrok/history/BitKeeperRepository.java
@@ -172,7 +172,7 @@ public class BitKeeperRepository extends Repository {
      */
     @Override
     String determineParent() throws IOException {
-        final File directory = new File(directoryName);
+        final File directory = new File(getDirectoryName());
 
         final ArrayList<String> argv = new ArrayList<String>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);

--- a/src/org/opensolaris/opengrok/history/CVSRepository.java
+++ b/src/org/opensolaris/opengrok/history/CVSRepository.java
@@ -197,8 +197,8 @@ public class CVSRepository extends RCSRepository {
     Executor getHistoryLogExecutor(final File file) throws IOException {
         String abs = file.getCanonicalPath();
         String filename = "";
-        if (abs.length() > directoryName.length()) {
-            filename = abs.substring(directoryName.length() + 1);
+        if (abs.length() > getDirectoryName().length()) {
+            filename = abs.substring(getDirectoryName().length() + 1);
         }
 
         List<String> cmd = new ArrayList<>();
@@ -347,7 +347,7 @@ public class CVSRepository extends RCSRepository {
 
     @Override
     String determineParent() throws IOException {
-        File rootFile = new File(directoryName + File.separator + "CVS"
+        File rootFile = new File(getDirectoryName() + File.separator + "CVS"
                 + File.separator + "Root");
         String parent = null;
 

--- a/src/org/opensolaris/opengrok/history/ClearCaseRepository.java
+++ b/src/org/opensolaris/opengrok/history/ClearCaseRepository.java
@@ -95,8 +95,8 @@ public class ClearCaseRepository extends Repository {
     Executor getHistoryLogExecutor(final File file) throws IOException {
         String abs = file.getCanonicalPath();
         String filename = "";
-        if (abs.length() > directoryName.length()) {
-            filename = abs.substring(directoryName.length() + 1);
+        if (abs.length() > getDirectoryName().length()) {
+            filename = abs.substring(getDirectoryName().length() + 1);
         }
 
         List<String> cmd = new ArrayList<>();
@@ -117,12 +117,12 @@ public class ClearCaseRepository extends Repository {
     public InputStream getHistoryGet(String parent, String basename, String rev) {
         InputStream ret = null;
 
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
 
         Process process = null;
         try {
             String filename = (new File(parent, basename)).getCanonicalPath()
-                    .substring(directoryName.length() + 1);
+                    .substring(getDirectoryName().length() + 1);
             final File tmp = File.createTempFile("opengrok", "tmp");
             String tmpName = tmp.getCanonicalPath();
 

--- a/src/org/opensolaris/opengrok/history/GitRepository.java
+++ b/src/org/opensolaris/opengrok/history/GitRepository.java
@@ -118,8 +118,8 @@ public class GitRepository extends Repository {
 
         String abs = file.getCanonicalPath();
         String filename = "";
-        if (abs.length() > directoryName.length()) {
-            filename = abs.substring(directoryName.length() + 1);
+        if (abs.length() > getDirectoryName().length()) {
+            filename = abs.substring(getDirectoryName().length() + 1);
         }
 
         List<String> cmd = new ArrayList<>();
@@ -167,10 +167,10 @@ public class GitRepository extends Repository {
             cmd.add(sinceRevision + "..");
         }
 
-        if (file.getCanonicalPath().length() > directoryName.length() + 1) {
+        if (file.getCanonicalPath().length() > getDirectoryName().length() + 1) {
             // this is a file in the repository
             cmd.add("--");
-            cmd.add(file.getCanonicalPath().substring(directoryName.length() + 1));
+            cmd.add(file.getCanonicalPath().substring(getDirectoryName().length() + 1));
         }
 
         return new Executor(cmd, new File(getDirectoryName()), sinceRevision != null);
@@ -201,11 +201,11 @@ public class GitRepository extends Repository {
      */
     private InputStream getHistoryRev(String fullpath, String rev) {
         InputStream ret = null;
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
         Process process = null;
 
         try {
-            String filename = fullpath.substring(directoryName.length() + 1);
+            String filename = fullpath.substring(getDirectoryName().length() + 1);
             ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
             String argv[] = {
                 RepoCommand,
@@ -303,7 +303,7 @@ public class GitRepository extends Repository {
      */
     protected String findOriginalName(String fullpath, String changeset)
             throws IOException {
-        if (fullpath == null || fullpath.isEmpty() || fullpath.length() < directoryName.length()) {
+        if (fullpath == null || fullpath.isEmpty() || fullpath.length() < getDirectoryName().length()) {
             throw new IOException(String.format("Invalid file path string: %s", fullpath));
         }
 
@@ -311,7 +311,7 @@ public class GitRepository extends Repository {
             throw new IOException(String.format("Invalid changeset string for path %s: %s", fullpath, changeset));
         }
 
-        String file = fullpath.replace(directoryName + File.separator, "");
+        String file = fullpath.replace(getDirectoryName() + File.separator, "");
         /*
          * Get the list of file renames for given file to the specified
          * revision.
@@ -330,7 +330,7 @@ public class GitRepository extends Repository {
         };
 
         ProcessBuilder pb = new ProcessBuilder(argv);
-        Process process = Runtime.getRuntime().exec(argv, null, new File(directoryName));
+        Process process = Runtime.getRuntime().exec(argv, null, new File(getDirectoryName()));
 
         try {
             try (BufferedReader in = new BufferedReader(
@@ -365,7 +365,7 @@ public class GitRepository extends Repository {
             }
         }
 
-        return (fullpath.substring(0, directoryName.length() + 1) + file);
+        return (fullpath.substring(0, getDirectoryName().length() + 1) + file);
     }
 
     /**
@@ -405,7 +405,7 @@ public class GitRepository extends Repository {
             }
             cmd.add("--");
             cmd.add(findOriginalName(file.getAbsolutePath(), revision));
-            File directory = new File(directoryName);
+            File directory = new File(getDirectoryName());
             exec = new Executor(cmd, directory);
             status = exec.exec();
         }
@@ -648,7 +648,7 @@ public class GitRepository extends Repository {
     @Override
     String determineParent() throws IOException {
         String parent = null;
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
@@ -667,7 +667,7 @@ public class GitRepository extends Repository {
                     String parts[] = line.split("\\s+");
                     if (parts.length != 3) {
                         LOGGER.log(Level.WARNING,
-                                "Failed to get parent for {0}", directoryName);
+                                "Failed to get parent for {0}", getDirectoryName());
                     }
                     parent = parts[1];
                     break;
@@ -681,7 +681,7 @@ public class GitRepository extends Repository {
     @Override
     String determineBranch() throws IOException {
         String branch = null;
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
@@ -707,7 +707,7 @@ public class GitRepository extends Repository {
 
     @Override
     public String determineCurrentVersion() throws IOException {
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
         List<String> cmd = new ArrayList<>();
         // The delimiter must not be contained in the date format emitted by
         // {@code GIT_DATE_OPT}.

--- a/src/org/opensolaris/opengrok/history/MercurialRepository.java
+++ b/src/org/opensolaris/opengrok/history/MercurialRepository.java
@@ -132,7 +132,7 @@ public class MercurialRepository extends Repository {
         cmd.add(RepoCommand);
         cmd.add("branch");
 
-        Executor executor = new Executor(cmd, new File(directoryName));
+        Executor executor = new Executor(cmd, new File(getDirectoryName()));
         if (executor.exec(false) != 0) {
             throw new IOException(executor.getErrorString());
         }
@@ -156,8 +156,8 @@ public class MercurialRepository extends Repository {
         String filename = "";
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
-        if (abs.length() > directoryName.length()) {
-            filename = abs.substring(directoryName.length() + 1);
+        if (abs.length() > getDirectoryName().length()) {
+            filename = abs.substring(getDirectoryName().length() + 1);
         }
 
         List<String> cmd = new ArrayList<>();
@@ -206,7 +206,7 @@ public class MercurialRepository extends Repository {
             cmd.add(filename);
         }
 
-        return new Executor(cmd, new File(directoryName), sinceRevision != null);
+        return new Executor(cmd, new File(getDirectoryName()), sinceRevision != null);
     }
 
     /**
@@ -219,7 +219,7 @@ public class MercurialRepository extends Repository {
     private InputStream getHistoryRev(String fullpath, String rev) {
         InputStream ret = null;
 
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
 
         Process process = null;
         String revision = rev;
@@ -229,7 +229,7 @@ public class MercurialRepository extends Repository {
         }
         try {
             String filename
-                    = fullpath.substring(directoryName.length() + 1);
+                    = fullpath.substring(getDirectoryName().length() + 1);
             ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
             String argv[] = {RepoCommand, "cat", "-r", revision, filename};
             process = Runtime.getRuntime().exec(argv, null, directory);
@@ -284,7 +284,7 @@ public class MercurialRepository extends Repository {
     private String findOriginalName(String fullpath, String full_rev_to_find)
             throws IOException {
         Matcher matcher = LOG_COPIES_PATTERN.matcher("");
-        String file = fullpath.substring(directoryName.length() + 1);
+        String file = fullpath.substring(getDirectoryName().length() + 1);
         ArrayList<String> argv = new ArrayList<>();
 
         // Extract {rev} from the full revision specification string.
@@ -375,7 +375,7 @@ public class MercurialRepository extends Repository {
             }
         }
 
-        return (fullpath.substring(0, directoryName.length() + 1) + file);
+        return (fullpath.substring(0, getDirectoryName().length() + 1) + file);
     }
 
     @Override
@@ -514,7 +514,7 @@ public class MercurialRepository extends Repository {
 
     @Override
     public void update() throws IOException {
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
@@ -686,7 +686,7 @@ public class MercurialRepository extends Repository {
 
     @Override
     String determineParent() throws IOException {
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
@@ -704,7 +704,7 @@ public class MercurialRepository extends Repository {
     @Override
     public String determineCurrentVersion() throws IOException {
         String line = null;
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);

--- a/src/org/opensolaris/opengrok/history/MonotoneRepository.java
+++ b/src/org/opensolaris/opengrok/history/MonotoneRepository.java
@@ -70,14 +70,14 @@ public class MonotoneRepository extends Repository {
     public InputStream getHistoryGet(String parent, String basename, String rev) {
         InputStream ret = null;
 
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
 
         Process process = null;
         String revision = rev;
 
         try {
             String filename = (new File(parent, basename)).getCanonicalPath()
-                    .substring(directoryName.length() + 1);
+                    .substring(getDirectoryName().length() + 1);
             ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
             String argv[] = {RepoCommand, "cat", "-r", revision, filename};
             process = Runtime.getRuntime().exec(argv, null, directory);
@@ -126,8 +126,8 @@ public class MonotoneRepository extends Repository {
             throws IOException {
         String abs = file.getCanonicalPath();
         String filename = "";
-        if (abs.length() > directoryName.length()) {
-            filename = abs.substring(directoryName.length() + 1);
+        if (abs.length() > getDirectoryName().length()) {
+            filename = abs.substring(getDirectoryName().length() + 1);
         }
 
         List<String> cmd = new ArrayList<>();
@@ -145,7 +145,7 @@ public class MonotoneRepository extends Repository {
         cmd.add("--no-format-dates");
         cmd.add(filename);
 
-        return new Executor(cmd, new File(directoryName), sinceRevision != null);
+        return new Executor(cmd, new File(getDirectoryName()), sinceRevision != null);
     }
     /**
      * Pattern used to extract author/revision from hg annotate.
@@ -173,7 +173,7 @@ public class MonotoneRepository extends Repository {
             cmd.add(revision);
         }
         cmd.add(file.getName());
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
 
         Executor executor = new Executor(cmd, directory);
         if (executor.exec() != 0) {
@@ -207,7 +207,7 @@ public class MonotoneRepository extends Repository {
 
     @Override
     public void update() throws IOException {
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
 
         List<String> cmd = new ArrayList<>();
@@ -283,7 +283,7 @@ public class MonotoneRepository extends Repository {
     @Override
     String determineParent() throws IOException {
         String parent = null;
-        File directory = new File(directoryName);
+        File directory = new File(getDirectoryName());
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
@@ -303,7 +303,7 @@ public class MonotoneRepository extends Repository {
                     String parts[] = line.split("\\s+");
                     if (parts.length != 3) {
                         LOGGER.log(Level.WARNING,
-                                "Failed to get parent for {0}", directoryName);
+                                "Failed to get parent for {0}", getDirectoryName());
                     }
                     parent = parts[2];
                     break;

--- a/src/org/opensolaris/opengrok/history/Repository.java
+++ b/src/org/opensolaris/opengrok/history/Repository.java
@@ -344,7 +344,7 @@ public abstract class Repository extends RepositoryInfo {
         // We need to refresh list of tags for incremental reindex.
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         if (env.isTagsEnabled() && this.hasFileBasedTags()) {
-            this.buildTagList(new File(this.directoryName));
+            this.buildTagList(new File(this.getDirectoryName()));
         }
 
         if (history != null) {

--- a/src/org/opensolaris/opengrok/history/RepositoryInfo.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryInfo.java
@@ -22,12 +22,8 @@
  */
 package org.opensolaris.opengrok.history;
 
-import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.util.ClassUtil;
 

--- a/src/org/opensolaris/opengrok/history/RepositoryInfo.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryInfo.java
@@ -22,8 +22,14 @@
  */
 package org.opensolaris.opengrok.history;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
+import org.opensolaris.opengrok.util.ClassUtil;
 
 /**
  * Class to contain the common info for a repository. This object will live on
@@ -34,9 +40,15 @@ import java.text.SimpleDateFormat;
  */
 public class RepositoryInfo implements Serializable {
 
-    private static final long serialVersionUID = 2L;
+    static {
+        ClassUtil.remarkTransientFields(RepositoryInfo.class);
+    }
 
-    protected String directoryName; // absolute path
+    private static final long serialVersionUID = 3L;
+
+    // dummy to avoid storing absolute path in XML encoded configuration
+    private transient String directoryName;
+    private String directoryNameRelative;
     protected Boolean working;
     protected String type;
     protected boolean remote;
@@ -58,7 +70,7 @@ public class RepositoryInfo implements Serializable {
     }
 
     public RepositoryInfo(RepositoryInfo orig) {
-        this.directoryName = orig.directoryName;
+        this.directoryNameRelative = orig.directoryNameRelative;
         this.type = orig.type;
         this.working = orig.isWorking();
         this.remote = orig.isRemote();
@@ -69,21 +81,43 @@ public class RepositoryInfo implements Serializable {
     }
 
     /**
+     * @return relative path to source root
+     */
+    public String getDirectoryNameRelative() {
+        return directoryNameRelative;
+    }
+
+    /**
+     * Set relative path to source root
+     * @param dir directory
+     */
+    public void setDirectoryNameRelative(String dir) {
+        this.directoryNameRelative = dir;
+    }
+
+    /**
      * Get the name of the root directory for this repository.
      *
      * @return the name of the root directory
      */
     public String getDirectoryName() {
-        return directoryName;
+        return RuntimeEnvironment.getInstance().getSourceRootPath() +
+                directoryNameRelative;
     }
 
     /**
      * Specify the name of the root directory for this repository.
      *
-     * @param directoryName the new name of the root directory
+     * @param dir the new name of the root directory. Can be absolute
+     * path or relative to source root.
      */
-    public void setDirectoryName(String directoryName) {
-        this.directoryName = directoryName;
+    public void setDirectoryName(String dir) {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        if (dir.startsWith(env.getSourceRootPath())) {
+            this.directoryNameRelative = dir.substring(env.getSourceRootPath().length());
+        } else {
+            this.directoryNameRelative = dir;
+        }
     }
 
     /**

--- a/src/org/opensolaris/opengrok/history/SCCSRepository.java
+++ b/src/org/opensolaris/opengrok/history/SCCSRepository.java
@@ -267,7 +267,7 @@ public class SCCSRepository extends Repository {
 
     @Override
     String determineParent() throws IOException {
-        File parentFile = new File(directoryName + File.separator
+        File parentFile = new File(getDirectoryName() + File.separator
                 + "Codemgr_wsdata" + File.separator + "parent");
         String parent = null;
 
@@ -276,15 +276,15 @@ public class SCCSRepository extends Repository {
             try (BufferedReader in = new BufferedReader(new FileReader(parentFile))) {
                 if ((line = in.readLine()) == null) {
                     LOGGER.log(Level.WARNING,
-                            "Failed to get parent for {0} (cannot read line)", directoryName);
+                            "Failed to get parent for {0} (cannot read line)", getDirectoryName());
                 }
                 if (!line.startsWith("VERSION")) {
                     LOGGER.log(Level.WARNING,
-                            "Failed to get parent for {0} (first line does not start with VERSION)", directoryName);
+                            "Failed to get parent for {0} (first line does not start with VERSION)", getDirectoryName());
                 }
                 if ((parent = in.readLine()) == null) {
                     LOGGER.log(Level.WARNING,
-                            "Failed to get parent for {0} (cannot read second line)", directoryName);
+                            "Failed to get parent for {0} (cannot read second line)", getDirectoryName());
                 }
             }
         }

--- a/test/org/opensolaris/opengrok/web/ProjectHelperTest.java
+++ b/test/org/opensolaris/opengrok/web/ProjectHelperTest.java
@@ -53,7 +53,7 @@ public class ProjectHelperTest extends ProjectHelperTestBase {
      * Test if projects and groups are always reloaded fully from the env.
      *
      * This ensures that when the RuntimeEnvironment changes that it also
-     * updates the projects in the ui.
+     * updates the projects in the UI.
      */
     @Test
     public void testSynchronization() {
@@ -62,6 +62,7 @@ public class ProjectHelperTest extends ProjectHelperTestBase {
         Set<Group> oldGroups = new TreeSet<>(env.getGroups());
         Map<Project, List<RepositoryInfo>> oldMap = new TreeMap<>(getRepositoriesMap());
         env.getAuthorizationFramework().removeAll(env.getAuthorizationFramework().getStack());
+        env.setSourceRoot("/src"); // needed for setDirectoryName() below
 
         cfg = PageConfig.get(getRequest());
         helper = cfg.getProjectHelper();
@@ -89,7 +90,7 @@ public class ProjectHelperTest extends ProjectHelperTestBase {
 
         RepositoryInfo info = new RepoRepository();
         info.setParent(repo.getName());
-        info.setDirectoryName(null);
+        info.setDirectoryName("/foo");
 
         List<RepositoryInfo> infos = getRepositoriesMap().get(repo);
         if (infos == null) {

--- a/test/org/opensolaris/opengrok/web/ProjectHelperTestBase.java
+++ b/test/org/opensolaris/opengrok/web/ProjectHelperTestBase.java
@@ -71,7 +71,7 @@ public class ProjectHelperTestBase {
         for (int i = 0; i < cnt; i++) {
             RepositoryInfo info = new RepoRepository();
             info.setParent(p.getName() + "_" + i);
-            info.setDirectoryName(p.getPath());
+            info.setDirectoryNameRelative(p.getPath());
             rps.add(info);
             List<RepositoryInfo> infos = map.get(p);
             if (infos == null) {


### PR DESCRIPTION
This is a bit of a hack to store only relative paths in `RepositoryInfo` object encoding.