### PR TITLE
project sync tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ egrok/bin
 pmd.bat
 *.iml
 .idea
+*.pyc

--- a/build.xml
+++ b/build.xml
@@ -582,6 +582,12 @@ Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
                 <include name="Messages"/>
                 <include name="Groups"/>
             </tarfileset>
+            <tarfileset dir="tools/sync" prefix="${distname}-${version}/bin/" mode="555">
+                <include name="sync.py"/>
+                <include name="command.py"/>
+                <include name="commands.py"/>
+                <include name="reindex-project.ksh"/>
+            </tarfileset>
             <tarfileset dir="doc" prefix="${distname}-${version}/doc">
                 <include name="EXAMPLE.txt"/>
                 <include name="ctags.config"/>

--- a/platform/solaris/ips/create.sh
+++ b/platform/solaris/ips/create.sh
@@ -242,6 +242,17 @@ PKG pkgsend add file tools/ConfigMerge \
 PKG pkgsend add file tools/Messages \
     mode=0555 owner=root group=bin path=/usr/opengrok/bin/Messages
 
+PKG pkgsend add file tools/sync/sync.py \
+    mode=0555 owner=root group=bin path=/usr/opengrok/bin/sync.py
+PKG pkgsend add file tools/sync/command.py \
+    mode=0555 owner=root group=bin path=/usr/opengrok/bin/command.py
+PKG pkgsend add file tools/sync/commands.py \
+    mode=0555 owner=root group=bin path=/usr/opengrok/bin/commands.py
+PKG pkgsend add file tools/sync/filelock.py \
+    mode=0555 owner=root group=bin path=/usr/opengrok/bin/filelock.py
+PKG pkgsend add file tools/sync/reindex-project.ksh \
+    mode=0555 owner=root group=bin path=/usr/opengrok/bin/reindex-project.ksh
+
 PKG pkgsend add file dist/opengrok.jar \
     mode=0444 owner=root group=bin path=/usr/opengrok/lib/opengrok.jar
 

--- a/tools/sync/README
+++ b/tools/sync/README
@@ -1,0 +1,18 @@
+
+Set of scripts to facilitate parallel project synchronization and mirroring
+
+Use e.g. like this:
+
+  # sync.py -c /scripts/sync.conf -d /ws-local/ -p
+
+where the sync.conf file contents might look like this:
+
+  {
+     "commands": [["/usr/opengrok/bin/Messages", "-c", "info", "-e", "+1 hour",
+                   "-n", "normal", "-t", "ARG", "resync + reindex in progress"],
+                  ["sudo", "-u", "wsmirror", "/scripts/mirror-project.ksh"],
+                  ["sudo", "-u", "webservd", "/scripts/reindex-project.ksh"],
+                  ["/usr/opengrok/bin/Messages", "-n", "abort", "-t"],
+                  ["/scripts/check-indexer-logs.ksh"]]
+  }
+

--- a/tools/sync/command.py
+++ b/tools/sync/command.py
@@ -1,0 +1,115 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+#
+
+import os
+import logging
+import subprocess
+from string import join
+
+
+class Command:
+    """
+    wrapper for synchronous execution of commands via subprocess.Popen()
+    and getting their output (stderr is redirected to stdout) and return value
+    """
+
+    def __init__(self, cmd, args_subst=None, args_append=None, logger=None,
+                 excl_subst=False):
+        self.cmd = cmd
+        self.state = "notrun"
+        self.excl_subst = excl_subst
+
+        self.logger = logger or logging.getLogger(__name__)
+        logging.basicConfig()
+        if args_subst or args_append:
+            self.fill_arg(args_append, args_subst)
+
+    def __str__(self):
+        return join(self.cmd)
+
+    def execute(self):
+        """
+        Execute the command and capture its output and return code.
+        """
+
+        out = []
+        try:
+            self.logger.debug("command = {}".format(self.cmd))
+            p = subprocess.Popen(self.cmd, stderr=subprocess.STDOUT,
+                                 stdout=subprocess.PIPE)
+            p.wait()
+        except KeyboardInterrupt as e:
+            self.logger.debug("Got KeyboardException while processing ",
+                              exc_info=True)
+            self.state = "interrupted"
+        except OSError as e:
+            self.logger.debug("Got OS error", exc_info=True)
+            self.state = "errored"
+        else:
+            if p.stdout is not None:
+                self.logger.debug("Program output:")
+                for line in p.stdout:
+                    self.logger.debug(line.rstrip(os.linesep))
+                    out.append(line)
+
+            self.state = "finished"
+            self.returncode = int(p.returncode)
+            self.out = out
+
+    def fill_arg(self, args_append=None, args_subst=None):
+        """
+        Replace argument names with actual values or append arguments
+        to the command vector.
+        """
+
+        newcmd = []
+        subst_done = False
+        for i, cmdarg in enumerate(self.cmd):
+            if args_subst:
+                if cmdarg in args_subst.keys():
+                    self.logger.debug("replacing cmdarg with {}".
+                                      format(args_subst[cmdarg]))
+                    newcmd.append(args_subst[cmdarg])
+                    subst_done = True
+                else:
+                    newcmd.append(self.cmd[i])
+            else:
+                newcmd.append(self.cmd[i])
+
+        if args_append and (not self.excl_subst or not subst_done):
+            self.logger.debug("appending {}".format(args_append))
+            newcmd.extend(args_append)
+
+        self.cmd = newcmd
+
+    def getretcode(self):
+        if self.state is not "finished":
+            return None
+        else:
+            return self.returncode
+
+    def getoutput(self):
+        if self.state is "finished":
+            return self.out
+        else:
+            return None

--- a/tools/sync/commands.py
+++ b/tools/sync/commands.py
@@ -1,0 +1,74 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+#
+
+import logging
+import command
+from command import Command
+import os
+
+
+class Commands:
+    """
+    Wrap the run of a set of Command instances.
+    """
+
+    def __init__(self, name, commands, logger=None):
+        self.name = name
+        self.commands = commands
+        self.failed = False
+        self.retcodes = {}
+        self.outputs = {}
+        # XXX this will not work in Python 2.x since logging contains
+        # threading stuff that does not work with multiprocessing
+        #self.logger = logger or logging.getLogger(__name__)
+        #logging.basicConfig()
+
+    def __str__(self):
+        return str(self.name)
+
+    def get_cmd_output(self, cmd, indent=""):
+        str = ""
+        #logger.debug("getting output for command {}".format(cmd))
+        for line in self.outputs[cmd]:
+            # logger.error('{}{}'.format(indent, line.rstrip(os.linesep)))
+            str += '{}{}'.format(indent, line)
+
+        return str
+
+    def run(self):
+        """
+        Run the sequence of commands and capture their output and return code.
+        First command that returns code other than 0 terminates the sequence.
+        """
+        for command in self.commands:
+            cmd = Command(command,
+                          args_subst={"ARG": self.name},
+                          args_append=[self.name], excl_subst=True)
+            cmd.execute()
+            # XXX logger.debug("{} -> {}".format(command, cmd.getretcode()))
+            # If a command fails, terminate the sequence of commands.
+            self.retcodes[str(cmd)] = cmd.getretcode()
+            self.outputs[str(cmd)] = cmd.getoutput()
+            if cmd.getretcode() != 0:
+                self.failed = True
+                break

--- a/tools/sync/filelock.py
+++ b/tools/sync/filelock.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python
+
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# For more information, please refer to <http://unlicense.org>
+
+"""
+A platform independent file lock that supports the with-statement.
+"""
+
+
+# Modules
+# ------------------------------------------------
+import logging
+import os
+import threading
+import time
+try:
+    import warnings
+except ImportError:
+    warnings = None
+
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+
+# Backward compatibility
+# ------------------------------------------------
+try:
+    TimeoutError
+except NameError:
+    TimeoutError = OSError
+
+
+# Data
+# ------------------------------------------------
+__all__ = [
+    "Timeout",
+    "BaseFileLock",
+    "WindowsFileLock",
+    "UnixFileLock",
+    "SoftFileLock",
+    "FileLock"
+]
+
+__version__ = "2.0.12"
+
+logger = logging.getLogger(__name__)
+
+
+# Exceptions
+# ------------------------------------------------
+class Timeout(TimeoutError):
+    """
+    Raised when the lock could not be acquired in *timeout*
+    seconds.
+    """
+
+    def __init__(self, lock_file):
+        """
+        """
+        #: The path of the file lock.
+        self.lock_file = lock_file
+        return None
+
+    def __str__(self):
+        temp = "The file lock '{}' could not be acquired."\
+               .format(self.lock_file)
+        return temp
+
+
+# Classes
+# ------------------------------------------------
+class BaseFileLock(object):
+    """
+    Implements the base class of a file lock.
+    """
+
+    def __init__(self, lock_file, timeout = -1):
+        """
+        """
+        # The path to the lock file.
+        self._lock_file = lock_file
+
+        # The file descriptor for the *_lock_file* as it is returned by the
+        # os.open() function.
+        # This file lock is only NOT None, if the object currently holds the
+        # lock.
+        self._lock_file_fd = None
+
+        # The default timeout value.
+        self.timeout = timeout
+
+        # We use this lock primarily for the lock counter.
+        self._thread_lock = threading.Lock()
+
+        # The lock counter is used for implementing the nested locking
+        # mechanism. Whenever the lock is acquired, the counter is increased and
+        # the lock is only released, when this value is 0 again.
+        self._lock_counter = 0
+        return None
+
+    @property
+    def lock_file(self):
+        """
+        The path to the lock file.
+        """
+        return self._lock_file
+
+    @property
+    def timeout(self):
+        """
+        You can set a default timeout for the filelock. It will be used as
+        fallback value in the acquire method, if no timeout value (*None*) is
+        given.
+
+        If you want to disable the timeout, set it to a negative value.
+
+        A timeout of 0 means, that there is exactly one attempt to acquire the
+        file lock.
+
+        .. versionadded:: 2.0.0
+        """
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, value):
+        """
+        """
+        self._timeout = float(value)
+        return None
+
+    # Platform dependent locking
+    # --------------------------------------------
+
+    def _acquire(self):
+        """
+        Platform dependent. If the file lock could be
+        acquired, self._lock_file_fd holds the file descriptor
+        of the lock file.
+        """
+        raise NotImplementedError()
+
+    def _release(self):
+        """
+        Releases the lock and sets self._lock_file_fd to None.
+        """
+        raise NotImplementedError()
+
+    # Platform independent methods
+    # --------------------------------------------
+
+    @property
+    def is_locked(self):
+        """
+        True, if the object holds the file lock.
+
+        .. versionchanged:: 2.0.0
+
+            This was previously a method and is now a property.
+        """
+        return self._lock_file_fd is not None
+
+    def acquire(self, timeout=None, poll_intervall=0.05):
+        """
+        Acquires the file lock or fails with a :exc:`Timeout` error.
+
+        .. code-block:: python
+
+            # You can use this method in the context manager (recommended)
+            with lock.acquire():
+                pass
+
+            # Or you use an equal try-finally construct:
+            lock.acquire()
+            try:
+                pass
+            finally:
+                lock.release()
+
+        :arg float timeout:
+            The maximum time waited for the file lock.
+            If ``timeout <= 0``, there is no timeout and this method will
+            block until the lock could be acquired.
+            If ``timeout`` is None, the default :attr:`~timeout` is used.
+
+        :arg float poll_intervall:
+            We check once in *poll_intervall* seconds if we can acquire the
+            file lock.
+
+        :raises Timeout:
+            if the lock could not be acquired in *timeout* seconds.
+
+        .. versionchanged:: 2.0.0
+
+            This method returns now a *proxy* object instead of *self*,
+            so that it can be used in a with statement without side effects.
+        """
+        # Use the default timeout, if no timeout is provided.
+        if timeout is None:
+            timeout = self.timeout
+
+        # Increment the number right at the beginning.
+        # We can still undo it, if something fails.
+        with self._thread_lock:
+            self._lock_counter += 1
+
+        try:
+            start_time = time.time()
+            while True:
+                lock_id = id(self)
+                lock_filename = self._lock_file
+
+                with self._thread_lock:
+                    if not self.is_locked:
+                        logger.debug('Attempting to acquire lock %s on %s', lock_id, lock_filename)
+                        self._acquire()
+
+                if self.is_locked:
+                    logger.info('Lock %s acquired on %s', lock_id, lock_filename)
+                    break
+                elif timeout >= 0 and time.time() - start_time > timeout:
+                    logger.debug('Timeout on acquiring lock %s on %s', lock_id, lock_filename)
+                    raise Timeout(self._lock_file)
+                else:
+                    logger.debug(
+                        'Lock %s not acquired on %s, waiting %s seconds ...',
+                        lock_id, lock_filename, poll_intervall
+                    )
+                    time.sleep(poll_intervall)
+        except:
+            # Something did go wrong, so decrement the counter.
+            with self._thread_lock:
+                self._lock_counter = max(0, self._lock_counter - 1)
+
+            raise
+
+        # This class wraps the lock to make sure __enter__ is not called
+        # twiced when entering the with statement.
+        # If we would simply return *self*, the lock would be acquired again
+        # in the *__enter__* method of the BaseFileLock, but not released again
+        # automatically.
+        class ReturnProxy(object):
+
+            def __init__(self, lock):
+                self.lock = lock
+                return None
+
+            def __enter__(self):
+                return self.lock
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                self.lock.release()
+                return None
+
+        return ReturnProxy(lock = self)
+
+    def release(self, force = False):
+        """
+        Releases the file lock.
+
+        Please note, that the lock is only completly released, if the lock
+        counter is 0.
+
+        Also note, that the lock file itself is not automatically deleted.
+
+        :arg bool force:
+            If true, the lock counter is ignored and the lock is released in
+            every case.
+        """
+        with self._thread_lock:
+
+            if self.is_locked:
+                self._lock_counter -= 1
+
+                if self._lock_counter == 0 or force:
+                    lock_id = id(self)
+                    lock_filename = self._lock_file
+
+                    logger.debug('Attempting to release lock %s on %s', lock_id, lock_filename)
+                    self._release()
+                    self._lock_counter = 0
+                    logger.info('Lock %s released on %s', lock_id, lock_filename)
+
+        return None
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.release()
+        return None
+
+    def __del__(self):
+        self.release(force = True)
+        return None
+
+
+# Windows locking mechanism
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class WindowsFileLock(BaseFileLock):
+    """
+    Uses the :func:`msvcrt.locking` function to hard lock the lock file on
+    windows systems.
+    """
+
+    def _acquire(self):
+        open_mode = os.O_RDWR | os.O_CREAT | os.O_TRUNC
+
+        try:
+            fd = os.open(self._lock_file, open_mode)
+        except OSError:
+            pass
+        else:
+            try:
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            except (IOError, OSError):
+                os.close(fd)
+            else:
+                self._lock_file_fd = fd
+        return None
+
+    def _release(self):
+        fd = self._lock_file_fd
+        self._lock_file_fd = None
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        os.close(fd)
+
+        try:
+            os.remove(self._lock_file)
+        # Probably another instance of the application
+        # that acquired the file lock.
+        except OSError:
+            pass
+        return None
+
+# Unix locking mechanism
+# ~~~~~~~~~~~~~~~~~~~~~~
+
+class UnixFileLock(BaseFileLock):
+    """
+    Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems.
+    """
+
+    def _acquire(self):
+        open_mode = os.O_RDWR | os.O_CREAT | os.O_TRUNC
+        fd = os.open(self._lock_file, open_mode)
+
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (IOError, OSError):
+            os.close(fd)
+        else:
+            self._lock_file_fd = fd
+        return None
+
+    def _release(self):
+        fd = self._lock_file_fd
+        self._lock_file_fd = None
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+        return None
+
+# Soft lock
+# ~~~~~~~~~
+
+class SoftFileLock(BaseFileLock):
+    """
+    Simply watches the existence of the lock file.
+    """
+
+    def _acquire(self):
+        open_mode = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_TRUNC
+        try:
+            fd = os.open(self._lock_file, open_mode)
+        except (IOError, OSError):
+            pass
+        else:
+            self._lock_file_fd = fd
+        return None
+
+    def _release(self):
+        os.close(self._lock_file_fd)
+        self._lock_file_fd = None
+
+        try:
+            os.remove(self._lock_file)
+        # The file is already deleted and that's what we want.
+        except OSError:
+            pass
+        return None
+
+
+# Platform filelock
+# ~~~~~~~~~~~~~~~~~
+
+#: Alias for the lock, which should be used for the current platform. On
+#: Windows, this is an alias for :class:`WindowsFileLock`, on Unix for
+#: :class:`UnixFileLock` and otherwise for :class:`SoftFileLock`.
+FileLock = None
+
+if msvcrt:
+    FileLock = WindowsFileLock
+elif fcntl:
+    FileLock = UnixFileLock
+else:
+    FileLock = SoftFileLock
+
+    if warnings is not None:
+        warnings.warn("only soft file lock is available")

--- a/tools/sync/reindex-project.ksh
+++ b/tools/sync/reindex-project.ksh
@@ -1,0 +1,113 @@
+#!/usr/bin/ksh -p
+#
+# OpenGrok reindexing script for one project
+#
+
+#
+# Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+#
+
+#
+# Reindex just one project. For that special logging.properties file will be
+# created to have per-project logs. Also, to avoid configuration file being
+# changed while the indexer is reading it, get the configuration from
+# the webapp.
+#
+function reindex_one
+{
+	# path relative to source root
+	typeset project_path=$1
+	typeset -r project_name=$( basename $1 )
+	typeset -r template="$OPENGROK_INSTANCE_BASE/etc/logging.properties.template"
+
+	if [[ ! -r $template ]]; then
+		print -u2 "cannot read template $template"
+		return 1
+	fi
+
+	print "Refreshing OpenGrok index for $1"
+
+	#
+	# Make sure there is separate logging configuration for this project.
+	#
+	typeset -r log_conf_dir=$OPENGROK_INSTANCE_BASE/log/configs
+	if [[ ! -d $log_conf_dir ]]; then
+		mkdir "$log_conf_dir"
+		if (( $? != 0 )); then
+			print -u2 "cannot create directory $log_conf_dir"
+			return 1
+		fi
+	fi
+
+	log_conf="$log_conf_dir/$project_name"
+	if [[ ! -f $log_conf || $template -nt $log_conf ]]; then
+		typeset project_log_dir=$OPENGROK_INSTANCE_BASE/log/$project_name
+		if [[ ! -d $project_log_dir ]]; then
+			mkdir "$project_log_dir"
+			if (( $? != 0 )); then
+				print -u2 "cannot create directory $project_log_dir"
+				return 1
+			fi
+		fi
+
+		typeset tmp=$( mktemp /tmp/logfile.XXXXXX )
+		if [[ -z $tmp ]]; then
+			print -u2 "cannot create temporary file"
+			return 1
+		fi
+
+		cat "$template" | sed "s%DIR_TO_BE%$project_log_dir%" > "$tmp"
+		mv "$tmp" "$log_conf"
+	fi
+
+	# Get fresh configuration from the webapp.
+	config_xml=$( mktemp /tmp/opengrok-conf.XXXXXX )
+	if [[ -z $config_xml ]]; then
+		print -u2 "cannot create temporary file for configuration"
+		exit 1
+	fi
+
+	$binary_base/Messages -n config -t getconf > "$config_xml"
+	if (( $? != 0 )); then
+		print -u2 "failed to get configuration from webapp"
+		rm -f "$config_xml"
+		exit 1
+	fi
+
+	OPENGROK_CONFIGURATION=$opengrok_conf		\
+	    OPENGROK_LOGGER_CONFIG_PATH=$log_conf	\
+	    OPENGROK_READ_XML_CONFIGURATION=$config_xml	\
+	    $binary_base/OpenGrok			\
+	    indexpart "$project_name"
+
+	rm -f "$config_xml"
+
+	return $?
+}
+
+if (( $# != 3 )); then
+	print -u2 "$0 opengrok_conf_file binary_base project_name"
+	exit 1
+fi
+
+typeset -r opengrok_conf=$1
+if [[ ! -f $opengrok_conf ]]; then
+	print -u2 "file $opengrok_conf does not exist"
+	exit 1
+fi
+
+. $opengrok_conf
+
+if [[ -z $OPENGROK_INSTANCE_BASE ]]; then
+	print -u2 "cannot get OPENGROK_INSTANCE_BASE from " \
+	    "$opengrok_conf"
+	return 1
+fi
+
+typeset -r binary_base=$2
+if [[ ! -d $binary_base ]]; then
+	print -u2 "not a directory: $binary_base"
+	exit 1
+fi
+
+reindex_one "$3"

--- a/tools/sync/sync.py
+++ b/tools/sync/sync.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+#
+
+"""
+ This script runs OpenGrok parallel project processing.
+
+ It is intended to work on Unix systems. (mainly because it relies on the
+ OpenGrok shell script - for the time being)
+
+"""
+
+# TODO: make sure it works on both Python 2 and 3
+
+from multiprocessing import Pool, TimeoutError
+import argparse
+import subprocess
+import time
+import os
+import sys
+from os import path
+import filelock
+from filelock import Timeout
+import command
+from command import Command
+import logging
+import tempfile
+import json
+import commands
+from commands import Commands
+
+
+__version__ = "0.2.1"
+
+
+def worker(x):
+    """ Process (resync + reindex) one project by calling external script.
+    """
+
+    logger.debug(str(os.getpid()) + " " + str(x))
+    x.run()
+
+    return x
+
+if __name__ == '__main__':
+    output = []
+    dirs_to_process = []
+
+    parser = argparse.ArgumentParser(description='Manage parallel workers.')
+    parser.add_argument('-w', '--workers', default=4,
+                        help='Number of worker processes')
+
+    # There can be only one way how to supply list of projects to process.
+    group1 = parser.add_mutually_exclusive_group()
+    group1.add_argument('-d', '--directory', default="/var/opengrok/src",
+                        help='Directory to process')
+    group1.add_argument('-P', '--projects', nargs='*',
+                        help='List of projects to process')
+
+    group2 = parser.add_mutually_exclusive_group()
+    group2.add_argument('-D', '--debug', action='store_true',
+                        help='Enable debug prints')
+    group2.add_argument('-p', '--logplain', action='store_true',
+                        help='log plain messages')
+
+    parser.add_argument('-i', '--ignore_errors', nargs='*',
+                        help='ignore errors from these projects')
+    parser.add_argument('-c', '--config', required=True,
+                        help='config file in JSON format')
+    parser.add_argument('-I', '--indexed', action='store_true',
+                        help='Sync indexed projects only')
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        if args.logplain:
+            logging.basicConfig(format="%(message)s")
+        else:
+            logging.basicConfig()
+
+    logger = logging.getLogger(os.path.basename(sys.argv[0]))
+
+    try:
+        with open(args.config) as json_data_file:
+            try:
+                config = json.load(json_data_file)
+            except ValueError, e:
+                logger.error("cannot decode {}".format(args.config))
+                sys.exit(1)
+            else:
+                logger.debug("config: {}".format(config))
+    except IOError, e:
+        logger.error("cannot open '{}'".format(args.config))
+        sys.exit(1)
+
+    try:
+        foo = config["commands"]
+    except KeyError:
+        logger.error("The config file has to contain key \"commands\"")
+        sys.exit(1)
+
+    ignore_errors = []
+    if args.ignore_errors:
+        ignore_errors = args.ignore_errors
+    else:
+        try:
+            ignore_errors = config["ignore_errors"]
+        except KeyError:
+            pass
+    logger.debug("Ignored projects: {}".format(ignore_errors))
+
+    lock = filelock.FileLock(os.path.join(tempfile.gettempdir(),
+                             "opengrok-sync.lock"))
+    try:
+        with lock.acquire(timeout=0):
+            pool = Pool(processes=int(args.workers))
+
+            if args.projects:
+                dirs_to_process = args.projects
+            elif args.indexed:
+                # XXX replace this with REST request after issue #1801
+                cmd = Command(['/usr/opengrok/bin/Messages', '-n', 'project',
+                               'list-indexed'])
+                cmd.execute()
+                if cmd.state is "finished":
+                    for line in cmd.getoutput():
+                        dirs_to_process.append(line.strip())
+                else:
+                    logger.error("cannot get list of projects")
+                    sys.exit(1)
+            else:
+                dir = args.directory
+                for entry in os.listdir(args.directory):
+                    if path.isdir(path.join(dir, entry)):
+                        dirs_to_process.append(entry)
+
+            logger.debug("to process: {}".format(dirs_to_process))
+
+            projects = []
+            for d in dirs_to_process:
+                proj = Commands(name=d, commands=config["commands"])
+                projects.append(proj)
+
+            try:
+                projects = pool.map(worker, projects, 1)
+            except KeyboardInterrupt:
+                # XXX lock.release() or return 1 ?
+                sys.exit(1)
+            else:
+                # XXX move the code below to Commands once it can work with
+                # logger
+                for proj in projects:
+                    logger.debug("Output from {}:".format(proj.name))
+                    for cmd in proj.outputs.keys():
+                        if len(proj.outputs[cmd]) > 0:
+                            logger.debug("{}: {}".
+                                         format(cmd, proj.outputs[cmd]))
+
+                    if proj.name in ignore_errors:
+                        continue
+
+                    if any(rv != 0 for rv in proj.retcodes.values()):
+                        logger.error("processing of project {} failed".
+                                     format(proj))
+                        indent = "  "
+                        logger.error("{}failed commands:".format(indent))
+                        failed_cmds = {k: v for k, v in
+                                       proj.retcodes.iteritems() if v != 0}
+                        indent = "    "
+                        for cmd in failed_cmds.keys():
+                            logger.error("{}'{}': {}".
+                                         format(indent, cmd, failed_cmds[cmd]))
+                            out = proj.get_cmd_output(cmd,
+                                                      indent=indent + "  ")
+                            if out:
+                                logger.error(out)
+                        logger.error("")
+
+                    errored_cmds = {k: v for k, v in proj.outputs.iteritems()
+                                    if "error" in str(v).lower()}
+                    if len(errored_cmds) > 0:
+                        logger.error("Command output in project {}"
+                                     " contains errors:".format(proj.name))
+                        indent = "  "
+                        for cmd in errored_cmds.keys():
+                            logger.error("{}{}".format(indent, cmd))
+                            out = proj.get_cmd_output(cmd,
+                                                      indent=indent + "  ")
+                            if out:
+                                logger.error(out)
+                            logger.error("")
+    except Timeout:
+        logger.warning("Already running, exiting.")
+        sys.exit(1)

--- a/tools/sync/test/test_command.py
+++ b/tools/sync/test/test_command.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+import unittest
+import logging
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(
+                os.path.join(os.path.dirname(__file__), '..')))
+
+import command
+from command import Command
+
+
+class TestApp(unittest.TestCase):
+    #def __init__(self):
+    #    logging.basicConfig(level=logging.DEBUG)
+
+    def test_subst_append_default(self):
+        cmd = Command(['foo', 'ARG', 'bar'],
+                        args_subst={"ARG": "blah"},
+                        args_append=["1", "2"])
+        self.assertEqual(['foo', 'blah', 'bar', '1', '2'], cmd.cmd)
+
+    def test_subst_append_exclsubst(self):
+        cmd = Command(['foo', 'ARG', 'bar'],
+                        args_subst={"ARG": "blah"},
+                        args_append=["1", "2"],
+                        excl_subst=True)
+        self.assertEqual(['foo', 'blah', 'bar'], cmd.cmd)
+
+    def test_execute_nonexistent(self):
+        cmd = Command(['/baaah', '/etc/passwd'])
+        cmd.execute()
+        self.assertEqual(None, cmd.getretcode())
+
+    def test_getoutput(self):
+        """
+        XXX this only works on Unix
+        """
+        cmd = Command(['/bin/ls', '/etc/passwd'])
+        cmd.execute()
+        self.assertEqual(['/etc/passwd\n'], cmd.getoutput())
+
+    def test_retcode(self):
+        """
+        XXX this only works on Unix
+        """
+
+        cmd = Command(["/bin/false"])
+        cmd.execute()
+        self.assertNotEqual(0, cmd.getretcode())
+
+        cmd = Command(["/bin/true"])
+        cmd.execute()
+        self.assertEqual(0, cmd.getretcode())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/sync/test/test_commands.py
+++ b/tools/sync/test/test_commands.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+
+import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(
+                os.path.join(os.path.dirname(__file__), '..')))
+
+import commands
+from commands import Commands
+
+
+class TestApp(unittest.TestCase):
+    def test_str(self):
+        p = Commands(name="opengrok-master",
+                    commands=[['foo'], ["bar"]])
+        self.assertEqual("opengrok-master", str(p))
+
+    def test_run_retcodes(self):
+        p = Commands(name="opengrok-master",
+                    commands=[["/bin/echo"], ["foo"]])
+        p.run()
+	self.assertEqual({'/bin/echo opengrok-master': 0,
+	                  'foo opengrok-master': None}, p.retcodes)
+
+    # def test_outputs(self):
+
+    # def test_get_cmd_output(self):
+        # print p.get_cmd_output('/var/tmp/print-error.ksh opengrok-master')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Here's set of simple scripts we've been using lately internally for setup with projects. They make it possible to handle projects in parallel, speeding the overall indexing. The handling can be a sequence of:
  - send a Message that project is synced+indexed
  - sync the project (e.g. `git pull`)
  - index the project
  - remove the previous Message

The `filelock.py` comes from https://github.com/benediktschmitt/py-filelock/