### PR TITLE
Drop static writeXref()s; use existing thread-cached analyzers instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 *~
-nbproject/*~
+*.swp
 /nbproject/configs/*.properties
-opengrok-web-nbproject/nbproject/*~
-opengrok-web-nbproject/nbproject/build-impl.xml~
 tags
 TAGS
 build
@@ -39,8 +37,6 @@ webrev
 opengrok-web-nbproject/nbproject/private/
 opengrok-web-nbproject/nbproject/genfiles.properties
 run_my.bat
-*.xml~
-opengrok-web-nbproject/nbproject/build-impl.xml~
 build.bat
 jacoco
 jacoco.exec

--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -460,7 +460,14 @@ public class AnalyzerGuru {
             // spaces to match the project's tab settings.
             input = ExpandTabsReader.wrap(in, project);
         }
-        factory.writeXref(input, out, defs, annotation, project);
+
+        WriteXrefArgs args = new WriteXrefArgs(input, out);
+        args.setDefs(defs);
+        args.setAnnotation(annotation);
+        args.setProject(project);
+
+        FileAnalyzer analyzer = factory.getAnalyzer();
+        analyzer.writeXref(args);
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/FileAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/FileAnalyzer.java
@@ -20,6 +20,7 @@
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
  * Use is subject to license terms.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -181,6 +182,18 @@ public class FileAnalyzer extends Analyzer {
      */
     public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
         // not used
+    }
+
+    /**
+     * Derived classes should override to write a cross referenced HTML file
+     * for the specified args.
+     * @param args a defined instance
+     * @return the instance used to write the cross-referencing
+     * @throws java.io.IOException if an error occurs
+     */
+    public JFlexXref writeXref(WriteXrefArgs args) throws IOException {
+        throw new UnsupportedOperationException(
+            "Base FileAnalyzer cannot write xref");
     }
     
     // you analyzer HAS to override this to get proper symbols in results

--- a/src/org/opensolaris/opengrok/analysis/FileAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/FileAnalyzerFactory.java
@@ -25,14 +25,10 @@ package org.opensolaris.opengrok.analysis;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Reader;
-import java.io.Writer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * Factory class which creates a {@code FileAnalyzer} object and
@@ -240,19 +236,5 @@ public class FileAnalyzerFactory {
          */
         FileAnalyzerFactory isMagic(byte[] contents, InputStream in)
                 throws IOException;
-    }
-
-    /**
-     * Write a cross referenced HTML file. Reads the source from {@code in}.
-     * @param in input source
-     * @param out output xref writer
-     * @param defs definitions for the file (could be {@code null})
-     * @param annotation annotation for the file (could be {@code null})
-     * @param project project the file belongs to (could be {@code null})
-     * @throws java.io.IOException if an error occurs
-     */
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-            throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/TextAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/TextAnalyzer.java
@@ -19,15 +19,13 @@
 
 /*
  * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.Charset;
 import org.opensolaris.opengrok.util.IOUtils;
 
 public abstract class TextAnalyzer extends FileAnalyzer {
@@ -35,6 +33,33 @@ public abstract class TextAnalyzer extends FileAnalyzer {
     public TextAnalyzer(FileAnalyzerFactory factory) {
         super(factory);
     }
+
+    /**
+     * Write a cross referenced HTML file reads the source from in
+     * @param args a defined instance
+     * @return the instance used to write the cross-referencing
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public JFlexXref writeXref(WriteXrefArgs args) throws IOException {
+        if (args == null) throw new IllegalArgumentException("`args' is null");
+        JFlexXref xref = newXref(args.getIn());
+        xref.setDefs(args.getDefs());
+        xref.setScopesEnabled(scopesEnabled);
+        xref.setFoldingEnabled(foldingEnabled);
+        xref.annotation = args.getAnnotation();
+        xref.project = args.getProject();
+        xref.write(args.getOut());
+        return xref;
+    }
+
+    /**
+     * Derived classes should implement to create an xref for the language
+     * supported by this analyzer.
+     * @param reader the data to produce xref for
+     * @return an xref instance
+     */
+    protected abstract JFlexXref newXref(Reader reader);
 
     protected Reader getReader(InputStream stream) throws IOException {
         return IOUtils.createBOMStrippedReader(stream);

--- a/src/org/opensolaris/opengrok/analysis/WriteXrefArgs.java
+++ b/src/org/opensolaris/opengrok/analysis/WriteXrefArgs.java
@@ -28,7 +28,8 @@ import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.history.Annotation;
 
 /**
- * Represents the arguments for the {@link FileAnalyzerFactory.writeXref}
+ * Represents the arguments for the
+ * {@link org.opensolaris.opengrok.analysis.FileAnalyzer#writeXref(org.opensolaris.opengrok.analysis.WriteXrefArgs)}
  * method.
  */
 public class WriteXrefArgs {

--- a/src/org/opensolaris/opengrok/analysis/WriteXrefArgs.java
+++ b/src/org/opensolaris/opengrok/analysis/WriteXrefArgs.java
@@ -1,0 +1,66 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+ /*
+ * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ */
+package org.opensolaris.opengrok.analysis;
+
+import java.io.Reader;
+import java.io.Writer;
+import org.opensolaris.opengrok.configuration.Project;
+import org.opensolaris.opengrok.history.Annotation;
+
+/**
+ * Represents the arguments for the {@link FileAnalyzerFactory.writeXref}
+ * method.
+ */
+public class WriteXrefArgs {
+    private final Reader in;
+    private final Writer out;
+    private Definitions defs;
+    private Annotation annotation;
+    private Project project;
+
+    /**
+     * Initializes an instance of {@link WriteXrefArgs} for the required
+     * arguments.
+     * @param in a defined instance
+     * @param out a defined instance
+     * @throws IllegalArgumentException thrown if any argument is null.
+     */
+    public WriteXrefArgs(Reader in, Writer out) {
+        if (in == null) throw new IllegalArgumentException("`in' is null");
+        if (out == null) throw new IllegalArgumentException("`out' is null");
+        this.in = in;
+        this.out = out;
+    }
+
+    public Reader getIn() { return in; }
+    public Writer getOut() { return out; }
+
+    public Definitions getDefs() { return defs; }
+    public void setDefs(Definitions value) { defs = value; }
+
+    public Annotation getAnnotation() { return annotation; }
+    public void setAnnotation(Annotation value) { annotation = value; }
+
+    public Project getProject() { return project; }
+    public void setProject(Project value) { project = value; }
+}

--- a/src/org/opensolaris/opengrok/analysis/c/CAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/c/CAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.c;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * An Analyzer for C/C++/Java type of files
@@ -59,10 +54,5 @@ public class CAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected boolean supportsScopes() {
         return true;
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        CXref xref = new CXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/c/CAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/c/CAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.c;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class CAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -58,11 +52,5 @@ public class CAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new CAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        CAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/c/CxxAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/c/CxxAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.c;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * An Analyzer for C++ files
@@ -57,10 +52,5 @@ public class CxxAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected boolean supportsScopes() {
         return true;
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        CxxXref xref = new CxxXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/c/CxxAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/c/CxxAnalyzerFactory.java
@@ -22,15 +22,9 @@
  */
 package org.opensolaris.opengrok.analysis.c;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class CxxAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -55,11 +49,5 @@ public class CxxAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new CxxAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        CxxAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/clojure/ClojureAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/clojure/ClojureAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.clojure;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class ClojureAnalyzer extends AbstractSourceCodeAnalyzer {
 
@@ -43,10 +38,5 @@ public class ClojureAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new ClojureXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        ClojureXref xref = new ClojureXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/clojure/ClojureAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/clojure/ClojureAnalyzerFactory.java
@@ -22,15 +22,9 @@
  */
 package org.opensolaris.opengrok.analysis.clojure;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class ClojureAnalyzerFactory extends FileAnalyzerFactory {
 
@@ -49,11 +43,5 @@ public class ClojureAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new ClojureAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-            throws IOException {
-        ClojureAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.csharp;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -52,10 +47,5 @@ public class CSharpAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected boolean supportsScopes() {
         return true;
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        CSharpXref xref = new CSharpXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.csharp;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class CSharpAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -51,11 +45,5 @@ public class CSharpAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new CSharpAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        CSharpAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/document/TroffAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/document/TroffAnalyzer.java
@@ -62,6 +62,7 @@ public class TroffAnalyzer extends TextAnalyzer {
         if (xrefOut != null) {
             try (Reader in = getReader(src.getStream())) {
                 WriteXrefArgs args = new WriteXrefArgs(in, xrefOut);
+                args.setProject(project);
                 writeXref(args);
             }
         }

--- a/src/org/opensolaris/opengrok/analysis/document/TroffAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/document/TroffAnalyzer.java
@@ -68,7 +68,7 @@ public class TroffAnalyzer extends TextAnalyzer {
     }
 
     /**
-     * Create an {@see TroffXref} instance.
+     * Create a {@link TroffXref} instance.
      * @param reader the data to produce xref for
      * @return an xref instance
      */

--- a/src/org/opensolaris/opengrok/analysis/document/TroffAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/document/TroffAnalyzer.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.document;
 
@@ -27,13 +28,12 @@ import java.io.Reader;
 import java.io.Writer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.TextField;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
+import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.StreamSource;
 import org.opensolaris.opengrok.analysis.TextAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
+import org.opensolaris.opengrok.analysis.WriteXrefArgs;
 import org.opensolaris.opengrok.search.QueryBuilder;
 
 /**
@@ -42,8 +42,6 @@ import org.opensolaris.opengrok.search.QueryBuilder;
  * @author Chandan
  */
 public class TroffAnalyzer extends TextAnalyzer {
-
-    private TroffXref xref;
 
     /**
      * Creates a new instance of TroffAnalyzer
@@ -63,43 +61,19 @@ public class TroffAnalyzer extends TextAnalyzer {
 
         if (xrefOut != null) {
             try (Reader in = getReader(src.getStream())) {
-                writeXref(in, xrefOut);
+                WriteXrefArgs args = new WriteXrefArgs(in, xrefOut);
+                writeXref(args);
             }
         }
     }
 
     /**
-     * Write a cross referenced HTML file.
-     *
-     * @param in Input source
-     * @param out Writer to write HTML cross-reference
+     * Create an {@see TroffXref} instance.
+     * @param reader the data to produce xref for
+     * @return an xref instance
      */
-    private void writeXref(Reader in, Writer out) throws IOException {
-        if (xref == null) {
-            xref = new TroffXref(in);
-        } else {
-            xref.reInit(in);
-        }
-        xref.project = project;
-        out.write("</pre><div id=\"man\">");
-        xref.write(out);
-        out.write("</div><pre>");
-    }
-
-    /**
-     * Write a cross referenced HTML file reads the source from in
-     *
-     * @param in Input source
-     * @param out Output xref writer
-     * @param defs definitions for the file (could be null)
-     * @param annotation annotation for the file (could be null)
-     */
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        TroffXref xref = new TroffXref(in);
-        xref.project = project;
-        xref.setDefs(defs);
-        out.write("</pre><div id=\"man\">");
-        xref.write(out);
-        out.write("</div><pre>");
+    @Override
+    protected JFlexXref newXref(Reader reader) {
+        return new TroffXref(reader);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/document/TroffAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/document/TroffAnalyzerFactory.java
@@ -19,19 +19,14 @@
 
 /*
  * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.document;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class TroffAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -49,12 +44,4 @@ public class TroffAnalyzerFactory extends FileAnalyzerFactory {
     protected FileAnalyzer newAnalyzer() {
         return new TroffAnalyzer(this);
     }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException
-    {
-        TroffAnalyzer.writeXref(in, out, defs, annotation, project);
-    }
-
 }

--- a/src/org/opensolaris/opengrok/analysis/document/TroffXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/document/TroffXref.lex
@@ -19,8 +19,8 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- *
  * Portions Copyright 2011 Jens Elkner.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.document;
@@ -48,8 +48,11 @@ import org.opensolaris.opengrok.web.Util;
         div = 0;
         yyline++;
         this.out = out;
+
+        out.write("</pre><div id=\"man\">");
         while(yylex() != YYEOF) {
         }
+        out.write("</div><pre>");
   }
 
   // TODO move this into an include file when bug #16053 is fixed

--- a/src/org/opensolaris/opengrok/analysis/erlang/ErlangAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/erlang/ErlangAnalyzer.java
@@ -23,16 +23,11 @@
 
 package org.opensolaris.opengrok.analysis.erlang;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class ErlangAnalyzer extends AbstractSourceCodeAnalyzer {
 
@@ -45,19 +40,8 @@ public class ErlangAnalyzer extends AbstractSourceCodeAnalyzer {
         SymbolTokenizer=new ErlangSymbolTokenizer(FileAnalyzer.dummyReader);    
     }
 
-//    @Override
-//    protected JFlexScopeParser newScopeParser(Reader reader) {
-//        return new ErlangScopeParser(reader);
-//    }
-   
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new ErlangXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        ErlangXref xref = new ErlangXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
-
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/erlang/ErlangAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/erlang/ErlangAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.erlang;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class ErlangAnalyzerFactory extends FileAnalyzerFactory {
 
@@ -51,11 +45,5 @@ public class ErlangAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new ErlangAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-            throws IOException {
-        ErlangAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/fortran/FortranAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/fortran/FortranAnalyzer.java
@@ -22,15 +22,10 @@
  */
 package org.opensolaris.opengrok.analysis.fortran;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * An Analyzer for Fortran type of files
@@ -47,10 +42,5 @@ public class FortranAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new FortranXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        FortranXref xref = new FortranXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/fortran/FortranAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/fortran/FortranAnalyzerFactory.java
@@ -22,15 +22,9 @@
  */
 package org.opensolaris.opengrok.analysis.fortran;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class FortranAnalyzerFactory extends FileAnalyzerFactory {
 
@@ -48,11 +42,5 @@ public class FortranAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new FortranAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-            throws IOException {
-        FortranAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/golang/GolangAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/golang/GolangAnalyzer.java
@@ -23,16 +23,11 @@
 
 package org.opensolaris.opengrok.analysis.golang;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * @author Patrick Lundquist
@@ -52,10 +47,5 @@ public class GolangAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new GolangXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        GolangXref xref = new GolangXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/golang/GolangAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/golang/GolangAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.golang;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * @author Patrick Lundquist
@@ -52,11 +46,5 @@ public class GolangAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new GolangAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        GolangAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/haskell/HaskellAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/haskell/HaskellAnalyzer.java
@@ -23,16 +23,11 @@
 
 package org.opensolaris.opengrok.analysis.haskell;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * @author Harry Pan
@@ -52,10 +47,5 @@ public class HaskellAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new HaskellXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        HaskellXref xref = new HaskellXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/haskell/HaskellAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/haskell/HaskellAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.haskell;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * @author Harry Pan
@@ -55,11 +49,5 @@ public class HaskellAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new HaskellAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        HaskellAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/java/JavaAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/java/JavaAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.java;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -56,10 +51,5 @@ public class JavaAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected boolean supportsScopes() {
         return true;
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        JavaXref xref = new JavaXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/java/JavaAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/java/JavaAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.java;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class JavaAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -49,11 +43,5 @@ public class JavaAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new JavaAnalyzer(this);
-    }
-    
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        JavaAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.javascript;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -52,10 +47,5 @@ public class JavaScriptAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new JavaScriptXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        JavaScriptXref xref = new JavaScriptXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.javascript;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class JavaScriptAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -52,11 +46,5 @@ public class JavaScriptAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new JavaScriptAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        JavaScriptAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/json/JsonAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/json/JsonAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.json;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -52,10 +47,5 @@ public class JsonAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new JsonXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        JsonXref xref = new JsonXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/json/JsonAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/json/JsonAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.json;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class JsonAnalyzerFactory extends FileAnalyzerFactory {
     // TODO add schema support
@@ -51,11 +45,5 @@ public class JsonAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new JsonAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        JsonAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/kotlin/KotlinAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/kotlin/KotlinAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.kotlin;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -56,10 +51,5 @@ public class KotlinAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected boolean supportsScopes() {
         return true;
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        KotlinXref xref = new KotlinXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/kotlin/KotlinAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/kotlin/KotlinAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.kotlin;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class KotlinAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -49,11 +43,5 @@ public class KotlinAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new KotlinAnalyzer(this);
-    }
-    
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        KotlinAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/lisp/LispAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/lisp/LispAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.lisp;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -47,10 +42,5 @@ public class LispAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new LispXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        LispXref xref = new LispXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/lisp/LispAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/lisp/LispAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.lisp;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class LispAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -51,11 +45,5 @@ public class LispAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new LispAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        LispAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/lua/LuaAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/lua/LuaAnalyzer.java
@@ -23,16 +23,11 @@
 
 package org.opensolaris.opengrok.analysis.lua;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * @author Evan Kinney
@@ -52,10 +47,5 @@ public class LuaAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new LuaXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        LuaXref xref = new LuaXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/lua/LuaAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/lua/LuaAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.lua;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * @author Evan Kinney
@@ -52,11 +46,5 @@ public class LuaAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new LuaAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        LuaAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.pascal;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -56,10 +51,5 @@ public class PascalAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected boolean supportsScopes() {
         return true;
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        PascalXref xref = new PascalXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.pascal;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -53,11 +47,5 @@ public class PascalAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new PascalAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        PascalAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.perl;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -51,11 +46,5 @@ public class PerlAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new PerlXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs,
-        Annotation annotation, Project project) throws IOException {
-        PerlXref xref = new PerlXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.perl;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -62,11 +56,5 @@ public class PerlAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new PerlAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        PerlAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/php/PhpAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/php/PhpAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.php;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -51,10 +46,5 @@ public class PhpAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new PhpXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        PhpXref xref = new PhpXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/php/PhpAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/php/PhpAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.php;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class PhpAnalyzerFactory extends FileAnalyzerFactory {
 
@@ -57,11 +51,5 @@ public class PhpAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new PhpAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        PhpAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/plain/AbstractSourceCodeAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/AbstractSourceCodeAnalyzer.java
@@ -26,12 +26,10 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 import org.apache.lucene.document.Document;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.StreamSource;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
+import org.opensolaris.opengrok.analysis.WriteXrefArgs;
 
 /**
  *
@@ -73,27 +71,4 @@ public abstract class AbstractSourceCodeAnalyzer extends PlainAnalyzer {
     public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
         super.analyze(doc, src, xrefOut);
     }        
-
-    /**
-     * Write a cross referenced HTML file reads the source from in
-     *
-     * @param lxref xrefer to be used
-     * @param in Input source
-     * @param out Output xref writer
-     * @param defs definitions for the file (could be null)
-     * @param annotation annotation for the file (could be null)
-     * @param project project where this xref belongs to
-     * @throws IOException when any I/O error occurs
-     */
-    static protected void writeXref(JFlexXref lxref, Reader in, Writer out,
-        Definitions defs, Annotation annotation, Project project)
-            throws IOException {
-        if (lxref != null) {
-            lxref.reInit(in);
-            lxref.annotation = annotation;
-            lxref.project = project;
-            lxref.setDefs(defs);
-            lxref.write(out);
-        }
-    }
 }

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzer.java
@@ -104,6 +104,7 @@ public class PlainAnalyzer extends TextAnalyzer {
             try (Reader in = getReader(src.getStream())) {
                 WriteXrefArgs args = new WriteXrefArgs(in, xrefOut);
                 args.setDefs(defs);
+                args.setProject(project);
                 JFlexXref xref = writeXref(args);
             
                 Scopes scopes = xref.getScopes();

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzer.java
@@ -58,7 +58,7 @@ public class PlainAnalyzer extends TextAnalyzer {
     }
 
     /**
-     * Create an {@see PlainXref} instance.
+     * Create a {@link PlainXref} instance.
      * @param reader the data to produce xref for
      * @return an xref instance
      */

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzerFactory.java
@@ -26,15 +26,9 @@ package org.opensolaris.opengrok.analysis.plain;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.AnalyzerGuru;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 import org.opensolaris.opengrok.util.IOUtils;
 
 public final class PlainAnalyzerFactory extends FileAnalyzerFactory {
@@ -99,12 +93,5 @@ public final class PlainAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new PlainAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException
-    {
-        PlainAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/plain/XMLAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/XMLAnalyzer.java
@@ -56,6 +56,7 @@ public class XMLAnalyzer extends TextAnalyzer {
         if (xrefOut != null) {
             try (Reader in = getReader(src.getStream())) {
                 WriteXrefArgs args = new WriteXrefArgs(in, xrefOut);
+                args.setProject(project);
                 writeXref(args);
             }
         }

--- a/src/org/opensolaris/opengrok/analysis/plain/XMLAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/XMLAnalyzer.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.plain;
 
@@ -27,13 +28,11 @@ import java.io.Reader;
 import java.io.Writer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.TextField;
-import org.opensolaris.opengrok.analysis.AnalyzerGuru;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
+import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.StreamSource;
 import org.opensolaris.opengrok.analysis.TextAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
+import org.opensolaris.opengrok.analysis.WriteXrefArgs;
 
 /**
  * Analyzes HTML files Created on September 30, 2005
@@ -41,8 +40,6 @@ import org.opensolaris.opengrok.history.Annotation;
  * @author Chandan
  */
 public class XMLAnalyzer extends TextAnalyzer {
-
-    private final XMLXref xref = new XMLXref(AnalyzerGuru.dummyR);
 
     /**
      * Creates a new instance of XMLAnalyzer
@@ -58,36 +55,19 @@ public class XMLAnalyzer extends TextAnalyzer {
 
         if (xrefOut != null) {
             try (Reader in = getReader(src.getStream())) {
-                writeXref(in, xrefOut);
+                WriteXrefArgs args = new WriteXrefArgs(in, xrefOut);
+                writeXref(args);
             }
         }
     }
 
     /**
-     * Write a cross referenced HTML file.
-     *
-     * @param in Input source
-     * @param out Writer to write HTML cross-reference
+     * Create an {@see XMLXref} instance.
+     * @param reader the data to produce xref for
+     * @return an xref instance
      */
-    private void writeXref(Reader in, Writer out) throws IOException {
-        xref.reInit(in);
-        xref.project = project;
-        xref.write(out);
-    }
-
-    /**
-     * Write a cross referenced HTML file reads the source from in
-     *
-     * @param in Input source
-     * @param out Output xref writer
-     * @param defs definitions for the file (could be null)
-     * @param annotation annotation for the file (could be null)
-     */
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        XMLXref xref = new XMLXref(in);
-        xref.annotation = annotation;
-        xref.project = project;
-        xref.setDefs(defs);
-        xref.write(out);
+    @Override
+    protected JFlexXref newXref(Reader reader) {
+        return new XMLXref(reader);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/plain/XMLAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/XMLAnalyzer.java
@@ -62,7 +62,7 @@ public class XMLAnalyzer extends TextAnalyzer {
     }
 
     /**
-     * Create an {@see XMLXref} instance.
+     * Create an {@link XMLXref} instance.
      * @param reader the data to produce xref for
      * @return an xref instance
      */

--- a/src/org/opensolaris/opengrok/analysis/plain/XMLAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/XMLAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.plain;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class XMLAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -54,12 +48,5 @@ public class XMLAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new XMLAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException
-    {
-        XMLAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/powershell/PowershellAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/powershell/PowershellAnalyzer.java
@@ -22,18 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.powershell;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.analysis.powershell.PoshSymbolTokenizer;
-import org.opensolaris.opengrok.analysis.powershell.PoshXref;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * Analyzes PowerShell scripts Created on August 18, 2017
@@ -59,12 +52,5 @@ public class PowershellAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new PoshXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        PoshXref xref = new PoshXref(in);
-        xref.setScopesEnabled(true);
-        xref.setFoldingEnabled(true);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/powershell/PowershellAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/powershell/PowershellAnalyzerFactory.java
@@ -22,15 +22,9 @@
  */
 package org.opensolaris.opengrok.analysis.powershell;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class PowershellAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -48,12 +42,5 @@ public class PowershellAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new PowershellAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs,
-        Annotation annotation, Project project)
-        throws IOException {
-        PowershellAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/python/PythonAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/python/PythonAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.python;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -51,10 +46,5 @@ public class PythonAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new PythonXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        PythonXref xref = new PythonXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/python/PythonAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/python/PythonAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.python;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -61,11 +55,5 @@ public class PythonAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new PythonAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        PythonAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/rust/RustAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/rust/RustAnalyzer.java
@@ -24,16 +24,11 @@
 
 package org.opensolaris.opengrok.analysis.rust;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -59,10 +54,5 @@ public class RustAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected boolean supportsScopes() {
         return true;
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        RustXref xref = new RustXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/rust/RustAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/rust/RustAnalyzerFactory.java
@@ -24,15 +24,9 @@
 
 package org.opensolaris.opengrok.analysis.rust;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -55,11 +49,5 @@ public class RustAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new RustAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        RustAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/scala/ScalaAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/scala/ScalaAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.scala;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -51,10 +46,5 @@ public class ScalaAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new ScalaXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        ScalaXref xref = new ScalaXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/scala/ScalaAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/scala/ScalaAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.scala;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -53,11 +47,5 @@ public class ScalaAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new ScalaAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-         ScalaAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/sh/ShAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/sh/ShAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.sh;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * Analyzes Shell scripts/Conf files etc., Created on September 21, 2005
@@ -52,10 +47,5 @@ public class ShAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new ShXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        ShXref xref = new ShXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/sh/ShAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/sh/ShAnalyzerFactory.java
@@ -22,15 +22,9 @@
  */
 package org.opensolaris.opengrok.analysis.sh;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class ShAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -74,12 +68,5 @@ public class ShAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new ShAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs,
-        Annotation annotation, Project project)
-        throws IOException {
-        ShAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/sql/PLSQLAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/sql/PLSQLAnalyzer.java
@@ -22,15 +22,10 @@
  */
 package org.opensolaris.opengrok.analysis.sql;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.PlainAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class PLSQLAnalyzer extends PlainAnalyzer {
 
@@ -41,22 +36,5 @@ public class PLSQLAnalyzer extends PlainAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new PLSQLXref(reader);
-    }
-
-    /**
-     * Write a cross referenced HTML file. Reads the source from an input
-     * stream.
-     *
-     * @param in input source
-     * @param out output xref writer
-     * @param defs definitions for the file (could be null)
-     * @param annotation annotation for the file (could be null)
-     */
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        PLSQLXref xref = new PLSQLXref(in);
-        xref.annotation = annotation;
-        xref.project = project;
-        xref.setDefs(defs);
-        xref.write(out);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/sql/PLSQLAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/sql/PLSQLAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.sql;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class PLSQLAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -53,11 +47,5 @@ public class PLSQLAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new PLSQLAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        PLSQLAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/sql/SQLAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/sql/SQLAnalyzer.java
@@ -22,15 +22,10 @@
  */
 package org.opensolaris.opengrok.analysis.sql;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.PlainAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class SQLAnalyzer extends PlainAnalyzer {
 
@@ -41,22 +36,5 @@ public class SQLAnalyzer extends PlainAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new SQLXref(reader);
-    }
-
-    /**
-     * Write a cross referenced HTML file. Reads the source from an input
-     * stream.
-     *
-     * @param in input source
-     * @param out output xref writer
-     * @param defs definitions for the file (could be null)
-     * @param annotation annotation for the file (could be null)
-     */
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        SQLXref xref = new SQLXref(in);
-        xref.annotation = annotation;
-        xref.project = project;
-        xref.setDefs(defs);
-        xref.write(out);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/sql/SQLAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/sql/SQLAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.sql;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class SQLAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -48,11 +42,5 @@ public class SQLAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new SQLAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        SQLAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/swift/SwiftAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/swift/SwiftAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.swift;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -56,10 +51,5 @@ public class SwiftAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected boolean supportsScopes() {
         return true;
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        SwiftXref xref = new SwiftXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/swift/SwiftAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/swift/SwiftAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.swift;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class SwiftAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -48,11 +42,5 @@ public class SwiftAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new SwiftAnalyzer(this);
-    }
-    
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        SwiftAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/tcl/TclAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/tcl/TclAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.tcl;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -47,10 +42,5 @@ public class TclAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new TclXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        TclXref xref = new TclXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/tcl/TclAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/tcl/TclAnalyzerFactory.java
@@ -23,15 +23,9 @@
 
 package org.opensolaris.opengrok.analysis.tcl;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class TclAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -55,11 +49,5 @@ public class TclAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new TclAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException {
-        TclAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/uue/UuencodeAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/uue/UuencodeAnalyzer.java
@@ -72,7 +72,7 @@ public class UuencodeAnalyzer extends TextAnalyzer {
     }
 
     /**
-     * Create an {@see UuencodeXref} instance.
+     * Create a {@link UuencodeXref} instance.
      * @param reader the data to produce xref for
      * @return an xref instance
      */

--- a/src/org/opensolaris/opengrok/analysis/uue/UuencodeAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/uue/UuencodeAnalyzer.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.uue;
 
@@ -30,8 +31,11 @@ import org.apache.lucene.document.TextField;
 import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
+import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.StreamSource;
 import org.opensolaris.opengrok.analysis.TextAnalyzer;
+import org.opensolaris.opengrok.analysis.WriteXrefArgs;
+import org.opensolaris.opengrok.analysis.plain.XMLXref;
 import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.history.Annotation;
 import org.opensolaris.opengrok.search.QueryBuilder;
@@ -43,7 +47,6 @@ import org.opensolaris.opengrok.search.QueryBuilder;
  * @author Chandan
  */
 public class UuencodeAnalyzer extends TextAnalyzer {
-    private UuencodeXref xref;
     /**
      * Creates a new instance of UuencodeAnalyzer
      * @param factory name
@@ -62,40 +65,19 @@ public class UuencodeAnalyzer extends TextAnalyzer {
                 
         if (xrefOut != null) {
             try (Reader in = getReader(src.getStream())) {
-                writeXref(in, xrefOut);
+                WriteXrefArgs args = new WriteXrefArgs(in, xrefOut);
+                writeXref(args);
             }
         }
     }
 
     /**
-     * Write a cross referenced HTML file.
-     *
-     * @param in Input source
-     * @param out Writer to write HTML cross-reference
+     * Create an {@see UuencodeXref} instance.
+     * @param reader the data to produce xref for
+     * @return an xref instance
      */
-    private void writeXref(Reader in, Writer out) throws IOException {
-        if (xref == null) {
-            xref = new UuencodeXref(in);
-        } else {
-            xref.reInit(in);
-        }
-        xref.project = project;
-        xref.write(out);
-    }
-
-    /**
-     * Write a cross referenced HTML file reads the source from in
-     *
-     * @param in Input source
-     * @param out Output xref writer
-     * @param defs definitions for the file (could be null)
-     * @param annotation annotation for the file (could be null)
-     */
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        UuencodeXref xref = new UuencodeXref(in);
-        xref.annotation = annotation;
-        xref.project = project;
-        xref.setDefs(defs);
-        xref.write(out);
+    @Override
+    protected JFlexXref newXref(Reader reader) {
+        return new UuencodeXref(reader);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/uue/UuencodeAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/uue/UuencodeAnalyzer.java
@@ -28,16 +28,12 @@ import java.io.Reader;
 import java.io.Writer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.TextField;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.StreamSource;
 import org.opensolaris.opengrok.analysis.TextAnalyzer;
 import org.opensolaris.opengrok.analysis.WriteXrefArgs;
-import org.opensolaris.opengrok.analysis.plain.XMLXref;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 import org.opensolaris.opengrok.search.QueryBuilder;
 
 /**
@@ -66,6 +62,7 @@ public class UuencodeAnalyzer extends TextAnalyzer {
         if (xrefOut != null) {
             try (Reader in = getReader(src.getStream())) {
                 WriteXrefArgs args = new WriteXrefArgs(in, xrefOut);
+                args.setProject(project);
                 writeXref(args);
             }
         }

--- a/src/org/opensolaris/opengrok/analysis/uue/UuencodeAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/uue/UuencodeAnalyzerFactory.java
@@ -24,15 +24,9 @@
 
 package org.opensolaris.opengrok.analysis.uue;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  * @author Constantine A. Murenin &lt;http://cnst.su/&gt;
@@ -66,12 +60,4 @@ public class UuencodeAnalyzerFactory extends FileAnalyzerFactory {
     protected FileAnalyzer newAnalyzer() {
         return new UuencodeAnalyzer(this);
     }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-        throws IOException
-    {
-        UuencodeAnalyzer.writeXref(in, out, defs, annotation, project);
-    }
-
 }

--- a/src/org/opensolaris/opengrok/analysis/vb/VBAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/vb/VBAnalyzer.java
@@ -22,16 +22,11 @@
  */
 package org.opensolaris.opengrok.analysis.vb;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.AbstractSourceCodeAnalyzer;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 /**
  *
@@ -51,10 +46,5 @@ public class VBAnalyzer extends AbstractSourceCodeAnalyzer {
     @Override
     protected JFlexXref newXref(Reader reader) {
         return new VBXref(reader);
-    }
-
-    static void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project) throws IOException {
-        VBXref xref = new VBXref(in);
-        AbstractSourceCodeAnalyzer.writeXref(xref, in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/vb/VBAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/vb/VBAnalyzerFactory.java
@@ -22,15 +22,9 @@
  */
 package org.opensolaris.opengrok.analysis.vb;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzer.Genre;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.history.Annotation;
 
 public class VBAnalyzerFactory extends FileAnalyzerFactory {
     
@@ -52,11 +46,5 @@ public class VBAnalyzerFactory extends FileAnalyzerFactory {
     @Override
     protected FileAnalyzer newAnalyzer() {
         return new VBAnalyzer(this);
-    }
-
-    @Override
-    public void writeXref(Reader in, Writer out, Definitions defs, Annotation annotation, Project project)
-            throws IOException {
-        VBAnalyzer.writeXref(in, out, defs, annotation, project);
     }
 }

--- a/src/org/opensolaris/opengrok/util/IOUtils.java
+++ b/src/org/opensolaris/opengrok/util/IOUtils.java
@@ -62,6 +62,11 @@ public final class IOUtils {
         // singleton
     }
 
+    /**
+     * If {@code c} is not null, tries to {@code close}, catching and logging
+     * any {@link IOException}.
+     * @param c null or a defined instance
+     */
     public static void close(Closeable c) {
         if (c != null) {
             try {

--- a/test/org/opensolaris/opengrok/analysis/TextAnalyzerTest.java
+++ b/test/org/opensolaris/opengrok/analysis/TextAnalyzerTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -134,6 +135,11 @@ public class TextAnalyzerTest {
 
                 contents = sb.toString();
             }
+        }
+
+        @Override
+        protected JFlexXref newXref(Reader reader) {
+            throw new UnsupportedOperationException("Not needed by test.");
         }
     }
 }

--- a/test/org/opensolaris/opengrok/analysis/haskell/HaskellXrefTest.java
+++ b/test/org/opensolaris/opengrok/analysis/haskell/HaskellXrefTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.haskell;
 
@@ -35,6 +36,8 @@ import org.opensolaris.opengrok.analysis.Definitions;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import org.opensolaris.opengrok.analysis.FileAnalyzer;
+import org.opensolaris.opengrok.analysis.WriteXrefArgs;
 
 /**
  * Tests the {@link HaskellXref} class.
@@ -47,7 +50,9 @@ public class HaskellXrefTest {
     public void basicTest() throws IOException {
         String s = "putStrLn \"Hello, world!\"";
         Writer w = new StringWriter();
-        HaskellAnalyzer.writeXref(new StringReader(s), w, null, null, null);
+        HaskellAnalyzerFactory fac = new HaskellAnalyzerFactory();
+        FileAnalyzer analyzer = fac.getAnalyzer();
+        analyzer.writeXref(new WriteXrefArgs(new StringReader(s), w));
         assertEquals(
                 "<a class=\"l\" name=\"1\" href=\"#1\">1</a>"
                 + "<a href=\"/source/s?defs=putStrLn\" class=\"intelliWindow-symbol\" data-definition-place=\"undefined-in-file\">putStrLn</a>"
@@ -61,7 +66,12 @@ public class HaskellXrefTest {
                 + "href=\"http://localhost:8080/source/default/style.css\" /><title>Haskell Xref Test</title></head>");
         os.println("<body><div id=\"src\"><pre>");
         Writer w = new StringWriter();
-        HaskellAnalyzer.writeXref(new InputStreamReader(is, "UTF-8"), w, defs, null, null);
+        HaskellAnalyzerFactory fac = new HaskellAnalyzerFactory();
+        FileAnalyzer analyzer = fac.getAnalyzer();
+        WriteXrefArgs args = new WriteXrefArgs(
+            new InputStreamReader(is, "UTF-8"), w);
+        args.setDefs(defs);
+        analyzer.writeXref(args);
         os.print(w.toString());
         os.println("</pre></div></body></html>");
     }

--- a/test/org/opensolaris/opengrok/analysis/perl/PerlXrefTest.java
+++ b/test/org/opensolaris/opengrok/analysis/perl/PerlXrefTest.java
@@ -36,6 +36,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import org.opensolaris.opengrok.analysis.FileAnalyzer;
+import org.opensolaris.opengrok.analysis.WriteXrefArgs;
 
 /**
  * Tests the {@link PerlXref} class.
@@ -81,8 +83,10 @@ public class PerlXrefTest {
         copyStream(begin, oss);
 
         Writer sw = new StringWriter();
-        PerlAnalyzer.writeXref(new InputStreamReader(iss, "UTF-8"), sw, null,
-            null, null);
+        PerlAnalyzerFactory fac = new PerlAnalyzerFactory();
+        FileAnalyzer analyzer = fac.getAnalyzer();
+        analyzer.writeXref(new WriteXrefArgs(
+            new InputStreamReader(iss, "UTF-8"), sw));
         oss.print(sw.toString());
 
         InputStream end = getClass().getClassLoader().getResourceAsStream(

--- a/test/org/opensolaris/opengrok/analysis/php/PhpXrefTest.java
+++ b/test/org/opensolaris/opengrok/analysis/php/PhpXrefTest.java
@@ -36,6 +36,8 @@ import java.io.Writer;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import org.opensolaris.opengrok.analysis.FileAnalyzer;
+import org.opensolaris.opengrok.analysis.WriteXrefArgs;
 
 /**
  * Tests the {@link PhpXref} class.
@@ -48,7 +50,9 @@ public class PhpXrefTest {
     public void basicTest() throws IOException {
         String s = "<?php foo bar";
         Writer w = new StringWriter();
-        PhpAnalyzer.writeXref(new StringReader(s), w, null, null, null);
+        PhpAnalyzerFactory fac = new PhpAnalyzerFactory();
+        FileAnalyzer analyzer = fac.getAnalyzer();
+        analyzer.writeXref(new WriteXrefArgs(new StringReader(s), w));
         assertEquals(
                 "<a class=\"l\" name=\"1\" href=\"#1\">1</a><strong>&lt;?php</strong> <a href=\"/"
                 + "source/s?defs=foo\" class=\"intelliWindow-symbol\" data-definition-place=\"undefined-in-file\">foo</a> <a href=\"/source/s?defs=bar\" class=\"intelliWindow-symbol\" data-definition-place=\"undefined-in-file\">bar</a>",
@@ -59,7 +63,9 @@ public class PhpXrefTest {
     public void basicSingleQuotedStringTest() throws IOException {
         String s = "<?php define(\"FOO\", 'BAR\\'\"'); $foo='bar'; $hola=\"ls\"; $hola=''; $hola=\"\";";
         Writer w = new StringWriter();
-        PhpAnalyzer.writeXref(new StringReader(s), w, null, null, null);
+        PhpAnalyzerFactory fac = new PhpAnalyzerFactory();
+        FileAnalyzer analyzer = fac.getAnalyzer();
+        analyzer.writeXref(new WriteXrefArgs(new StringReader(s), w));
         assertEquals(
                 "<a class=\"l\" name=\"1\" href=\"#1\">1</a><strong>&lt;?php</strong> "
                 + "<a href=\"/source/s?defs=define\" class=\"intelliWindow-symbol\" data-definition-place=\"undefined-in-file\">define</a>(<span class=\"s\">\"FOO\"</span>, <span class=\"s\">'BAR<strong>\\'</strong>\"'</span>); "
@@ -77,9 +83,10 @@ public class PhpXrefTest {
                 + "href=\"http://localhost:8080/source/default/style.css\" /><title>PHP Xref Test</title></head>");
         os.println("<body><div id=\"src\"><pre>");
         Writer w = new StringWriter();
-        PhpAnalyzer.writeXref(
-                new InputStreamReader(is, "UTF-8"),
-                w, null, null, null);
+        PhpAnalyzerFactory fac = new PhpAnalyzerFactory();
+        FileAnalyzer analyzer = fac.getAnalyzer();
+        analyzer.writeXref(new WriteXrefArgs(
+            new InputStreamReader(is, "UTF-8"), w));
         os.print(w.toString());
         os.println("</pre></div></body></html>");
     }

--- a/test/org/opensolaris/opengrok/analysis/plain/XMLAnalyzerTest.java
+++ b/test/org/opensolaris/opengrok/analysis/plain/XMLAnalyzerTest.java
@@ -20,6 +20,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.plain;
@@ -29,6 +30,8 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.opensolaris.opengrok.analysis.FileAnalyzer;
+import org.opensolaris.opengrok.analysis.WriteXrefArgs;
 
 public class XMLAnalyzerTest {
     @Test
@@ -41,7 +44,9 @@ public class XMLAnalyzerTest {
                 "</foo>";
         StringReader sr = new StringReader(xmlText);
         StringWriter sw = new StringWriter();
-        XMLAnalyzer.writeXref(sr, sw, null, null, null);
+        XMLAnalyzerFactory fac = new XMLAnalyzerFactory();
+        FileAnalyzer analyzer = fac.getAnalyzer();
+        analyzer.writeXref(new WriteXrefArgs(sr, sw));
         String[] xref = sw.toString().split("\n");
         // Reference to a Java class should have / instead of . in the path
         assertTrue(xref[2].contains("path=com/foo/bar/MyClass"));
@@ -65,7 +70,9 @@ public class XMLAnalyzerTest {
                 + "</server>";
         StringReader sr = new StringReader(xmlText);
         StringWriter sw = new StringWriter();
-        XMLAnalyzer.writeXref(sr, sw, null, null, null);
+        XMLAnalyzerFactory fac = new XMLAnalyzerFactory();
+        FileAnalyzer analyzer = fac.getAnalyzer();
+        analyzer.writeXref(new WriteXrefArgs(sr, sw));
         String[] xref = sw.toString().split("\n");
         // don't remove ../
         assertTrue(xref[7].contains("org.quartz.plugin.jobInitializer.fileNames</a> = <a href=\"/source/s?path=../\">..</a>/"));
@@ -80,12 +87,14 @@ public class XMLAnalyzerTest {
         StringReader input =
                 new StringReader("<foo xyz='<betweensinglequotes>'> </foo>");
         StringWriter output = new StringWriter();
-        XMLAnalyzer.writeXref(input, output, null, null, null);
+        XMLAnalyzerFactory fac = new XMLAnalyzerFactory();
+        FileAnalyzer analyzer = fac.getAnalyzer();
+        analyzer.writeXref(new WriteXrefArgs(input, output));
         assertTrue(output.toString().contains("&lt;betweensinglequotes&gt;"));
 
         input = new StringReader("<foo xyz=\"<betweendoublequotes>\"> </foo>");
         output = new StringWriter();
-        XMLAnalyzer.writeXref(input, output, null, null, null);
+        analyzer.writeXref(new WriteXrefArgs(input, output));
         assertTrue(output.toString().contains("&lt;betweendoublequotes&gt;"));
     }
 }


### PR DESCRIPTION
Hello,

Please consider for integration this patch that simplifies the FileAnalyzer and FileAnalyzerFactory subclasses by dropping static writeXref() methods and dropping FileAnalyzerFactory.writeXref() and all its overrides — and by just relying on the existing classes' newAnalyzer() and newXref() methods enlisted from AnalyzerGuru and TextAnalyzer.

Also:
- Move "&lt;pre&gt;"-manipulation and div#man writing into TroffXref so TroffAnalyzer doesn't have to know HTML formatting details.
- Do not force scopesEnabled,foldingEnabled to true for PowershellAnalyzer.
- Refactor (non-static) writeXref() to use new WriteXrefArgs class.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
