### PR TITLE
Feature/macos tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 nbproject/*~
+/nbproject/configs/*.properties
 opengrok-web-nbproject/nbproject/*~
 opengrok-web-nbproject/nbproject/build-impl.xml~
 tags

--- a/src/org/opensolaris/opengrok/analysis/IteratorReader.java
+++ b/src/org/opensolaris/opengrok/analysis/IteratorReader.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -36,12 +37,19 @@ public final class IteratorReader extends Reader {
     private StringReader current;
 
     public IteratorReader(Iterable<String> iterable) {
-        this(iterable.iterator());
+        if (iterable == null) {
+            throw new IllegalArgumentException("`iterable' is null");
+        }
+        Iterator<String> iter = iterable.iterator();
+        if (iter == null) {
+            throw new IllegalArgumentException("`iterable' did not produce iterator");
+        }
+        this.iterator = iter;
     }
 
     public IteratorReader(Iterator<String> iterator) {
         if (iterator == null) {
-            throw new NullPointerException();
+            throw new IllegalArgumentException("`iterator' is null");
         }
         this.iterator = iterator;
     }

--- a/src/org/opensolaris/opengrok/history/Repository.java
+++ b/src/org/opensolaris/opengrok/history/Repository.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -91,6 +92,15 @@ public abstract class Repository extends RepositoryInfo {
         super();
         ignoredFiles = new ArrayList<String>();
         ignoredDirs = new ArrayList<String>();
+    }
+
+    /**
+     * Gets the instance's repository command, primarily for testing purposes.
+     * @return null if not {@link isWorking}, or otherwise a defined command
+     */
+    public String getRepoCommand() {
+        isWorking();
+        return RepoCommand;
     }
 
     /**

--- a/src/org/opensolaris/opengrok/history/TagEntry.java
+++ b/src/org/opensolaris/opengrok/history/TagEntry.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2012, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -65,7 +66,7 @@ public abstract class TagEntry implements Comparable {
 
     public TagEntry(Date date, String tags) {
         if (date == null) {
-            throw new NullPointerException("Can't create TagEntry using date==null");
+            throw new IllegalArgumentException("`date' is null");
         }
         this.revision = NOREV;
         this.date = date;

--- a/src/org/opensolaris/opengrok/search/context/HistoryContext.java
+++ b/src/org/opensolaris/opengrok/search/context/HistoryContext.java
@@ -19,7 +19,6 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.search.context;
@@ -83,11 +82,9 @@ public class HistoryContext {
             return false;
         }
         File f = new File(filename);
-        History hist = HistoryGuru.getInstance().getHistory(f);
-        if (hist == null) {
-            throw new HistoryException("Could not get History for " + filename);
-        }
-        return getHistoryContext(hist, path, null, hits, null);
+        return getHistoryContext(HistoryGuru.getInstance().getHistory(f),
+                                 path, null, hits,null);
+
     }
 
     public boolean getContext(
@@ -117,10 +114,7 @@ public class HistoryContext {
             return false;
         }
         History hist = HistoryGuru.getInstance().getHistory(src);
-        if (hist == null) {
-            throw new HistoryException("Could not get History for " + src);
-        }
-        return getHistoryContext(hist, path, out, null, context);
+        return getHistoryContext(hist, path, out, null,context);
     }
 
     /**

--- a/src/org/opensolaris/opengrok/search/context/HistoryContext.java
+++ b/src/org/opensolaris/opengrok/search/context/HistoryContext.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.search.context;

--- a/src/org/opensolaris/opengrok/search/context/HistoryContext.java
+++ b/src/org/opensolaris/opengrok/search/context/HistoryContext.java
@@ -82,9 +82,11 @@ public class HistoryContext {
             return false;
         }
         File f = new File(filename);
-        return getHistoryContext(HistoryGuru.getInstance().getHistory(f),
-                                 path, null, hits,null);
-
+        History hist = HistoryGuru.getInstance().getHistory(f);
+        if (hist == null) {
+            throw new HistoryException("Could not get History for " + filename);
+        }
+        return getHistoryContext(hist, path, null, hits, null);
     }
 
     public boolean getContext(
@@ -114,7 +116,10 @@ public class HistoryContext {
             return false;
         }
         History hist = HistoryGuru.getInstance().getHistory(src);
-        return getHistoryContext(hist, path, out, null,context);
+        if (hist == null) {
+            throw new HistoryException("Could not get History for " + src);
+        }
+        return getHistoryContext(hist, path, out, null, context);
     }
 
     /**

--- a/test/org/opensolaris/opengrok/analysis/IteratorReaderTest.java
+++ b/test/org/opensolaris/opengrok/analysis/IteratorReaderTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -54,16 +55,16 @@ public class IteratorReaderTest {
      * Test that we get an error immediately when constructing a token stream
      * where the list is {@code null}.
      */
-    @Test(expected= NullPointerException.class)
+    @Test(expected= IllegalArgumentException.class)
     public void testFailfastOnNull() {
         new IteratorReader((List<String>) null);
     }
 
     /**
-     * Test that a {@code NullPointerException} is thrown immediately also
+     * Test that an {@code IllegalArgumentException} is thrown immediately also
      * when using the constructor that takes an {@code Iterator}.
      */
-    @Test(expected= NullPointerException.class)
+    @Test(expected= IllegalArgumentException.class)
     public void testFailfastOnNullIterator() {
         new IteratorReader((Iterator<String>) null);
     }

--- a/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkTest.java
+++ b/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkTest.java
@@ -19,6 +19,7 @@
 
  /*
  * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.authorization;
 
@@ -33,6 +34,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.opensolaris.opengrok.condition.DeliberateRuntimeException;
 import org.opensolaris.opengrok.configuration.Group;
 import org.opensolaris.opengrok.configuration.Nameable;
 import org.opensolaris.opengrok.configuration.Project;
@@ -741,7 +743,7 @@ public class AuthorizationFrameworkTest {
         return new TestPlugin() {
             @Override
             public void load(Map<String, Object> parameters) {
-                throw new NullPointerException("This plugin failed while loading.");
+                throw new DeliberateRuntimeException("This plugin failed while loading.");
             }
 
             @Override
@@ -766,12 +768,12 @@ public class AuthorizationFrameworkTest {
         return new TestPlugin() {
             @Override
             public boolean isAllowed(HttpServletRequest request, Project project) {
-                throw new NullPointerException("This plugin failed while checking.");
+                throw new DeliberateRuntimeException("This plugin failed while checking.");
             }
 
             @Override
             public boolean isAllowed(HttpServletRequest request, Group group) {
-                throw new NullPointerException("This plugin failed while checking.");
+                throw new DeliberateRuntimeException("This plugin failed while checking.");
             }
 
             @Override

--- a/test/org/opensolaris/opengrok/condition/DeliberateRuntimeException.java
+++ b/test/org/opensolaris/opengrok/condition/DeliberateRuntimeException.java
@@ -1,0 +1,36 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+ /*
+ * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ */
+package org.opensolaris.opengrok.condition;
+
+/**
+ * Represents an intentional exception thrown for testing purposes
+ * <p>
+ * https://stackoverflow.com/a/1754473/933163
+ * https://stackoverflow.com/questions/1754315/how-to-create-custom-exceptions-in-java
+ */
+public class DeliberateRuntimeException extends RuntimeException {
+      public DeliberateRuntimeException() { super(); }
+      public DeliberateRuntimeException(String message) { super(message); }
+      public DeliberateRuntimeException(String message, Throwable cause) { super(message, cause); }
+      public DeliberateRuntimeException(Throwable cause) { super(cause); }
+}

--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -19,6 +19,7 @@
 
  /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.configuration;
 

--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -199,7 +199,11 @@ public class RuntimeEnvironmentTest {
     @Test
     public void testCtags() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
-        assertEquals("ctags", instance.getCtags());
+        String instanceCtags = instance.getCtags();
+        assertNotNull(instanceCtags);
+        assertTrue("instance ctags should equals 'ctags' or the sys property",
+            instanceCtags.equals("ctags") || instanceCtags.equals(
+            System.getProperty("org.opensolaris.opengrok.analysis.Ctags")));
         String path = "/usr/bin/ctags";
         instance.setCtags(path);
         assertEquals(path, instance.getCtags());

--- a/test/org/opensolaris/opengrok/configuration/messages/ProjectMessageTest.java
+++ b/test/org/opensolaris/opengrok/configuration/messages/ProjectMessageTest.java
@@ -82,12 +82,14 @@ public class ProjectMessageTest {
 
     @After
     public void tearDown() {
-        env.removeAllMessages();
-        
-        // This should match Configuration constructor.
-        env.setProjects(new ConcurrentHashMap<>());
-        env.setRepositories(new ArrayList<RepositoryInfo>());
-        env.getProjectRepositoriesMap().clear();
+        if (env != null) {
+            env.removeAllMessages();
+
+            // This should match Configuration constructor.
+            env.setProjects(new ConcurrentHashMap<>());
+            env.setRepositories(new ArrayList<RepositoryInfo>());
+            env.getProjectRepositoriesMap().clear();
+        }
 
         repository.destroy();
     }

--- a/test/org/opensolaris/opengrok/configuration/messages/ProjectMessageTest.java
+++ b/test/org/opensolaris/opengrok/configuration/messages/ProjectMessageTest.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -161,6 +162,7 @@ public class ProjectMessageTest {
         File subDir = new File(mercurialRoot, "usr");
         Assert.assertTrue(subDir.mkdir());
         String subRepoPath = repoPath + File.separator + "usr" + File.separator + "closed";
+        File mercurialSubRoot = new File(subRepoPath);
         MercurialRepositoryTest.runHgCommand(mercurialRoot,
             "clone", mercurialRoot.getAbsolutePath(), subRepoPath);
 
@@ -179,12 +181,15 @@ public class ProjectMessageTest {
                 collect(Collectors.toSet()).size());
 
         // Check that HistoryGuru now includes the project in its list.
-        Assert.assertTrue(HistoryGuru.getInstance().getRepositories().stream().
-                map(ri -> ri.getDirectoryName()).collect(Collectors.toSet()).
-                contains(repoPath));
-        Assert.assertTrue(HistoryGuru.getInstance().getRepositories().stream().
-                map(ri -> ri.getDirectoryName()).collect(Collectors.toSet()).
-                contains(subRepoPath));
+        Set<String> directoryNames = HistoryGuru.getInstance().
+            getRepositories().stream().map(ri -> ri.getDirectoryName()).
+            collect(Collectors.toSet());
+        Assert.assertTrue("though it should contain the top root,",
+            directoryNames.contains(repoPath) || directoryNames.contains(
+            mercurialRoot.getCanonicalPath()));
+        Assert.assertTrue("though it should contain the sub-root,",
+            directoryNames.contains(subRepoPath) || directoryNames.contains(
+            mercurialSubRoot.getCanonicalPath()));
         
         // Add more projects and check that they have been added incrementally.
         // At the same time, it checks that multiple projects can be added

--- a/test/org/opensolaris/opengrok/configuration/messages/ProjectMessageTest.java
+++ b/test/org/opensolaris/opengrok/configuration/messages/ProjectMessageTest.java
@@ -19,6 +19,7 @@
 
  /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.configuration.messages;
 

--- a/test/org/opensolaris/opengrok/history/GitRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/GitRepositoryTest.java
@@ -181,11 +181,12 @@ public class GitRepositoryTest {
                 = (GitRepository) RepositoryFactory.getRepository(root);
         int i = 0;
         for (String[] test : tests) {
-            String file = root.getAbsolutePath() + File.separator + test[0];
+            String file = root.getCanonicalPath() + File.separator + test[0];
             String changeset = test[1];
-            String expected = root.getAbsolutePath() + File.separator + test[2];
+            String expected = root.getCanonicalPath() + File.separator + test[2];
             try {
-                Assert.assertEquals(expected, gitrepo.findOriginalName(file, changeset));
+                String originalName = gitrepo.findOriginalName(file, changeset);
+                Assert.assertEquals(expected, originalName);
             } catch (IOException ex) {
                 Assert.fail(String.format("Looking for original name of {} in {} shouldn't fail", file, changeset));
             }

--- a/test/org/opensolaris/opengrok/history/GitRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/GitRepositoryTest.java
@@ -19,6 +19,7 @@
 
  /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 

--- a/test/org/opensolaris/opengrok/history/MercurialRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/MercurialRepositoryTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -166,7 +167,8 @@ public class MercurialRepositoryTest {
      */
     static public void runHgCommand(File reposRoot, String ... args) {
         List<String> cmdargs = new ArrayList<>();
-        cmdargs.add(MercurialRepository.CMD_FALLBACK);
+        MercurialRepository repo = new MercurialRepository();
+        cmdargs.add(repo.getRepoCommand());
         for (String arg: args) {
             cmdargs.add(arg);
         }

--- a/test/org/opensolaris/opengrok/index/IndexerTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.index;
 

--- a/test/org/opensolaris/opengrok/index/IndexerTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerTest.java
@@ -41,9 +41,13 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.opensolaris.opengrok.analysis.AnalyzerGuru;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
+import org.opensolaris.opengrok.condition.ConditionalRun;
+import org.opensolaris.opengrok.condition.ConditionalRunRule;
+import org.opensolaris.opengrok.condition.RepositoryInstalled;
 import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.history.HistoryGuru;
@@ -68,8 +72,8 @@ public class IndexerTest {
     TestRepository repository;
     private final String ctagsProperty = "org.opensolaris.opengrok.analysis.Ctags";
 
-    public IndexerTest() {
-    }
+    @Rule
+    public ConditionalRunRule rule = new ConditionalRunRule();
 
     @BeforeClass
     public static void setUpClass() throws Exception {
@@ -323,6 +327,7 @@ public class IndexerTest {
      * @throws Exception 
      */
     @Test
+    @ConditionalRun(condition = RepositoryInstalled.MercurialInstalled.class)
     public void testRemoveFileOnFileChange() throws Exception {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 

--- a/test/org/opensolaris/opengrok/index/IndexerTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerTest.java
@@ -355,6 +355,7 @@ public class IndexerTest {
         listener.reset();
 
         // Change a file so that it gets picked up by the indexer.
+        Thread.sleep(1100);
         File bar = new File(testrepo.getSourceRoot() + File.separator + "mercurial",
                 "bar.txt");
         Assert.assertTrue(bar.exists());

--- a/test/org/opensolaris/opengrok/search/context/HistoryContextTest.java
+++ b/test/org/opensolaris/opengrok/search/context/HistoryContextTest.java
@@ -35,6 +35,7 @@ import org.apache.lucene.search.TermQuery;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.opensolaris.opengrok.history.HistoryGuru;
 import org.opensolaris.opengrok.search.Hit;
@@ -43,6 +44,9 @@ import org.opensolaris.opengrok.util.TestRepository;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import org.opensolaris.opengrok.condition.ConditionalRun;
+import org.opensolaris.opengrok.condition.ConditionalRunRule;
+import org.opensolaris.opengrok.condition.RepositoryInstalled;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 
 /**
@@ -51,6 +55,9 @@ import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 public class HistoryContextTest {
 
     private static TestRepository repositories;
+
+    @Rule
+    public ConditionalRunRule rule = new ConditionalRunRule();
 
     @BeforeClass
     public static void setUpClass() throws Exception {
@@ -87,6 +94,7 @@ public class HistoryContextTest {
     }
 
     @Test
+    @ConditionalRun(condition = RepositoryInstalled.MercurialInstalled.class)
     public void testGetContext_3args() throws Exception {
         String path = "/mercurial/Makefile";
         String filename = repositories.getSourceRoot() + path;
@@ -129,6 +137,7 @@ public class HistoryContextTest {
     }
 
     @Test
+    @ConditionalRun(condition = RepositoryInstalled.MercurialInstalled.class)
     public void testGetContext_4args() throws Exception {
         String path = "/mercurial/Makefile";
         File file = new File(repositories.getSourceRoot() + path);

--- a/test/org/opensolaris/opengrok/search/context/HistoryContextTest.java
+++ b/test/org/opensolaris/opengrok/search/context/HistoryContextTest.java
@@ -102,7 +102,8 @@ public class HistoryContextTest {
         // Construct a query equivalent to hist:dummy
         TermQuery q1 = new TermQuery(new Term("hist", "dummy"));
         ArrayList<Hit> hits = new ArrayList<>();
-        assertTrue(new HistoryContext(q1).getContext(filename, path, hits));
+        boolean gotCtx = new HistoryContext(q1).getContext(filename, path, hits);
+        assertTrue(gotCtx);
         assertEquals(1, hits.size());
         assertTrue(hits.get(0).getLine().contains(
                 "Created a small <b>dummy</b> program"));
@@ -112,7 +113,8 @@ public class HistoryContextTest {
         q2.add(new Term("hist", "dummy"));
         q2.add(new Term("hist", "program"));
         hits.clear();
-        assertTrue(new HistoryContext(q2.build()).getContext(filename, path, hits));
+        gotCtx = new HistoryContext(q2.build()).getContext(filename, path, hits);
+        assertTrue(gotCtx);
         assertEquals(1, hits.size());
         assertTrue(hits.get(0).getLine().contains(
                 "Created a small <b>dummy program</b>"));
@@ -120,7 +122,8 @@ public class HistoryContextTest {
         // Search for a term that doesn't exist
         TermQuery q3 = new TermQuery(new Term("hist", "term_does_not_exist"));
         hits.clear();
-        assertFalse(new HistoryContext(q3).getContext(filename, path, hits));
+        gotCtx = new HistoryContext(q3).getContext(filename, path, hits);
+        assertFalse(gotCtx);
         assertEquals(0, hits.size());
 
         // Search for term with multiple hits - hist:small OR hist:target
@@ -128,7 +131,8 @@ public class HistoryContextTest {
         q4.add(new TermQuery(new Term("hist", "small")), Occur.SHOULD);
         q4.add(new TermQuery(new Term("hist", "target")), Occur.SHOULD);
         hits.clear();
-        assertTrue(new HistoryContext(q4.build()).getContext(filename, path, hits));
+        gotCtx = new HistoryContext(q4.build()).getContext(filename, path, hits);
+        assertTrue(gotCtx);
         assertEquals(2, hits.size());
         assertTrue(hits.get(0).getLine().contains(
                 "Add lint make <b>target</b> and fix lint warnings"));

--- a/test/org/opensolaris/opengrok/search/context/HistoryContextTest.java
+++ b/test/org/opensolaris/opengrok/search/context/HistoryContextTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.search.context;


### PR DESCRIPTION
Hello,

Please consider for integration this pull request with some fixes for testing on macOS:

- Update test to allow for having set org.opensolaris.opengrok.analysis.Ctags
- Use getCanonicalPath() to allow for macOS's /var to /private/var symlink
- Decorate several methods as requiring "MercurialInstalled"
- Better to throw a HistoryException than NullReferenceException
- Do not throw NullReferenceException from a tearDown
- Store return value in local var before assertion for easier debugging

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
