### PR TITLE
remove extraneous message emitted to stderr about extra ctags config …

### DIFF
--- a/src/org/opensolaris/opengrok/index/Indexer.java
+++ b/src/org/opensolaris/opengrok/index/Indexer.java
@@ -328,8 +328,6 @@ public final class Indexer {
                                         + "' not found for the -o option");
                                 System.exit(1);
                             }
-                            System.err.println("INFO: file with extra "
-                                    + "options for ctags: " + CTagsExtraOptionsFile);
                             cfg.setCTagsExtraOptionsFile(CTagsExtraOptionsFile);
                             break;
                         case 'P':


### PR DESCRIPTION
This has been bothering me for quite some time. This message is extra naughty because:
  - it claims it is being sent with `INFO` prirority
  - is produced during every indexer run (with the `-o` option)
  - somehow it gets propagated through layers of processes to the session leader process so it ends up in cron emails etc.