### PR TITLE
Feature/cache control

### DIFF
--- a/src/org/opensolaris/opengrok/web/ResponseHeaderFilter.java
+++ b/src/org/opensolaris/opengrok/web/ResponseHeaderFilter.java
@@ -1,0 +1,46 @@
+/*
+ * The contents of this file are Copyright © 2003 Jayson Falkner made available
+ * under free license: "All of the code from Servlets and JSP the J2EE Web Tier
+ * is freely available. Additonally all of the code the book's code relies on
+ * is also freely available. With the exception of Sun's Java Development Kit,
+ * everything the book relies on is also open-source. You are encouraged to
+ * look at, learn from, and use everything!"
+ */
+
+package org.opensolaris.opengrok.web;
+
+import java.io.*;
+import javax.servlet.*;
+import javax.servlet.http.*;
+import java.util.*;
+
+public class ResponseHeaderFilter implements Filter {
+    FilterConfig fc;
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res,
+        FilterChain chain)
+        throws IOException, ServletException {
+
+        HttpServletResponse response = (HttpServletResponse) res;
+
+        // set the provided HTTP response parameters
+        for (Enumeration e = fc.getInitParameterNames(); e.hasMoreElements();) {
+            String headerName = (String)e.nextElement();
+            response.addHeader(headerName, fc.getInitParameter(headerName));
+        }
+
+        // pass the request/response on
+        chain.doFilter(req, response);
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        this.fc = filterConfig;
+    }
+
+    @Override
+    public void destroy() {
+        this.fc = null;
+    }
+}

--- a/src/org/opensolaris/opengrok/web/ResponseHeaderFilter.java
+++ b/src/org/opensolaris/opengrok/web/ResponseHeaderFilter.java
@@ -5,6 +5,7 @@
  * is also freely available. With the exception of Sun's Java Development Kit,
  * everything the book relies on is also open-source. You are encouraged to
  * look at, learn from, and use everything!"
+ * Copyright © 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.web;
@@ -32,7 +33,8 @@ public class ResponseHeaderFilter implements Filter {
         // set the provided HTTP response parameters
         for (Enumeration e = fc.getInitParameterNames(); e.hasMoreElements();) {
             String headerName = (String)e.nextElement();
-            response.addHeader(headerName, fc.getInitParameter(headerName));
+            if (!response.containsHeader(headerName))
+                response.addHeader(headerName, fc.getInitParameter(headerName));
         }
 
         // pass the request/response on

--- a/src/org/opensolaris/opengrok/web/ResponseHeaderFilter.java
+++ b/src/org/opensolaris/opengrok/web/ResponseHeaderFilter.java
@@ -9,10 +9,15 @@
 
 package org.opensolaris.opengrok.web;
 
-import java.io.*;
-import javax.servlet.*;
-import javax.servlet.http.*;
-import java.util.*;
+import java.io.IOException;
+import java.util.Enumeration;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
 
 public class ResponseHeaderFilter implements Filter {
     FilterConfig fc;

--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -57,10 +57,6 @@
         <!-- Place this mapping last, so /* wildcard is only a fallback -->
         <filter-name>ExpiresHalfHourFilter</filter-name>
         <url-pattern>/*</url-pattern>
-        <url-pattern>/download/*</url-pattern>
-        <url-pattern>/history/*</url-pattern>
-        <url-pattern>/xref/*</url-pattern>
-        <url-pattern>/raw/*</url-pattern>
         <dispatcher>REQUEST</dispatcher>
     </filter-mapping>
     <servlet>

--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -31,6 +31,36 @@
         <filter-name>StatisticsFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
+    <filter>
+        <filter-name>ExpiresHalfHourFilter</filter-name>
+        <filter-class>org.opensolaris.opengrok.web.ResponseHeaderFilter</filter-class>
+        <init-param>
+            <param-name>Cache-Control</param-name>
+            <param-value>max-age=1800</param-value>
+        </init-param>
+    </filter>
+    <filter>
+        <filter-name>ExpiresOneDayFilter</filter-name>
+        <filter-class>org.opensolaris.opengrok.web.ResponseHeaderFilter</filter-class>
+        <init-param>
+            <param-name>Cache-Control</param-name>
+            <param-value>max-age=86400</param-value>
+        </init-param>
+    </filter>
+    <filter-mapping>
+        <filter-name>ExpiresHalfHourFilter</filter-name>
+        <url-pattern>/download/*</url-pattern>
+        <url-pattern>/history/*</url-pattern>
+        <url-pattern>/xref/*</url-pattern>
+        <url-pattern>/raw/*</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>ExpiresOneDayFilter</filter-name>
+        <url-pattern>/default/*</url-pattern>
+        <url-pattern>/js/*</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+    </filter-mapping>
     <servlet>
         <display-name>Source Finder</display-name>
         <servlet-name>search</servlet-name>

--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -48,17 +48,19 @@
         </init-param>
     </filter>
     <filter-mapping>
+        <filter-name>ExpiresOneDayFilter</filter-name>
+        <url-pattern>/default/*</url-pattern>
+        <url-pattern>/js/*</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+    </filter-mapping>
+    <filter-mapping>
+        <!-- Place this mapping last, so /* wildcard is only a fallback -->
         <filter-name>ExpiresHalfHourFilter</filter-name>
+        <url-pattern>/*</url-pattern>
         <url-pattern>/download/*</url-pattern>
         <url-pattern>/history/*</url-pattern>
         <url-pattern>/xref/*</url-pattern>
         <url-pattern>/raw/*</url-pattern>
-        <dispatcher>REQUEST</dispatcher>
-    </filter-mapping>
-    <filter-mapping>
-        <filter-name>ExpiresOneDayFilter</filter-name>
-        <url-pattern>/default/*</url-pattern>
-        <url-pattern>/js/*</url-pattern>
         <dispatcher>REQUEST</dispatcher>
     </filter-mapping>
     <servlet>

--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -1,209 +1,225 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
-  <display-name>OpenGrok</display-name>
-  <description>A wicked fast source browser</description>
-  <context-param>
-    <description>Full path to the configuration file where OpenGrok can read its configuration</description>
-    <param-name>CONFIGURATION</param-name>
-    <param-value>/var/opengrok/etc/configuration.xml</param-value>
-  </context-param>
-
-  <context-param>
-    <description>An address where OpenGrok can receive new configuration</description>
-    <param-name>ConfigAddress</param-name>
-    <param-value>localhost:2424</param-value>
-  </context-param>
-
-  <listener>
-   <listener-class>org.opensolaris.opengrok.web.WebappListener</listener-class>
-  </listener>
-
-  <filter>
-      <filter-name>AuthorizationFilter</filter-name>
-      <filter-class>org.opensolaris.opengrok.web.AuthorizationFilter</filter-class>
-  </filter>
-
-  <filter-mapping>
-      <filter-name>AuthorizationFilter</filter-name>
-      <url-pattern>/*</url-pattern>
-  </filter-mapping>
-
-  <filter>
-      <filter-name>StatisticsFilter</filter-name>
-      <filter-class>org.opensolaris.opengrok.web.StatisticsFilter</filter-class>
-  </filter>
-
-  <filter-mapping>
-      <filter-name>StatisticsFilter</filter-name>
-      <url-pattern>/*</url-pattern>
-  </filter-mapping>
-
-  <servlet>
-    <display-name>Source Finder</display-name>
-    <servlet-name>search</servlet-name>
-    <jsp-file>/search.jsp</jsp-file>
-<init-param>
-<param-name>keepgenerated</param-name><param-value>true</param-value>
-</init-param>
-  </servlet>
-  <servlet>
-  <servlet-name>json</servlet-name>
-  <servlet-class>org.opensolaris.opengrok.web.JSONSearchServlet</servlet-class>
-  </servlet>
-  <servlet>
-    <display-name>Source History</display-name>
-    <servlet-name>history</servlet-name>
-    <jsp-file>/history.jsp</jsp-file>
-<init-param>
-<param-name>keepgenerated</param-name><param-value>true</param-value>
-</init-param>
-  </servlet>
-  <servlet>
-    <display-name>Source lister</display-name>
-    <servlet-name>lister</servlet-name>
-    <jsp-file>/list.jsp</jsp-file>
-<init-param>
-<param-name>keepgenerated</param-name><param-value>true</param-value>
-</init-param>
-  </servlet>
-  <servlet>
-    <display-name>Source diffs between revisions</display-name>
-    <servlet-name>diff</servlet-name>
-    <jsp-file>/diff.jsp</jsp-file>
-<init-param>
-<param-name>keepgenerated</param-name><param-value>true</param-value>
-</init-param>
-  </servlet>
-  <servlet>
-    <display-name>Shows more matching lines</display-name>
-    <servlet-name>more</servlet-name>
-    <jsp-file>/more.jsp</jsp-file>
-  </servlet>
-  <servlet>
-    <display-name>Source Changes in RSS format</display-name>
-    <servlet-name>rss</servlet-name>
-    <jsp-file>/rss.jsp</jsp-file>
-<init-param>
-<param-name>keepgenerated</param-name><param-value>true</param-value>
-</init-param>
-  </servlet>
-  <servlet>
-    <display-name>OpenSearch link for current project</display-name>
-    <servlet-name>opensearch</servlet-name>
-    <jsp-file>/opensearch.jsp</jsp-file>
-<init-param>
-<param-name>keepgenerated</param-name><param-value>true</param-value>
-</init-param>
-  </servlet>
-  <servlet>
-    <display-name>Raw Source lister</display-name>
-    <servlet-name>raw</servlet-name>
-    <jsp-file>/raw.jsp</jsp-file>
-<init-param>
-<param-name>keepgenerated</param-name><param-value>true</param-value>
-</init-param>
-  </servlet>
-  <servlet>
-    <display-name>Download source</display-name>
-    <servlet-name>download</servlet-name>
-    <jsp-file>/raw.jsp</jsp-file>
-<init-param>
-<param-name>keepgenerated</param-name><param-value>true</param-value>
-</init-param>
-  </servlet>
-  <servlet>
-    <display-name>Error Handler</display-name>
-    <servlet-name>error</servlet-name>
-    <jsp-file>/error.jsp</jsp-file>
-<init-param>
-<param-name>keepgenerated</param-name><param-value>true</param-value>
-</init-param>
-  </servlet>
-  <servlet>
-    <display-name>File not found handler</display-name>
-    <servlet-name>enoent</servlet-name>
-    <jsp-file>/enoent.jsp</jsp-file>
-<init-param>
-<param-name>keepgenerated</param-name><param-value>true</param-value>
-</init-param>
-  </servlet>
-  <servlet>
-      <display-name>Forbidden error handler</display-name>
-      <servlet-name>eforbidden</servlet-name>
-      <jsp-file>/eforbidden.jsp</jsp-file>
-      <init-param>
-          <param-name>keepgenerated</param-name>
-          <param-value>true</param-value>
-      </init-param>
-  </servlet>
-  <servlet-mapping>
-    <servlet-name>search</servlet-name>
-    <url-pattern>/search</url-pattern>		<!-- SEARCH_P -->
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>json</servlet-name>
-    <url-pattern>/json</url-pattern>
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>opensearch</servlet-name>
-    <url-pattern>/opensearch</url-pattern>	<!-- SEARCH_O -->
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>history</servlet-name>
-    <url-pattern>/history/*</url-pattern>	<!-- HIST_L -->
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>lister</servlet-name>
-    <url-pattern>/xref/*</url-pattern>		<!-- XREF_P -->
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>raw</servlet-name>
-    <url-pattern>/raw/*</url-pattern> 		<!-- RAW_P -->
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>download</servlet-name>
-    <url-pattern>/download/*</url-pattern> 	<!-- DOWNLOAD_P -->
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>search</servlet-name>
-    <url-pattern>/s</url-pattern>			<!-- SEARCH_R -->
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>diff</servlet-name>
-    <url-pattern>/diff/*</url-pattern>		<!-- DIFF_P -->
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>more</servlet-name>
-    <url-pattern>/more/*</url-pattern>		<!-- MORE_P -->
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>rss</servlet-name>
-    <url-pattern>/rss/*</url-pattern>		<!-- RSS_P -->
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>error</servlet-name>
-    <url-pattern>/error</url-pattern>		<!-- ERROR -->
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>enoent</servlet-name>
-    <url-pattern>/enoent</url-pattern>		<!-- NOT_FOUND -->
-  </servlet-mapping>
-  <servlet-mapping>
-      <servlet-name>eforbidden</servlet-name>
-      <url-pattern>/eforbidden</url-pattern>		<!-- FORBIDDEN -->
-  </servlet-mapping>
-  <error-page>
-    <error-code>404</error-code>
-    <location>/enoent</location>
-  </error-page>
-  <error-page>
-    <error-code>500</error-code>
-    <location>/error</location>
-  </error-page>
-  <jsp-config>
-      <jsp-property-group>
-      <url-pattern>*.jsp</url-pattern>
-      <trim-directive-whitespaces>true</trim-directive-whitespaces>
-    </jsp-property-group>
-  </jsp-config>
+    <display-name>OpenGrok</display-name>
+    <description>A wicked fast source browser</description>
+    <context-param>
+        <description>Full path to the configuration file where OpenGrok can read its configuration</description>
+        <param-name>CONFIGURATION</param-name>
+        <param-value>/var/opengrok/etc/configuration.xml</param-value>
+    </context-param>
+    <context-param>
+        <description>An address where OpenGrok can receive new configuration</description>
+        <param-name>ConfigAddress</param-name>
+        <param-value>localhost:2424</param-value>
+    </context-param>
+    <listener>
+        <listener-class>org.opensolaris.opengrok.web.WebappListener</listener-class>
+    </listener>
+    <filter>
+        <filter-name>AuthorizationFilter</filter-name>
+        <filter-class>org.opensolaris.opengrok.web.AuthorizationFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>AuthorizationFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter>
+        <filter-name>StatisticsFilter</filter-name>
+        <filter-class>org.opensolaris.opengrok.web.StatisticsFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>StatisticsFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <servlet>
+        <display-name>Source Finder</display-name>
+        <servlet-name>search</servlet-name>
+        <jsp-file>/search.jsp</jsp-file>
+        <init-param>
+            <param-name>keepgenerated</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </servlet>
+    <servlet>
+        <servlet-name>json</servlet-name>
+        <servlet-class>org.opensolaris.opengrok.web.JSONSearchServlet</servlet-class>
+    </servlet>
+    <servlet>
+        <display-name>Source History</display-name>
+        <servlet-name>history</servlet-name>
+        <jsp-file>/history.jsp</jsp-file>
+        <init-param>
+            <param-name>keepgenerated</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </servlet>
+    <servlet>
+        <display-name>Source lister</display-name>
+        <servlet-name>lister</servlet-name>
+        <jsp-file>/list.jsp</jsp-file>
+        <init-param>
+            <param-name>keepgenerated</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </servlet>
+    <servlet>
+        <display-name>Source diffs between revisions</display-name>
+        <servlet-name>diff</servlet-name>
+        <jsp-file>/diff.jsp</jsp-file>
+        <init-param>
+            <param-name>keepgenerated</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </servlet>
+    <servlet>
+        <display-name>Shows more matching lines</display-name>
+        <servlet-name>more</servlet-name>
+        <jsp-file>/more.jsp</jsp-file>
+    </servlet>
+    <servlet>
+        <display-name>Source Changes in RSS format</display-name>
+        <servlet-name>rss</servlet-name>
+        <jsp-file>/rss.jsp</jsp-file>
+        <init-param>
+            <param-name>keepgenerated</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </servlet>
+    <servlet>
+        <display-name>OpenSearch link for current project</display-name>
+        <servlet-name>opensearch</servlet-name>
+        <jsp-file>/opensearch.jsp</jsp-file>
+        <init-param>
+            <param-name>keepgenerated</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </servlet>
+    <servlet>
+        <display-name>Raw Source lister</display-name>
+        <servlet-name>raw</servlet-name>
+        <jsp-file>/raw.jsp</jsp-file>
+        <init-param>
+            <param-name>keepgenerated</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </servlet>
+    <servlet>
+        <display-name>Download source</display-name>
+        <servlet-name>download</servlet-name>
+        <jsp-file>/raw.jsp</jsp-file>
+        <init-param>
+            <param-name>keepgenerated</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </servlet>
+    <servlet>
+        <display-name>Error Handler</display-name>
+        <servlet-name>error</servlet-name>
+        <jsp-file>/error.jsp</jsp-file>
+        <init-param>
+            <param-name>keepgenerated</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </servlet>
+    <servlet>
+        <display-name>File not found handler</display-name>
+        <servlet-name>enoent</servlet-name>
+        <jsp-file>/enoent.jsp</jsp-file>
+        <init-param>
+            <param-name>keepgenerated</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </servlet>
+    <servlet>
+        <display-name>Forbidden error handler</display-name>
+        <servlet-name>eforbidden</servlet-name>
+        <jsp-file>/eforbidden.jsp</jsp-file>
+        <init-param>
+            <param-name>keepgenerated</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>search</servlet-name>
+        <url-pattern>/search</url-pattern>
+        <!-- SEARCH_P -->
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>json</servlet-name>
+        <url-pattern>/json</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>opensearch</servlet-name>
+        <url-pattern>/opensearch</url-pattern>
+        <!-- SEARCH_O -->
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>history</servlet-name>
+        <url-pattern>/history/*</url-pattern>
+        <!-- HIST_L -->
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>lister</servlet-name>
+        <url-pattern>/xref/*</url-pattern>
+        <!-- XREF_P -->
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>raw</servlet-name>
+        <url-pattern>/raw/*</url-pattern>
+        <!-- RAW_P -->
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>download</servlet-name>
+        <url-pattern>/download/*</url-pattern>
+        <!-- DOWNLOAD_P -->
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>search</servlet-name>
+        <url-pattern>/s</url-pattern>
+        <!-- SEARCH_R -->
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>diff</servlet-name>
+        <url-pattern>/diff/*</url-pattern>
+        <!-- DIFF_P -->
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>more</servlet-name>
+        <url-pattern>/more/*</url-pattern>
+        <!-- MORE_P -->
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>rss</servlet-name>
+        <url-pattern>/rss/*</url-pattern>
+        <!-- RSS_P -->
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>error</servlet-name>
+        <url-pattern>/error</url-pattern>
+        <!-- ERROR -->
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>enoent</servlet-name>
+        <url-pattern>/enoent</url-pattern>
+        <!-- NOT_FOUND -->
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>eforbidden</servlet-name>
+        <url-pattern>/eforbidden</url-pattern>
+        <!-- FORBIDDEN -->
+    </servlet-mapping>
+    <error-page>
+        <error-code>404</error-code>
+        <location>/enoent</location>
+    </error-page>
+    <error-page>
+        <error-code>500</error-code>
+        <location>/error</location>
+    </error-page>
+    <jsp-config>
+        <jsp-property-group>
+            <url-pattern>*.jsp</url-pattern>
+            <trim-directive-whitespaces>true</trim-directive-whitespaces>
+        </jsp-property-group>
+    </jsp-config>
 </web-app>


### PR DESCRIPTION
Hello,

Please consider for integration this patch to set HTTP cache-controls for most OpenGrok content. Rather than use a container-specific filter (e.g.. org.catalina...), which I think would not be accepted for OpenGrok, I imported a simple filter implementation that is licensed freely from the book support site of "Servlets and JavaServer Pages; the J2EE Web Tier" by Jayson Falkner.

Because the filter is simple, it applies only by url-pattern (and not by e.g., content-type as Tomcat's might do). I set a one-half hour expiration for `/download/*`, `/history/*`, `/xref/*`, and `/raw/*` and one day for `/default/*` and `/js/*`. Any other content (e.g. `/Help.jsp`) will not be affected by this patch.

I split it into two commits. The first is just a re-save of web.xml from the NetBeans editor for its formatting revisions, and the second is the addition of and configuration of the filters.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
