### PR TITLE
populate HistoryGuru repositories list from add project Message

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/ConfigMerge.java
+++ b/src/org/opensolaris/opengrok/configuration/ConfigMerge.java
@@ -31,8 +31,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.text.ParseException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.opensolaris.opengrok.util.Getopt;
 
 /**
@@ -49,6 +47,7 @@ public class ConfigMerge {
      * Merge base and new configuration.
      * @param cfgBase base configuration
      * @param cfgNew new configuration, will receive properties from the base configuration
+     * @throws Exception
      */
     public static void merge(Configuration cfgBase, Configuration cfgNew) throws Exception {
         Configuration cfgDefault = new Configuration();

--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -114,13 +114,13 @@ public final class Configuration {
      */
     private int messageLimit;
     /**
-     * Directory with authorization plugins. Default value is
-     * dataRoot/../plugins (can be /var/opengrok/plugins if dataRoot is
-     * /var/opengrok/data).
+     * Directory with authorization plug-ins. Default value is
+     * {@code dataRoot/../plugins} (can be {@code /var/opengrok/plugins} if dataRoot is
+     * {@code /var/opengrok/data}).
      */
     private String pluginDirectory;
     /**
-     * Enable watching the plugin directory for changes in real time. Suitable
+     * Enable watching the plug-in directory for changes in real time. Suitable
      * for development.
      */
     private boolean authorizationWatchdogEnabled;
@@ -658,7 +658,7 @@ public final class Configuration {
      * @see #setPluginDirectory(java.lang.String)
      * @see #setStatisticsFilePath(java.lang.String)
      *
-     * @param dataRoot
+     * @param dataRoot data root path
      */
     public void setDataRoot(String dataRoot) {
         if (dataRoot != null && getPluginDirectory() == null) {

--- a/src/org/opensolaris/opengrok/configuration/messages/ProjectMessage.java
+++ b/src/org/opensolaris/opengrok/configuration/messages/ProjectMessage.java
@@ -87,19 +87,18 @@ public class ProjectMessage extends Message {
         }
     }
 
-    private List<RepositoryInfo> getRepositoriesInDir(RuntimeEnvironment env, File projDir) {
-        List<RepositoryInfo> repos = new ArrayList<>();
-        HistoryGuru hg = HistoryGuru.getInstance();
+    private List<RepositoryInfo> getRepositoriesInDir(RuntimeEnvironment env,
+            File projDir) {
+
+        HistoryGuru histGuru = HistoryGuru.getInstance();
 
         // There is no need to perform the work of invalidateRepositories(),
         // since addRepositories() calls getRepository() for each of
         // the repos.
-        hg.addRepositories(new File[]{projDir}, repos,
-            env.getIgnoredNames());
-
-        return repos;
+        return new ArrayList<>(histGuru.addRepositories(new File[]{projDir},
+            env.getIgnoredNames()));
     }
-    
+
     @Override
     protected byte[] applyMessage(RuntimeEnvironment env) throws Exception {
         String command = getText();
@@ -193,11 +192,7 @@ public class ProjectMessage extends Message {
                                 File.separator + projectName));
                     }
                     HistoryGuru guru = HistoryGuru.getInstance();
-                    // removeCache() for single repository would call
-                    // {@code invalidateRepositories()} on it which
-                    // would corrupt HistoryGuru's view of all repositories
-                    // so call clearCache() to avoid it.
-                    guru.clearCache(repos.stream().
+                    guru.removeCache(repos.stream().
                         map((x) -> {
                             try {
                                 return env.getPathRelativeToSourceRoot(
@@ -213,9 +208,6 @@ public class ProjectMessage extends Message {
                                 return "";
                             }
                         }).collect(Collectors.toSet()));
-
-                    // Remove the repositories in the HistoryGuru.
-                    guru.removeRepositories(repos);
                 }
                 break;
             case "indexed":
@@ -245,7 +237,7 @@ public class ProjectMessage extends Message {
                     }
                 }
 
-                // In case this project has just been incremetally indexed,
+                // In case this project has just been incrementally indexed,
                 // its IndexSearcher needs a poke.
                 env.maybeRefreshIndexSearchers(getTags());
 

--- a/src/org/opensolaris/opengrok/history/RepositoryFactory.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryFactory.java
@@ -73,12 +73,18 @@ public final class RepositoryFactory {
         for (int i = repositories.length - 1; i >= 0; i--) {
             list.add(repositories[i].getClass());
         }
+        
         return list;
     }
 
     /**
      * Returns a repository for the given file, or null if no repository was
      * found.
+     *
+     * Note that the operations performed by this method take quite a long time
+     * thanks to external commands being executed. For that reason, when run
+     * on multiple files, it should be parallelized, e.g. like it is done in
+     * {@code invalidateRepositories()}.
      *
      * @param file File that might contain a repository
      * @return Correct repository for the given file
@@ -90,6 +96,7 @@ public final class RepositoryFactory {
     public static Repository getRepository(File file) throws InstantiationException, IllegalAccessException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         Repository repo = null;
+
         for (Repository rep : repositories) {
             if (rep.isRepositoryFor(file)) {
                 repo = rep.getClass().newInstance();
@@ -153,6 +160,7 @@ public final class RepositoryFactory {
                 break;
             }
         }
+        
         return repo;
     }
 
@@ -163,8 +171,8 @@ public final class RepositoryFactory {
      * @param info Information about the repository
      * @return Correct repository for the given file
      * @throws java.lang.InstantiationException in case we cannot create the
-     * repo object
-     * @throws java.lang.IllegalAccessException in case no permissions to repo
+     * repository object
+     * @throws java.lang.IllegalAccessException in case no permissions to repository
      */
     public static Repository getRepository(RepositoryInfo info) throws InstantiationException, IllegalAccessException {
         return getRepository(new File(info.getDirectoryName()));
@@ -175,6 +183,8 @@ public final class RepositoryFactory {
      * files/directories. This way per-repository ignored entries are set
      * inside repository classes rather than globally in IgnoredFiles/Dirs.
      * Should be called after {@code setConfiguration()}.
+     * 
+     * @param env runtime environment
      */
     public static void initializeIgnoredNames(RuntimeEnvironment env) {
         for (Repository repo : repositories) {

--- a/src/org/opensolaris/opengrok/history/RepositoryInfo.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryInfo.java
@@ -43,7 +43,9 @@ public class RepositoryInfo implements Serializable {
     private static final long serialVersionUID = 3L;
 
     // dummy to avoid storing absolute path in XML encoded configuration
+    // Do not use this member.
     private transient String directoryName;
+    
     private String directoryNameRelative;
     protected Boolean working;
     protected String type;

--- a/src/org/opensolaris/opengrok/index/Indexer.java
+++ b/src/org/opensolaris/opengrok/index/Indexer.java
@@ -689,7 +689,7 @@ public final class Indexer {
             LOGGER.log(Level.INFO, "Scanning for repositories...");
             long start = System.currentTimeMillis();
             if (env.isHistoryEnabled()) {
-                HistoryGuru.getInstance().addRepositories(env.getSourceRootPath());
+                env.setRepositories(env.getSourceRootPath());
             }
             long time = (System.currentTimeMillis() - start) / 1000;
             LOGGER.log(Level.INFO, "Done scanning for repositories ({0}s)", time);
@@ -730,7 +730,8 @@ public final class Indexer {
                     try {
                         HistoryGuru.getInstance().removeCache(toZap);
                     } catch (HistoryException e) {
-                        LOGGER.log(Level.WARNING, "Clearing history cache failed: {0}", e.getLocalizedMessage());
+                        LOGGER.log(Level.WARNING, "Clearing history cache failed: {0}",
+                                e.getLocalizedMessage());
                     }
                 }
                 return;

--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -257,7 +257,7 @@ public class RuntimeEnvironmentTest {
     public void testRepositories() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertNotNull(instance.getRepositories());
-        instance.setRepositories(null);
+        instance.removeRepositories();
         assertNull(instance.getRepositories());
         List<RepositoryInfo> reps = new ArrayList<>();
         instance.setRepositories(reps);

--- a/test/org/opensolaris/opengrok/index/IndexerTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerTest.java
@@ -239,7 +239,7 @@ public class IndexerTest {
         env.setCtags(System.getProperty(ctagsProperty, "ctags"));
         env.setSourceRoot(repository.getSourceRoot());
         env.setDataRoot(repository.getDataRoot());
-        HistoryGuru.getInstance().addRepositories(repository.getSourceRoot());
+        env.setRepositories(repository.getSourceRoot());
 
         List<RepositoryInfo> repos = env.getRepositories();
         Repository r = null;
@@ -336,7 +336,7 @@ public class IndexerTest {
 
         env.setSourceRoot(testrepo.getSourceRoot());
         env.setDataRoot(testrepo.getDataRoot());
-        HistoryGuru.getInstance().addRepositories(testrepo.getSourceRoot());
+        env.setRepositories(testrepo.getSourceRoot());
 
         // create index
         Project project = new Project("mercurial", "/mercurial");

--- a/test/org/opensolaris/opengrok/search/context/HistoryContextTest.java
+++ b/test/org/opensolaris/opengrok/search/context/HistoryContextTest.java
@@ -43,6 +43,7 @@ import org.opensolaris.opengrok.util.TestRepository;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 
 /**
  * Unit tests for the {@code HistoryContext} class.
@@ -56,7 +57,7 @@ public class HistoryContextTest {
         repositories = new TestRepository();
         repositories.create(HistoryContextTest.class.getResourceAsStream(
                 "/org/opensolaris/opengrok/history/repositories.zip"));
-        HistoryGuru.getInstance().addRepositories(repositories.getSourceRoot());
+        RuntimeEnvironment.getInstance().setRepositories(repositories.getSourceRoot());
     }
 
     @AfterClass

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -64,7 +64,7 @@ public class PageConfigTest {
         repository = new TestRepository();
         repository.create(
                 HistoryGuru.class.getResourceAsStream("repositories.zip"));
-        HistoryGuru.getInstance().addRepositories(repository.getSourceRoot());
+        RuntimeEnvironment.getInstance().setRepositories(repository.getSourceRoot());
     }
 
     @AfterClass


### PR DESCRIPTION
In the process of addressing #1809 I tried to fix the HistoryGuru API and its usage, namely:
  - addRepositories() not adding repositories to the HistoryGuru map (this gist of the fix for #1809) and needlessly calling invalidateRepositories()
    - renamed addRepositories(dir) to setRepositories(dir) to better reflect what it is doing and moved it to RuntimeEnvironment since it also modifies the configuration
  - removeCache() using invalidateRepositories() needlessly and actually in a wrong way (invalidateRepositories() needs to be called with full set of repositories since it sets the map from scratch)
  - setConfiguration() not setting the repository list in configuration after invalidateRepositories() (the latter can remove some repositories)
