### PR TITLE
searchable-option-list workaround for less jumpy page loading

### DIFF
--- a/web/default/style.css
+++ b/web/default/style.css
@@ -1242,6 +1242,22 @@ h6.message-group-caption {
     *zoom: 1;
 }
 
+/** --------------- sol workaround ------------ */
+
+select#project, select#type {
+    height: 20px;
+    width: 30px;
+    visibility: hidden;
+}
+
+td#projectLabelTd {
+    height: 24px;
+}
+
+td#typeLabelTd {
+    height: 26px;
+}
+
 /** ---------------- markdown readme format ----- */
 
 .markdown {

--- a/web/menu.jspf
+++ b/web/menu.jspf
@@ -85,7 +85,7 @@ org.opensolaris.opengrok.web.Util"
     %>
     <tbody id="ptbl">
     <tr>
-    <td>
+    <td id="projectLabelTd">
     <label for="project">Project(s)</label>
     </td>
     <td colspan="2">
@@ -193,7 +193,7 @@ org.opensolaris.opengrok.web.Util"
         }
     %>
     <tr>
-        <td><label for="s5">Type</label></td>
+        <td id="typeLabelTd"><label for="s5">Type</label></td>
         <td><select class="q" tabindex="6" name="type" id="type"><%
                 String selection = queryParams.getType();
                 %>


### PR DESCRIPTION
Minor UI fix.

searchable-option-list plugin adds functionality: autocomplete + multi selection handling.
Unfortunately it also causes UI to be jumpy, because it has to be loaded client-side after the initial page load.

Proposed solution is not pretty, but it does the job.

before:
![peek sol before](https://user-images.githubusercontent.com/2456881/31047740-65e5be74-a610-11e7-8515-7e11b10922b3.gif)

after:
![peek sol after](https://user-images.githubusercontent.com/2456881/31047743-6a53c74e-a610-11e7-8c65-1896028b6d79.gif)

I accept OCA for this patch