### PR TITLE
Feature/magics

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/FileAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/FileAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -148,7 +149,7 @@ public class FileAnalyzerFactory {
      * should be used to analyze it.
      *
      * <p><b>Note:</b> Currently this assumes that the file is encoded with
-     * ISO-8859-1.
+     * UTF-8 unless a BOM is detected.
      *
      * @return list of magic strings
      */
@@ -220,6 +221,11 @@ public class FileAnalyzerFactory {
      * Interface for matchers which map file contents to analyzer factories.
      */
     protected interface Matcher {
+
+        /**
+         * Get a value indicating if the magic is byte-precise.
+         */
+        default boolean getIsPreciseMagic() { return false; }
 
         /**
          * Try to match the file contents with an analyzer factory.

--- a/src/org/opensolaris/opengrok/analysis/archive/ZipAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/archive/ZipAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.archive;
@@ -62,6 +63,9 @@ public final class ZipAnalyzerFactory extends FileAnalyzerFactory {
         }
 
         private static final int XFHSIZ = 4;
+
+        @Override
+        public boolean getIsPreciseMagic() { return true; }
 
         @Override
         public FileAnalyzerFactory isMagic(byte[] contents, InputStream in)

--- a/src/org/opensolaris/opengrok/analysis/executables/JavaClassAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/executables/JavaClassAnalyzerFactory.java
@@ -36,7 +36,7 @@ public class JavaClassAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     private static final String[] MAGICS = {
-        "\312\376\272\276"      // cafebabe
+        new String(new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE})
     };
 
     public JavaClassAnalyzerFactory() {

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.plain;
@@ -50,18 +51,18 @@ public final class PlainAnalyzerFactory extends FileAnalyzerFactory {
             }
 
             /**
-             * Check whether the byte array contains plain text. First, check
-             * assuming US-ASCII encoding. Then, if unsuccessful, try to
-             * strip away Unicode byte-order marks and try again.
+             * Check whether the byte array contains plain text. First, look
+             * for a UTF BOM; otherwise, inspect as if US-ASCII.
              */
             private boolean isPlainText(byte[] content) throws IOException {
+                int lengthBOM = AnalyzerGuru.skipForBOM(content);
+                if (lengthBOM > 0) return true;
                 String ascii = new String(content, "US-ASCII");
                 if (isPlainText(ascii)) {
                     return true;
                 }
 
-                String noBOM = AnalyzerGuru.stripBOM(content);
-                return (noBOM != null) && isPlainText(noBOM);
+                return false;
             }
 
             /**

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzerFactory.java
@@ -35,6 +35,7 @@ import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.history.Annotation;
+import org.opensolaris.opengrok.util.IOUtils;
 
 public final class PlainAnalyzerFactory extends FileAnalyzerFactory {
 
@@ -55,7 +56,7 @@ public final class PlainAnalyzerFactory extends FileAnalyzerFactory {
              * for a UTF BOM; otherwise, inspect as if US-ASCII.
              */
             private boolean isPlainText(byte[] content) throws IOException {
-                int lengthBOM = AnalyzerGuru.skipForBOM(content);
+                int lengthBOM = IOUtils.skipForBOM(content);
                 if (lengthBOM > 0) return true;
                 String ascii = new String(content, "US-ASCII");
                 if (isPlainText(ascii)) {

--- a/src/org/opensolaris/opengrok/util/IOUtils.java
+++ b/src/org/opensolaris/opengrok/util/IOUtils.java
@@ -20,6 +20,7 @@
 /*
  * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Trond Norbye 
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.util;
 
@@ -40,7 +41,9 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.opensolaris.opengrok.logger.LoggerFactory;
@@ -218,5 +221,55 @@ public final class IOUtils {
         }
 
         return new InputStreamReader(in, charset);
+    }
+
+    /**
+     * Byte-order markers.
+     */
+    private static final Map<String, byte[]> BOMS = new HashMap<>();
+
+    static {
+        BOMS.put("UTF-8", new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF});
+        BOMS.put("UTF-16BE", new byte[]{(byte) 0xFE, (byte) 0xFF});
+        BOMS.put("UTF-16LE", new byte[]{(byte) 0xFF, (byte) 0xFE});
+    }
+
+    /**
+     * Gets a value indicating a UTF encoding if the array starts with a
+     * known byte sequence.
+     *
+     * @param sig a sequence of bytes to inspect for a BOM
+     * @return null if no BOM was identified; otherwise a defined charset name
+     */
+    public static String findBOMEncoding(byte[] sig) {
+        for (Map.Entry<String, byte[]> entry : BOMS.entrySet()) {
+            String encoding = entry.getKey();
+            byte[] bom = entry.getValue();
+            if (sig.length > bom.length) {
+                int i = 0;
+                while (i < bom.length && sig[i] == bom[i]) {
+                    i++;
+                }
+                if (i == bom.length) return encoding;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets a value indicating the number of UTF BOM bytes at the start of an
+     * array.
+     *
+     * @param sig a sequence of bytes to inspect for a BOM
+     * @return 0 if the array doesn't start with a BOM; otherwise the number of
+     * BOM bytes
+     */
+    public static int skipForBOM(byte[] sig) {
+        String encoding = findBOMEncoding(sig);
+        if (encoding != null) {
+            byte[] bom = BOMS.get(encoding);
+            return bom.length;
+        }
+        return 0;
     }
 }

--- a/test/org/opensolaris/opengrok/analysis/AnalyzerGuruTest.java
+++ b/test/org/opensolaris/opengrok/analysis/AnalyzerGuruTest.java
@@ -20,6 +20,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis;
@@ -37,6 +38,7 @@ import org.junit.Test;
 import org.opensolaris.opengrok.analysis.archive.ZipAnalyzer;
 import org.opensolaris.opengrok.analysis.c.CxxAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.executables.JarAnalyzer;
+import org.opensolaris.opengrok.analysis.perl.PerlAnalyzer;
 import org.opensolaris.opengrok.analysis.plain.PlainAnalyzer;
 import org.opensolaris.opengrok.analysis.plain.XMLAnalyzer;
 import org.opensolaris.opengrok.analysis.sh.ShAnalyzer;
@@ -74,6 +76,16 @@ public class AnalyzerGuruTest {
     }
 
     @Test
+    public void testUTF8ByteOrderMarkPlusCopyrightSymbol() throws Exception {
+        byte[] doc = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF, // UTF-8 BOM
+                       '/', '/', ' ', (byte) 0xC2, (byte)0xA9};
+        ByteArrayInputStream in = new ByteArrayInputStream(doc);
+        FileAnalyzer fa = AnalyzerGuru.getAnalyzer(in, "/dummy/file");
+        assertSame("despite BOM as precise match,", PlainAnalyzer.class,
+            fa.getClass());
+    }
+
+    @Test
     public void testUTF8ByteOrderMarkPlainFile() throws Exception {
         byte[] bytes = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF, // UTF-8 BOM
                        'h', 'e', 'l', 'l', 'o', ' ',
@@ -82,6 +94,26 @@ public class AnalyzerGuruTest {
         ByteArrayInputStream in = new ByteArrayInputStream(bytes);
         FileAnalyzer fa = AnalyzerGuru.getAnalyzer(in, "/dummy/file");
         assertSame(PlainAnalyzer.class, fa.getClass());
+    }
+
+    @Test
+    public void testUTF16BigByteOrderMarkPlusCopyrightSymbol() throws Exception {
+        byte[] doc = {(byte) 0xFE, (byte) 0xFF, // UTF-16BE BOM
+                       0, '#', 0, ' ', (byte) 0xC2, (byte) 0xA9};
+        ByteArrayInputStream in = new ByteArrayInputStream(doc);
+        FileAnalyzer fa = AnalyzerGuru.getAnalyzer(in, "/dummy/file");
+        assertSame("despite BOM as precise match,", PlainAnalyzer.class,
+            fa.getClass());
+    }
+
+    @Test
+    public void testUTF16LittleByteOrderMarkPlusCopyrightSymbol() throws Exception {
+        byte[] doc = {(byte) 0xFF, (byte) 0xFE, // UTF-16BE BOM
+                       '#', 0, ' ', 0, (byte) 0xA9, (byte) 0xC2};
+        ByteArrayInputStream in = new ByteArrayInputStream(doc);
+        FileAnalyzer fa = AnalyzerGuru.getAnalyzer(in, "/dummy/file");
+        assertSame("despite BOM as precise match,", PlainAnalyzer.class,
+            fa.getClass());
     }
 
     @Test
@@ -207,5 +239,45 @@ public class AnalyzerGuruTest {
         
         Class fc = AnalyzerGuru.getFactoryClass("UnknownAnalyzerFactory");
         assertNull(fc);
+    }
+
+    @Test
+    public void shouldMatchPerlHashbang() throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(
+                "#!/usr/bin/perl -w".getBytes("US-ASCII"));
+        assertSame("despite Perl hashbang,", PerlAnalyzer.class,
+            AnalyzerGuru.getAnalyzer(in, "dummy").getClass());
+    }
+
+    @Test
+    public void shouldMatchPerlHashbangSpaced() throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(
+                "\n\t #!  /usr/bin/perl -w".getBytes("US-ASCII"));
+        assertSame("despite Perl hashbang,", PerlAnalyzer.class,
+            AnalyzerGuru.getAnalyzer(in, "dummy").getClass());
+    }
+
+    @Test
+    public void shouldMatchEnvPerlHashbang() throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(
+                "#!/usr/bin/env perl -w".getBytes("US-ASCII"));
+        assertSame("despite env hashbang with perl,", PerlAnalyzer.class,
+            AnalyzerGuru.getAnalyzer(in, "dummy").getClass());
+    }
+
+    @Test
+    public void shouldMatchEnvPerlHashbangSpaced() throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(
+                "\n\t #!  /usr/bin/env\t perl -w".getBytes("US-ASCII"));
+        assertSame("despite env hashbang with perl,", PerlAnalyzer.class,
+            AnalyzerGuru.getAnalyzer(in, "dummy").getClass());
+    }
+
+    @Test
+    public void shouldNotMatchEnvLFPerlHashbang() throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(
+                "#!/usr/bin/env\nperl".getBytes("US-ASCII"));
+        assertNotSame("despite env hashbang LF,", PerlAnalyzer.class,
+            AnalyzerGuru.getAnalyzer(in, "dummy").getClass());
     }
 }

--- a/test/org/opensolaris/opengrok/analysis/AnalyzerGuruTest.java
+++ b/test/org/opensolaris/opengrok/analysis/AnalyzerGuruTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import org.opensolaris.opengrok.analysis.archive.ZipAnalyzer;
 import org.opensolaris.opengrok.analysis.c.CxxAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.executables.JarAnalyzer;
+import org.opensolaris.opengrok.analysis.executables.JavaClassAnalyzer;
 import org.opensolaris.opengrok.analysis.perl.PerlAnalyzer;
 import org.opensolaris.opengrok.analysis.plain.PlainAnalyzer;
 import org.opensolaris.opengrok.analysis.plain.XMLAnalyzer;
@@ -279,5 +280,21 @@ public class AnalyzerGuruTest {
                 "#!/usr/bin/env\nperl".getBytes("US-ASCII"));
         assertNotSame("despite env hashbang LF,", PerlAnalyzer.class,
             AnalyzerGuru.getAnalyzer(in, "dummy").getClass());
+    }
+
+    @Test
+    public void shouldMatchJavaClassMagic() throws Exception {
+        String oldMagic = "\312\376\272\276";      // cafebabe?
+        String newMagic = new String(new byte[] {(byte) 0xCA, (byte) 0xFE,
+            (byte) 0xBA, (byte) 0xBE});
+        assertNotEquals("despite octal escape as unicode,", oldMagic, newMagic);
+
+        // 0xCAFEBABE (4), minor (2), major (2)
+        byte[] dotclass = {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE,
+            (byte) 0, (byte) 1, (byte) 0, (byte) 0x34};
+        ByteArrayInputStream in = new ByteArrayInputStream(dotclass);
+        FileAnalyzer fa = AnalyzerGuru.getAnalyzer(in, "/dummy/file");
+        assertSame("despite 0xCAFEBABE magic,", JavaClassAnalyzer.class,
+            fa.getClass());
     }
 }

--- a/test/org/opensolaris/opengrok/analysis/AnalyzerGuruTest.java
+++ b/test/org/opensolaris/opengrok/analysis/AnalyzerGuruTest.java
@@ -37,6 +37,7 @@ import java.util.zip.ZipOutputStream;
 import org.junit.Test;
 import org.opensolaris.opengrok.analysis.archive.ZipAnalyzer;
 import org.opensolaris.opengrok.analysis.c.CxxAnalyzerFactory;
+import org.opensolaris.opengrok.analysis.executables.ELFAnalyzer;
 import org.opensolaris.opengrok.analysis.executables.JarAnalyzer;
 import org.opensolaris.opengrok.analysis.executables.JavaClassAnalyzer;
 import org.opensolaris.opengrok.analysis.perl.PerlAnalyzer;
@@ -280,6 +281,16 @@ public class AnalyzerGuruTest {
                 "#!/usr/bin/env\nperl".getBytes("US-ASCII"));
         assertNotSame("despite env hashbang LF,", PerlAnalyzer.class,
             AnalyzerGuru.getAnalyzer(in, "dummy").getClass());
+    }
+
+    @Test
+    public void shouldMatchELFMagic() throws Exception {
+        byte[] elfmt = {(byte)0x7F, 'E', 'L', 'F', (byte) 2, (byte) 2, (byte) 1,
+            (byte) 0x06};
+        ByteArrayInputStream in = new ByteArrayInputStream(elfmt);
+        FileAnalyzer fa = AnalyzerGuru.getAnalyzer(in, "/dummy/file");
+        assertSame("despite \\177ELF magic,", ELFAnalyzer.class,
+            fa.getClass());
     }
 
     @Test


### PR DESCRIPTION
(This is a recreation of #1817 which is rebased since AnalyzerGuruTest had conflicts from recent merges and with an additional commit to "move BOM-related methods to IOUtils where other BOM-methods live".)

- Fix so magics (TreeMap) lookup can work by inspecting it with full
  two- (e.g. "/usr/bin/env perl") or one-word (e.g. "/usr/bin/perl") magics
  extracted from file contents.
- Condense spaced, extracted hashbangs for lookup (e.g.,
  " #! /usr/bin/env  perl" to "#!/usr/bin/env perl").
- Add Comparator so longer magic strings are checked first during the
  imprecise phase of matching (so ShAnalyzerFactory's short "#!" magic is not
  accidentally preferred).
- Add property, isPreciseMagic, to FileAnalyzerFactory.Matcher so byte-precise
  magic detection can be done early. (Only ZipAnalyzerFactory now has this set
  to true.)
- Use a UTF BOM as a precise indication of plain text in the otherwise
  imprecise PlainAnalyzerFactory.Matcher.isMagic().
- Add tests of fixed matching of magics
- Fix historically broken Java class magic
- Add test of ELF magic
- Move BOM-related methods to IOUtils where other BOM-methods live

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
