### PR TITLE
Java 9 compilation support

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -151,7 +151,10 @@ Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
 
     <target name="get-java-version">
         <condition property="java.version.checked">
-            <equals arg1="${ant.java.version}" arg2="1.8"/>
+            <or>
+                <equals arg1="${ant.java.version}" arg2="1.8"/>
+                <equals arg1="${ant.java.version}" arg2="9"/>
+            </or>
         </condition>
     </target>
 


### PR DESCRIPTION
Compilation error: "Unsupported Java version: 9. Make sure that the Java version is 1.8 or greater."

This fix adds Java 9 to supported versions.