### PR TITLE
Improve AnalyzerGuru magic identification

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -19,17 +19,21 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -110,6 +114,18 @@ import org.opensolaris.opengrok.web.Util;
  */
 public class AnalyzerGuru {
 
+    /**
+     * The maximum number of characters (multi-byte if a BOM is identified) to
+     * read from the input stream to be used for magic string matching
+     */
+    private static final int OPENING_MAX_CHARS = 100;
+
+    /**
+     * Define very close to OPENING_MAX_CHARS so the input stream stays easily
+     * in the <code>mark</code> limit
+     */
+    private static final int OPENING_BUF_SIZE = 102;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AnalyzerGuru.class);
 
     /**
@@ -132,11 +148,28 @@ public class AnalyzerGuru {
      */
     private static final Map<String, FileAnalyzerFactory> pre = new HashMap<>();
 
-    // @TODO: have a comparator
+    /**
+     * Descending string length comparator for magics
+     */
+    private static Comparator<String> descStrlenComparator =
+        new Comparator<String>() {
+        @Override public int compare(String s1, String s2) {
+            // DESC: s2 length <=> s1 length
+            int cmp = Integer.compare(s2.length(), s1.length());
+            if (cmp != 0) return cmp;
+
+            // the Comparator must also be "consistent with equals", so check
+            // string contents too when (length)cmp == 0. (ASC: s1 <=> s2.)
+            cmp = s1.compareTo(s2);
+            return cmp;
+        }
+    };
+
     /**
      * Map from magic strings to analyzer factories.
      */
-    private static final SortedMap<String, FileAnalyzerFactory> magics = new TreeMap<>();
+    private static final SortedMap<String, FileAnalyzerFactory> magics =
+        new TreeMap<>(descStrlenComparator);
 
     /**
      * List of matcher objects which can be used to determine which analyzer
@@ -313,7 +346,13 @@ public class AnalyzerGuru {
     public static FileAnalyzer getAnalyzer(InputStream in, String file) throws IOException {
         FileAnalyzerFactory factory = find(in, file);
         if (factory == null) {
-            return getAnalyzer();
+            FileAnalyzer defaultAnalyzer = getAnalyzer();
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, "{0}: fallback {1}",
+                    new Object[]{ file,
+                    defaultAnalyzer.getClass().getSimpleName() });
+            }
+            return defaultAnalyzer;
         }
         return factory.getAnalyzer();
     }
@@ -519,7 +558,7 @@ public class AnalyzerGuru {
         if (factory != null) {
             return factory;
         }
-        return find(in);
+        return findForStream(in, file);
     }
 
     /**
@@ -547,6 +586,11 @@ public class AnalyzerGuru {
                 factory
                         = pre.get(path.substring(0, dotpos).toUpperCase(Locale.getDefault()));
                 if (factory != null) {
+                    if (LOGGER.isLoggable(Level.FINER)) {
+                        LOGGER.log(Level.FINER, "{0}: chosen by prefix: {1}",
+                            new Object[]{ file,
+                            factory.getClass().getSimpleName() });
+                    }
                     return factory;
                 }
             }
@@ -557,6 +601,11 @@ public class AnalyzerGuru {
             factory
                     = ext.get(path.substring(dotpos + 1).toUpperCase(Locale.getDefault()));
             if (factory != null) {
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.log(Level.FINER, "{0}: chosen by suffix: {1}",
+                        new Object[]{ file,
+                        factory.getClass().getSimpleName() });
+                }
                 return factory;
             }
         }
@@ -574,6 +623,22 @@ public class AnalyzerGuru {
      * the stream
      */
     public static FileAnalyzerFactory find(InputStream in) throws IOException {
+        return findForStream(in, "<anonymous>");
+    }
+
+    /**
+     * Finds a suitable analyzer class for the data in this stream
+     * corresponding to a file of the specified name
+     *
+     * @param in The stream containing the data to analyze
+     * @param file The file name to get the analyzer for
+     * @return the analyzer factory to use
+     * @throws java.io.IOException if an error occurs while reading data from
+     * the stream
+     */
+    private static FileAnalyzerFactory findForStream(InputStream in,
+        String file) throws IOException {
+
         in.mark(8);
         byte[] content = new byte[8];
         int len = in.read(content);
@@ -589,14 +654,88 @@ public class AnalyzerGuru {
             content = Arrays.copyOf(content, len);
         }
 
-        FileAnalyzerFactory factory = find(content);
-        if (factory != null) {
-            return factory;
+        FileAnalyzerFactory fac;
+
+        // First, do precise-magic Matcher matching
+        for (FileAnalyzerFactory.Matcher matcher : matchers) {
+            if (matcher.getIsPreciseMagic()) {
+                fac = matcher.isMagic(content, in);
+                if (fac != null) {
+                    if (LOGGER.isLoggable(Level.FINER)) {
+                        LOGGER.log(Level.FINER,
+                            "{0}: chosen by precise magic: {1}", new Object[]{
+                            file, fac.getClass().getSimpleName() });
+                    }
+                    return fac;
+                }
+            }
         }
 
+        // Next, look for magic strings
+        String opening = readOpening(in, content);
+        fac = findMagicString(opening, file);
+        if (fac != null) {
+            return fac;
+        }
+
+        // Last, do imprecise-magic Matcher matching
         for (FileAnalyzerFactory.Matcher matcher : matchers) {
-            FileAnalyzerFactory fac = matcher.isMagic(content, in);
-            if (fac != null) {
+            if (!matcher.getIsPreciseMagic()) {
+                fac = matcher.isMagic(content, in);
+                if (fac != null) {
+                    if (LOGGER.isLoggable(Level.FINER)) {
+                        LOGGER.log(Level.FINER,
+                            "{0}: chosen by imprecise magic: {1}",
+                            new Object[]{ file,
+                            fac.getClass().getSimpleName() });
+                    }
+                    return fac;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static FileAnalyzerFactory findMagicString(String opening,
+        String file)
+            throws IOException {
+
+        // first, try to look up two words in magics
+        String fragment = getWords(opening, 2);
+        FileAnalyzerFactory fac = magics.get(fragment);
+        if (fac != null) {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.log(Level.FINER, "{0}: chosen by magic {2}: {1}",
+                    new Object[]{ file, fac.getClass().getSimpleName(),
+                    fragment});
+            }
+            return fac;
+        }
+
+        // second, try to look up one word in magics
+        fragment = getWords(opening, 1);
+        fac = magics.get(fragment);
+        if (fac != null) {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.log(Level.FINER, "{0}: chosen by magic {2}: {1}",
+                    new Object[]{ file, fac.getClass().getSimpleName(),
+                    fragment});
+            }
+            return fac;
+        }
+
+        // try to match initial substrings (DESC strlen)
+        for (Map.Entry<String, FileAnalyzerFactory> entry :
+            magics.entrySet()) {
+            String magic = entry.getKey();
+            if (opening.startsWith(magic)) {
+                fac = entry.getValue();
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.log(Level.FINER,
+                        "{0}: chosen by magic(substr) {2}: {1}", new Object[]{
+                        file, fac.getClass().getSimpleName(), magic});
+                }
                 return fac;
             }
         }
@@ -605,41 +744,96 @@ public class AnalyzerGuru {
     }
 
     /**
-     * Finds a suitable analyzer class for a magic signature
+     * Extract initial words from a String, or take the entire
+     * <code>value</code> if not enough words can be identified. (If
+     * <code>n</code> is not 1 or more, returns an empty String.) (A "word"
+     * ends at each and every space character.)
      *
-     * @param signature the magic signature look up
-     * @return the analyzer factory to use
+     * @param value The source from which words are cut
+     * @param n The number of words to try to extract
+     * @return The extracted words or <code>""</code>
      */
-    private static FileAnalyzerFactory find(byte[] signature)
-            throws IOException {
-        // XXX this assumes ISO-8859-1 encoding (and should work in most cases
-        // for US-ASCII, UTF-8 and other ISO-8859-* encodings, but not always),
-        // we should try to be smarter than this...
-        char[] chars = new char[signature.length > 8 ? 8 : signature.length];
-        for (int i = 0; i < chars.length; i++) {
-            chars[i] = (char) (0xFF & signature[i]);
+    private static String getWords(String value, int n) {
+        if (n < 1) return "";
+        int l = 0;
+        while (n-- > 0) {
+            int o = l > 0 ? l + 1 : l;
+            int i = value.indexOf(' ', o);
+            if (i == -1) return value;
+            l = i;
+        }
+        return value.substring(0, l);
+    }
+
+    /**
+     * Extract an opening string from the input stream, past any BOM, and past
+     * any initial whitespace, but only up to <code>OPENING_MAX_CHARS</code> or
+     * to the first <code>\n</code> after any non-whitespace. (Hashbang, #!,
+     * openings will have superfluous space removed.)
+     *
+     * @param in The input stream containing the data
+     * @param sig The initial sequence of bytes in the input stream
+     * @return The extracted string or <code>""</code>
+     * @throws java.io.IOException in case of any read error
+     */
+    private static String readOpening(InputStream in, byte[] sig)
+        throws IOException {
+
+        in.mark(512);
+
+        String encoding = findBOMEncoding(sig);
+        if (encoding == null) {
+            encoding = "UTF-8";
+        } else {
+            byte[] bom = BOMS.get(encoding);
+            if (in.skip(bom.length) < bom.length) {
+                in.reset();
+                return "";
+            }
         }
 
-        String sig = new String(chars);
+        int nRead = 0;
+        boolean sawNonWhitespace = false;
+        boolean lastWhitespace = false;
+        boolean postHashbang = false;
+        int r;
 
-        FileAnalyzerFactory a = magics.get(sig);
-        if (a == null) {
-            String sigWithoutBOM = stripBOM(signature);
-            for (Map.Entry<String, FileAnalyzerFactory> entry
-                    : magics.entrySet()) {
-                if (sig.startsWith(entry.getKey())) {
-                    return entry.getValue();
-                }
-                // See if text files have the magic sequence if we remove the
-                // byte-order marker
-                if (sigWithoutBOM != null
-                        && entry.getValue().getGenre() == Genre.PLAIN
-                        && sigWithoutBOM.startsWith(entry.getKey())) {
-                    return entry.getValue();
+        StringBuilder opening = new StringBuilder();
+        BufferedReader readr = new BufferedReader(
+            new InputStreamReader(in, encoding), OPENING_BUF_SIZE);
+        while ((r = readr.read()) != -1)
+        {
+            if (++nRead > OPENING_MAX_CHARS) break;
+            char c = (char)r;
+            boolean isWhitespace = Character.isWhitespace(c);
+            if (!sawNonWhitespace) {
+                if (isWhitespace) continue;
+                sawNonWhitespace = true;
+            }
+            if (c == '\n') break;
+
+            if (isWhitespace) {
+                // Track `lastWhitespace' to condense stretches of whitespace,
+                // and use ' ' regardless of actual whitespace character to
+                // accord with magic string definitions.
+                if (!lastWhitespace && !postHashbang) opening.append(' ');
+            } else {
+                opening.append(c);
+                postHashbang = false;
+            }
+            lastWhitespace = isWhitespace;
+
+            // If the opening starts with "#!", then track so that any
+            // trailing whitespace after the hashbang is ignored.
+            if (opening.length() == 2) {
+                if (opening.charAt(0) == '#' && opening.charAt(1) == '!') {
+                    postHashbang = true;
                 }
             }
         }
-        return a;
+
+        in.reset();
+        return opening.toString();
     }
 
     /**
@@ -655,14 +849,13 @@ public class AnalyzerGuru {
     }
 
     /**
-     * Strip away the byte-order marker from the string, if it has one.
+     * Gets a value indicating a UTF encoding if the array starts with a
+     * known byte sequence
      *
-     * @param sig a sequence of bytes from which to remove the BOM
-     * @return a string without the byte-order marker, or <code>null</code> if
-     * the string doesn't start with a BOM
-     * @throws java.io.IOException in case of any read error
+     * @param sig a sequence of bytes to inspect for a BOM
+     * @return null if no BOM was identified; otherwise a defined charset name
      */
-    public static String stripBOM(byte[] sig) throws IOException {
+    private static String findBOMEncoding(byte[] sig) {
         for (Map.Entry<String, byte[]> entry : BOMS.entrySet()) {
             String encoding = entry.getKey();
             byte[] bom = entry.getValue();
@@ -671,16 +864,26 @@ public class AnalyzerGuru {
                 while (i < bom.length && sig[i] == bom[i]) {
                     i++;
                 }
-                if (i == bom.length) {
-                    // BOM matched beginning of signature
-                    return new String(
-                            sig,
-                            bom.length, // offset
-                            sig.length - bom.length, // length
-                            encoding);
-                }
+                if (i == bom.length) return encoding;
             }
         }
         return null;
+    }
+
+    /**
+     * Gets a value indicating the number of UTF BOM bytes at the start of an
+     * array
+     *
+     * @param sig a sequence of bytes to inspect for a BOM
+     * @return 0 if the array doesn't start with a BOM; otherwise the number of
+     * BOM bytes
+     */
+    public static int skipForBOM(byte[] sig) {
+        String encoding = findBOMEncoding(sig);
+        if (encoding != null) {
+            byte[] bom = BOMS.get(encoding);
+            return bom.length;
+        }
+        return 0;
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/FileAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/FileAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -148,7 +149,7 @@ public class FileAnalyzerFactory {
      * should be used to analyze it.
      *
      * <p><b>Note:</b> Currently this assumes that the file is encoded with
-     * ISO-8859-1.
+     * UTF-8 unless a BOM is detected.
      *
      * @return list of magic strings
      */
@@ -220,6 +221,11 @@ public class FileAnalyzerFactory {
      * Interface for matchers which map file contents to analyzer factories.
      */
     protected interface Matcher {
+
+        /**
+         * Get a value indicating if the magic is byte-precise.
+         */
+        default boolean getIsPreciseMagic() { return false; }
 
         /**
          * Try to match the file contents with an analyzer factory.

--- a/src/org/opensolaris/opengrok/analysis/archive/ZipAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/archive/ZipAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.archive;
@@ -62,6 +63,9 @@ public final class ZipAnalyzerFactory extends FileAnalyzerFactory {
         }
 
         private static final int XFHSIZ = 4;
+
+        @Override
+        public boolean getIsPreciseMagic() { return true; }
 
         @Override
         public FileAnalyzerFactory isMagic(byte[] contents, InputStream in)

--- a/src/org/opensolaris/opengrok/analysis/executables/JavaClassAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/executables/JavaClassAnalyzerFactory.java
@@ -36,7 +36,7 @@ public class JavaClassAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     private static final String[] MAGICS = {
-        "\312\376\272\276"      // cafebabe
+        new String(new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE})
     };
 
     public JavaClassAnalyzerFactory() {

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.plain;
@@ -50,18 +51,18 @@ public final class PlainAnalyzerFactory extends FileAnalyzerFactory {
             }
 
             /**
-             * Check whether the byte array contains plain text. First, check
-             * assuming US-ASCII encoding. Then, if unsuccessful, try to
-             * strip away Unicode byte-order marks and try again.
+             * Check whether the byte array contains plain text. First, look
+             * for a UTF BOM; otherwise, inspect as if US-ASCII.
              */
             private boolean isPlainText(byte[] content) throws IOException {
+                int lengthBOM = AnalyzerGuru.skipForBOM(content);
+                if (lengthBOM > 0) return true;
                 String ascii = new String(content, "US-ASCII");
                 if (isPlainText(ascii)) {
                     return true;
                 }
 
-                String noBOM = AnalyzerGuru.stripBOM(content);
-                return (noBOM != null) && isPlainText(noBOM);
+                return false;
             }
 
             /**

--- a/test/org/opensolaris/opengrok/analysis/AnalyzerGuruTest.java
+++ b/test/org/opensolaris/opengrok/analysis/AnalyzerGuruTest.java
@@ -36,6 +36,7 @@ import java.util.zip.ZipOutputStream;
 import org.junit.Test;
 import org.opensolaris.opengrok.analysis.archive.ZipAnalyzer;
 import org.opensolaris.opengrok.analysis.c.CxxAnalyzerFactory;
+import org.opensolaris.opengrok.analysis.executables.ELFAnalyzer;
 import org.opensolaris.opengrok.analysis.executables.JarAnalyzer;
 import org.opensolaris.opengrok.analysis.executables.JavaClassAnalyzer;
 import org.opensolaris.opengrok.analysis.perl.PerlAnalyzer;
@@ -252,6 +253,16 @@ public class AnalyzerGuruTest {
                 "#!/usr/bin/env\nperl".getBytes("US-ASCII"));
         assertNotSame("despite env hashbang LF,", PerlAnalyzer.class,
             AnalyzerGuru.getAnalyzer(in, "dummy").getClass());
+    }
+
+    @Test
+    public void shouldMatchELFMagic() throws Exception {
+        byte[] elfmt = {(byte)0x7F, 'E', 'L', 'F', (byte) 2, (byte) 2, (byte) 1,
+            (byte) 0x06};
+        ByteArrayInputStream in = new ByteArrayInputStream(elfmt);
+        FileAnalyzer fa = AnalyzerGuru.getAnalyzer(in, "/dummy/file");
+        assertSame("despite \\177ELF magic,", ELFAnalyzer.class,
+            fa.getClass());
     }
 
     @Test

--- a/test/org/opensolaris/opengrok/analysis/AnalyzerGuruTest.java
+++ b/test/org/opensolaris/opengrok/analysis/AnalyzerGuruTest.java
@@ -96,7 +96,7 @@ public class AnalyzerGuruTest {
     @Test
     public void testUTF16BigByteOrderMarkPlusCopyrightSymbol() throws Exception {
         byte[] doc = {(byte) 0xFE, (byte) 0xFF, // UTF-16BE BOM
-                       '/', '/', ' ', (byte) 0xC2, (byte) 0xA9};
+                       0, '#', 0, ' ', (byte) 0xC2, (byte) 0xA9};
         ByteArrayInputStream in = new ByteArrayInputStream(doc);
         FileAnalyzer fa = AnalyzerGuru.getAnalyzer(in, "/dummy/file");
         assertSame("despite BOM as precise match,", PlainAnalyzer.class,
@@ -106,7 +106,7 @@ public class AnalyzerGuruTest {
     @Test
     public void testUTF16LittleByteOrderMarkPlusCopyrightSymbol() throws Exception {
         byte[] doc = {(byte) 0xFF, (byte) 0xFE, // UTF-16BE BOM
-                       '/', '/', ' ', (byte) 0xA9, (byte) 0xC2};
+                       '#', 0, ' ', 0, (byte) 0xA9, (byte) 0xC2};
         ByteArrayInputStream in = new ByteArrayInputStream(doc);
         FileAnalyzer fa = AnalyzerGuru.getAnalyzer(in, "/dummy/file");
         assertSame("despite BOM as precise match,", PlainAnalyzer.class,

--- a/test/org/opensolaris/opengrok/analysis/AnalyzerGuruTest.java
+++ b/test/org/opensolaris/opengrok/analysis/AnalyzerGuruTest.java
@@ -96,7 +96,7 @@ public class AnalyzerGuruTest {
     @Test
     public void testUTF16BigByteOrderMarkPlusCopyrightSymbol() throws Exception {
         byte[] doc = {(byte) 0xFE, (byte) 0xFF, // UTF-16BE BOM
-                       '/', '/', ' ', (byte) 0x00, (byte) 0xA9};
+                       '/', '/', ' ', (byte) 0xC2, (byte) 0xA9};
         ByteArrayInputStream in = new ByteArrayInputStream(doc);
         FileAnalyzer fa = AnalyzerGuru.getAnalyzer(in, "/dummy/file");
         assertSame("despite BOM as precise match,", PlainAnalyzer.class,
@@ -106,7 +106,7 @@ public class AnalyzerGuruTest {
     @Test
     public void testUTF16LittleByteOrderMarkPlusCopyrightSymbol() throws Exception {
         byte[] doc = {(byte) 0xFF, (byte) 0xFE, // UTF-16BE BOM
-                       '/', '/', ' ', (byte) 0xA9, (byte) 0x00};
+                       '/', '/', ' ', (byte) 0xA9, (byte) 0xC2};
         ByteArrayInputStream in = new ByteArrayInputStream(doc);
         FileAnalyzer fa = AnalyzerGuru.getAnalyzer(in, "/dummy/file");
         assertSame("despite BOM as precise match,", PlainAnalyzer.class,


### PR DESCRIPTION
- Fix so magics (TreeMap) lookup can work by inspecting it with full
  two- (e.g. "/usr/bin/env perl") or one-word (e.g. "/usr/bin/perl") magics
  extracted from file contents.
- Condense spaced, extracted hashbangs for lookup (e.g.,
  " #! /usr/bin/env  perl" to "#!/usr/bin/env perl").
- Add Comparator so longer magic strings are checked first during the
  imprecise phase of matching (so ShAnalyzerFactory's short "#!" magic is not
  accidentally preferred).
- Add property, isPreciseMagic, to FileAnalyzerFactory.Matcher so byte-precise
  magic detection can be done early. (Only ZipAnalyzerFactory now has this set
  to true.)
- Use a UTF BOM as a precise indication of plain text in the otherwise
  now-imprecise PlainAnalyzerFactory.Matcher.isMagic().
