### PR TITLE
Improve Perl // heuristic to allow arbitrary whitespace between tokens

### DIFF
--- a/testdata/sources/perl/main.pl
+++ b/testdata/sources/perl/main.pl
@@ -151,9 +151,16 @@ if (/pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./) { print; }
 if (1 && /pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./) { print; }
 if (0 || /pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./) { print; }
 print if /pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./;
+print unless
+
+
+	/pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./;
 
 my @o = $contents =~
+
+
     /^(?>\S+) \s* := \s* LINKSRC \s* = \s* \S+/mxg;
+
 foreach my $v (@o) { # This loop shouldn't mistakenly be inside the previous m//
 	print $v;
 }

--- a/testdata/sources/perl/main.pl
+++ b/testdata/sources/perl/main.pl
@@ -145,11 +145,13 @@ THAT
 #
 
 $var =~ /pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./ && print;
+$var !~/pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./ && print;
 /pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./ && print;
 (/pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./) && print;
 if (/pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./) { print; }
 if (1 && /pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./) { print; }
 if (0 || /pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./) { print; }
+print or/pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./;
 print if /pP \"\'\(\)\<\>\{\}\[\]\/\# et $var./;
 print unless
 


### PR DESCRIPTION
Hello,

Please consider for integration the attached patch to improve the Perl // heuristic to allow arbitrary whitespace between tokens instead of just a single LF.

Also:
- remove no-longer-needed splitEol() and the fields: value1, value2

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
