### PR TITLE
Perl improvements 

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/perl/PerlLexHelper.java
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlLexHelper.java
@@ -389,16 +389,13 @@ class PerlLexHelper {
         if (c != '\0') {
             if ((i = remaining.indexOf(c)) < 1) {
                 terminator = remaining;
-                remaining = "";
             } else {
                 terminator = remaining.substring(0, i);
-                remaining = remaining.substring(i + 1);
             }
         } else {
             Matcher m = HERE_TERMINATOR_MATCH.matcher(remaining);
             if (!m.find()) return;
             terminator = m.group(0);
-            remaining = remaining.substring(terminator.length());
         }
 
         int state;

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlLexHelper.java
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlLexHelper.java
@@ -431,8 +431,11 @@ class PerlLexHelper {
     public boolean maybeEndHere(String capture) throws IOException {
         String trimmed = capture.replaceFirst("^\\s+", "");
         HereDocSettings settings = hereSettings.peek();
+
+        boolean didZspan = false;
         if (trimmed.equals(settings.terminator)) {
             listener.take(Consts.ZS);
+            didZspan = true;
             hereSettings.remove();
         }
 
@@ -441,7 +444,7 @@ class PerlLexHelper {
         if (hereSettings.size() > 0) {
             settings = hereSettings.peek();
             listener.switchState(settings.state);
-            listener.take(Consts.SS);
+            if (didZspan) listener.take(Consts.SS);
             return false;
         } else {
             listener.popState();

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
@@ -108,12 +108,12 @@ HereEOF4 = [\\]?{Identifier}
 //
 // Track some keywords that can be used to identify heuristically a possible
 // beginning of the shortcut syntax, //, for m//. Also include any perlfunc
-// that takes /PATTERN/ -- which is just "split". Heuristics using punctuation
-// are defined inline later in some rules.
+// that takes /PATTERN/. Heuristics using punctuation are defined inline later
+// in some rules.
 //
 Mwords_1 = ("eq" | "ne" | "le" | "ge" | "lt" | "gt" | "cmp")
 Mwords_2 = ("if" | "unless" | "or" | "and" | "not")
-Mwords_3 = ("split")
+Mwords_3 = ("split" | "grep")
 Mwords = ({Mwords_1} | {Mwords_2} | {Mwords_3})
 
 Mpunc1YYIN = [\(\!]

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
@@ -150,13 +150,13 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>")
 %%
 <HERE, HERExN> {
     ^ {Identifier} / {MaybeWhsp}{EOL}    {
-        if (h.maybeEndHere(yytext())) yyjump(YYINITIAL);
+        h.maybeEndHere(yytext());
     }
 }
 
 <HEREin, HEREinxN> {
     ^ {MaybeWhsp} {Identifier} / {MaybeWhsp}{EOL}    {
-        if (h.maybeEndHere(yytext())) yyjump(YYINITIAL);
+        h.maybeEndHere(yytext());
     }
 }
 

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
@@ -388,11 +388,13 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>")
     }
 }
 
-<QUO, QUOxN, QUOxL, QUOxLxN> {
+<FMT, QUO, QUOxN, QUOxL, QUOxLxN, HERE, HEREin> {
     \\ \S    {
         takeNonword(yytext());
     }
+}
 
+<QUO, QUOxN, QUOxL, QUOxLxN> {
     {Quo0} |
     \w    {
         String capture = yytext();

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
@@ -122,13 +122,14 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>")
 // Unfortunately, we cannot control the %state values, so we have to declare
 // a cross-product of states. (Technically, state values are not guaranteed to
 // be unique by jflex, but states that do not have identical rules will have
-// different values. The following four "QUO" states satisfy this difference
-// criterion. Likewise with the four "HERE" states.)
+// different values. The four "QUO" below states satisfy this difference
+// criterion; as likewise do the four "HERE" states.)
 //
 // YYINITIAL : nothing yet parsed or just after a non-quoted [;{}]
 // INTRA : saw content from YYINITIAL but not yet other state or [;{}]
 // SCOMMENT : single-line comment
 // POD : Perl Plain-Old-Documentation
+// FMT : an output record format
 // QUO : quote-like that is OK to match paths|files|URLs|e-mails
 // QUOxN : "" but with no interpolation
 // QUOxL : quote-like that is not OK to match paths|files|URLs|e-mails
@@ -139,9 +140,10 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>")
 // HERExN : Here-docs with no interpolation
 // HEREin : Indented Here-docs
 // HEREinxN : Indented Here-docs with no interpolation
-// FMT : an output record format
 //
-%state INTRA SCOMMENT POD FMT QUO QUOxN QUOxL QUOxLxN QM HERE HERExN HEREin HEREinxN
+%state INTRA SCOMMENT POD FMT
+%state QUO QUOxN QUOxL QUOxLxN QM
+%state HERE HERExN HEREin HEREinxN
 
 %%
 <HERE, HERExN> {

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
@@ -32,7 +32,7 @@ MaybeWhsp     = {WhspChar}*
 EOL = \r|\n|\r\n
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 Sigils = ("$" | "@" | "%" | "&" | "*")
-WxSigils = [[\W]--[\$\@\%\&\*\"\'\`\#]]
+WxSigils = [[\W]--[\$\@\%\&\*\"\'\`\#\r\n]]
 
 // Perl special identifiers (four of six from
 // https://perldoc.perl.org/perldata.html#Identifier-parsing):
@@ -100,8 +100,10 @@ TRhash = "tr"\#
 TRpunc = "tr" {MaybeWhsp} {Quo0xHash}
 TRword = "tr" {WhiteSpace} \w
 
-HereContinuation = \,{MaybeWhsp} "<<"\~? {MaybeWhsp}
-MaybeHereMarkers = ([\"\'\`\\]?{Identifier} [^\n\r]* {HereContinuation})?
+HereEOF1 = [\"][^\r\n\"]*[\"]
+HereEOF2 = [\`][^\r\n\`]*[\`]
+HereEOF3 = [\'][^\r\n\']*[\']
+HereEOF4 = [\\]?{Identifier}
 
 //
 // Track some keywords that can be used to identify heuristically a possible
@@ -175,23 +177,8 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>")
         takeNonword(yytext());
     }
 
- // Following are rules for Here-documents. Stacked multiple here-docs are
- // recognized, but not fully supported, as only the interpolation setting
- // of the first marker will apply to all sections. (The final, second HERE
- // quoting character is not demanded, as it is superfluous for the needs of
- // xref lexing; and leaving it off simplifies parsing.)
-
- "<<"  {MaybeWhsp} {MaybeHereMarkers} [\"\`]?{Identifier}    {
-    h.hop(yytext(), false/*nointerp*/, false/*indented*/);
- }
- "<<~" {MaybeWhsp} {MaybeHereMarkers} [\"\`]?{Identifier}    {
-    h.hop(yytext(), false/*nointerp*/, true/*indented*/);
- }
- "<<"  {MaybeWhsp} {MaybeHereMarkers} [\'\\]{Identifier}    {
-    h.hop(yytext(), true/*nointerp*/, false/*indented*/);
- }
- "<<~" {MaybeWhsp} {MaybeHereMarkers} [\'\\]{Identifier}    {
-    h.hop(yytext(), true/*nointerp*/, true/*indented*/);
+ "<<"[~]? {MaybeWhsp} ({HereEOF1}|{HereEOF2}|{HereEOF3}|{HereEOF4})    {
+    h.hop(yytext());
  }
 
  {Identifier}    {
@@ -451,6 +438,11 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>")
     takeNonword(yytext());
     take(Consts.ZS);
   }
+
+  {WhiteSpace}{EOL} |
+  {EOL}    {
+    doStartNewLine();
+  }
 }
 
 <FMT> {
@@ -477,10 +469,23 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>")
 <SCOMMENT> {
   {WhiteSpace}{EOL} |
   {EOL} {
+    String capture = yytext();
+    yypushback(capture.length());
     yypop();
     take(Consts.ZS);
-    doStartNewLine();
   }
+}
+
+<YYINITIAL, INTRA> {
+    {WhiteSpace}{EOL} |
+    {EOL}    {
+        String capture = yytext();
+        if (h.maybeStartHere()) {
+            yypushback(capture.length());
+        } else {
+            doStartNewLine();
+        }
+    }
 }
 
 <YYINITIAL, INTRA, SCOMMENT, POD, FMT, QUO, QUOxN, QUOxL, QUOxLxN,
@@ -488,11 +493,6 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>")
  [&<>\"\']      {
         maybeIntraState();
         takeNonword(yytext());
- }
-
- {WhiteSpace}{EOL} |
- {EOL}          {
-        doStartNewLine();
  }
 
  // Only one whitespace char at a time or else {WxSigils} can be broken

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
@@ -117,7 +117,7 @@ Mwords_3 = ("split" | "grep")
 Mwords = ({Mwords_1} | {Mwords_2} | {Mwords_3})
 
 Mpunc1YYIN = [\(\!]
-Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>")
+Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>"|"=>")
 
 //
 // There are two dimensions to quoting: "link"-or-not and "interpolate"-or-not.
@@ -282,7 +282,8 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>")
  }
 
  // FORMAT start
- ^ {MaybeWhsp} "format" ({WhiteSpace} {Identifier})? {MaybeWhsp} "="    {
+ ^ {MaybeWhsp} "format" ({WhiteSpace} {Identifier})? {MaybeWhsp} "=" /
+     {MaybeWhsp}{EOL}    {
     pushState(FMT);
     if (takeAllContent()) {
         // split off the "  format" as `initial' for keyword processing

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlSymbolTokenizer.lex
@@ -55,6 +55,8 @@ super(in);
 
     public void popState() throws IOException { yypop(); }
 
+    public void switchState(int state) { yybegin(state); }
+
     public void take(String value) throws IOException {
         // noop
     }

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlXref.lex
@@ -57,6 +57,8 @@ import org.opensolaris.opengrok.web.Util;
 
     public void popState() throws IOException { yypop(); }
 
+    public void switchState(int state) { yybegin(state); }
+
     public void take(String value) throws IOException {
         out.write(value);
     }

--- a/test/org/opensolaris/opengrok/analysis/perl/sample.pl
+++ b/test/org/opensolaris/opengrok/analysis/perl/sample.pl
@@ -353,3 +353,17 @@ print "%\abc\n", %\, "abc\n";
 # some comment
 push @arr, "'$key'=>" . 'q[' . $val . '],';
 #qq[$var]
+
+# more HERE-document tests
+myfunc2(<< "THIS", $var, <<~'THAT', $var, <<OTHER, <<\ELSE, <<`Z`);
+Here's a $line1
+THIS
+	Here's a $line2
+	THAT
+Here's a $line3
+OTHER
+Here's a $line4
+ELSE
+Here's a $line5
+Z
+/\b sentinel \b/ && print; # This should heuristically match as m//

--- a/test/org/opensolaris/opengrok/analysis/perl/sample.pl
+++ b/test/org/opensolaris/opengrok/analysis/perl/sample.pl
@@ -367,3 +367,8 @@ ELSE
 Here's a $line5
 Z
 /\b sentinel \b/ && print; # This should heuristically match as m//
+
+# more quote-like tests
+for my $k (grep /=/, split /;/, $d, -1) {
+	print "1\n";
+}

--- a/test/org/opensolaris/opengrok/analysis/perl/sample.pl
+++ b/test/org/opensolaris/opengrok/analysis/perl/sample.pl
@@ -319,7 +319,7 @@ print "1\n";
  format STDOUT =
 @<<<<<<   @||||||   @>>>>>>
 # comment <args to follow>
-"left",  substr($var, 0, 2), "right"
+"left",  substr($var, 0, 2), "\$right"
  ...
  print
 .
@@ -365,6 +365,7 @@ OTHER
 Here's a $line4
 ELSE
 Here's a $line5
+Here's a \$line6
 Z
 /\b sentinel \b/ && print; # This should heuristically match as m//
 

--- a/test/org/opensolaris/opengrok/analysis/perl/sample.pl
+++ b/test/org/opensolaris/opengrok/analysis/perl/sample.pl
@@ -134,8 +134,8 @@ I said bar.
 bar
 
 myfunc(<< "THIS", 23, <<'THAT');
-Here's a line
-or two.
+Here's a line or
+two
 THIS
 and here's another.
 THAT

--- a/test/org/opensolaris/opengrok/analysis/perl/sample.pl
+++ b/test/org/opensolaris/opengrok/analysis/perl/sample.pl
@@ -373,3 +373,12 @@ Z
 for my $k (grep /=/, split /;/, $d, -1) {
 	print "1\n";
 }
+
+# more format tests
+%a = (
+    format => "%s");
+ format=
+@<<<<<<   @||||||   @>>>>>>
+"left",  "middle", "right"
+.
+print "1\n";

--- a/test/org/opensolaris/opengrok/analysis/perl/samplesymbols.txt
+++ b/test/org/opensolaris/opengrok/analysis/perl/samplesymbols.txt
@@ -302,3 +302,9 @@ html		# 351:push @$html
 arr		# 354:push @arr
 key
 val
+myfunc2		# 358:myfunc2(
+var
+var
+line1
+line3
+line5

--- a/test/org/opensolaris/opengrok/analysis/perl/samplesymbols.txt
+++ b/test/org/opensolaris/opengrok/analysis/perl/samplesymbols.txt
@@ -310,3 +310,5 @@ line3
 line5
 k
 d
+a		# 378:%a =
+s

--- a/test/org/opensolaris/opengrok/analysis/perl/samplesymbols.txt
+++ b/test/org/opensolaris/opengrok/analysis/perl/samplesymbols.txt
@@ -308,3 +308,5 @@ var
 line1
 line3
 line5
+k
+d

--- a/test/org/opensolaris/opengrok/analysis/perl/samplexrefres.html
+++ b/test/org/opensolaris/opengrok/analysis/perl/samplexrefres.html
@@ -380,5 +380,14 @@
 <a class="l" name="373" href="#373">373</a><b>for</b> <b>my</b> $k (<b>grep</b> <span class="s">/=/</span>, <b>split</b> <span class="s">/;/</span>, $d, -<span class="n">1</span>) {
 <a class="l" name="374" href="#374">374</a>	<b>print</b> <span class="s">&quot;1\n&quot;</span>;
 <a class="l" name="375" href="#375">375</a>}
-<a class="l" name="376" href="#376">376</a></body>
+<a class="l" name="376" href="#376">376</a>
+<a class="l" name="377" href="#377">377</a><span class="c"># more format tests</span>
+<a class="l" name="378" href="#378">378</a>%a = (
+<a class="l" name="379" href="#379">379</a>    <b>format</b> =&gt; <span class="s">&quot;%s&quot;</span>);
+<a class="hl" name="380" href="#380">380</a><b> format</b>=<span class="s"></span>
+<a class="l" name="381" href="#381">381</a><span class="s">@&lt;&lt;&lt;&lt;&lt;&lt;   @||||||   @&gt;&gt;&gt;&gt;&gt;&gt;</span>
+<a class="l" name="382" href="#382">382</a><span class="s">&quot;left&quot;,  &quot;middle&quot;, &quot;right&quot;</span>
+<a class="l" name="383" href="#383">383</a><span class="s">.</span>
+<a class="l" name="384" href="#384">384</a><b>print</b> <span class="s">&quot;1\n&quot;</span>;
+<a class="l" name="385" href="#385">385</a></body>
 </html>

--- a/test/org/opensolaris/opengrok/analysis/perl/samplexrefres.html
+++ b/test/org/opensolaris/opengrok/analysis/perl/samplexrefres.html
@@ -141,8 +141,8 @@
 <a class="l" name="134" href="#134">134</a><span class="s"></span>bar
 <a class="l" name="135" href="#135">135</a>
 <a class="l" name="136" href="#136">136</a><a href="/source/s?defs=myfunc" class="intelliWindow-symbol" data-definition-place="undefined-in-file">myfunc</a>(&lt;&lt; &quot;THIS&quot;, <span class="n">23</span>, &lt;&lt;&apos;THAT&apos;);<span class="s"></span>
-<a class="l" name="137" href="#137">137</a><span class="s">Here&apos;s a line</span>
-<a class="l" name="138" href="#138">138</a><span class="s">or two.</span>
+<a class="l" name="137" href="#137">137</a><span class="s">Here&apos;s a line or</span>
+<a class="l" name="138" href="#138">138</a><span class="s">two</span>
 <a class="l" name="139" href="#139">139</a><span class="s"></span>THIS<span class="s"></span>
 <a class="hl" name="140" href="#140">140</a><span class="s">and here&apos;s another.</span>
 <a class="l" name="141" href="#141">141</a><span class="s"></span>THAT

--- a/test/org/opensolaris/opengrok/analysis/perl/samplexrefres.html
+++ b/test/org/opensolaris/opengrok/analysis/perl/samplexrefres.html
@@ -326,7 +326,7 @@
 <a class="l" name="319" href="#319">319</a><b> format</b> STDOUT =<span class="s"></span>
 <a class="hl" name="320" href="#320">320</a><span class="s">@&lt;&lt;&lt;&lt;&lt;&lt;   @||||||   @&gt;&gt;&gt;&gt;&gt;&gt;</span>
 <a class="l" name="321" href="#321">321</a><span class="s"><span class="c"># comment &lt;args to follow&gt;</span></span>
-<a class="l" name="322" href="#322">322</a><span class="s">&quot;left&quot;,  substr($<a href="/source/s?defs=var" class="intelliWindow-symbol" data-definition-place="undefined-in-file">var</a>, 0, 2), &quot;right&quot;</span>
+<a class="l" name="322" href="#322">322</a><span class="s">&quot;left&quot;,  substr($<a href="/source/s?defs=var" class="intelliWindow-symbol" data-definition-place="undefined-in-file">var</a>, 0, 2), &quot;\$right&quot;</span>
 <a class="l" name="323" href="#323">323</a><span class="s"> ...</span>
 <a class="l" name="324" href="#324">324</a><span class="s"> print</span>
 <a class="l" name="325" href="#325">325</a><span class="s">.</span>
@@ -372,12 +372,13 @@
 <a class="l" name="365" href="#365">365</a><span class="s">Here&apos;s a $line4</span>
 <a class="l" name="366" href="#366">366</a><span class="s"></span>ELSE<span class="s"></span>
 <a class="l" name="367" href="#367">367</a><span class="s">Here&apos;s a $<a href="/source/s?defs=line5" class="intelliWindow-symbol" data-definition-place="undefined-in-file">line5</a></span>
-<a class="l" name="368" href="#368">368</a><span class="s"></span>Z
-<a class="l" name="369" href="#369">369</a><span class="s">/\b sentinel \b/</span> &amp;&amp; <b>print</b>; <span class="c"># This should heuristically match as m//</span>
-<a class="hl" name="370" href="#370">370</a>
-<a class="l" name="371" href="#371">371</a><span class="c"># more quote-like tests</span>
-<a class="l" name="372" href="#372">372</a><b>for</b> <b>my</b> $k (<b>grep</b> <span class="s">/=/</span>, <b>split</b> <span class="s">/;/</span>, $d, -<span class="n">1</span>) {
-<a class="l" name="373" href="#373">373</a>	<b>print</b> <span class="s">&quot;1\n&quot;</span>;
-<a class="l" name="374" href="#374">374</a>}
-<a class="l" name="375" href="#375">375</a></body>
+<a class="l" name="368" href="#368">368</a><span class="s">Here&apos;s a \$line6</span>
+<a class="l" name="369" href="#369">369</a><span class="s"></span>Z
+<a class="hl" name="370" href="#370">370</a><span class="s">/\b sentinel \b/</span> &amp;&amp; <b>print</b>; <span class="c"># This should heuristically match as m//</span>
+<a class="l" name="371" href="#371">371</a>
+<a class="l" name="372" href="#372">372</a><span class="c"># more quote-like tests</span>
+<a class="l" name="373" href="#373">373</a><b>for</b> <b>my</b> $k (<b>grep</b> <span class="s">/=/</span>, <b>split</b> <span class="s">/;/</span>, $d, -<span class="n">1</span>) {
+<a class="l" name="374" href="#374">374</a>	<b>print</b> <span class="s">&quot;1\n&quot;</span>;
+<a class="l" name="375" href="#375">375</a>}
+<a class="l" name="376" href="#376">376</a></body>
 </html>

--- a/test/org/opensolaris/opengrok/analysis/perl/samplexrefres.html
+++ b/test/org/opensolaris/opengrok/analysis/perl/samplexrefres.html
@@ -98,52 +98,52 @@
 <a class="l" name="91" href="#91">91</a><span class="c"># <a href="https://perldoc.perl.org/perlop.html#Quote-and-Quote-like-Operators">https://perldoc.perl.org/perlop.html#Quote-and-Quote-like-Operators</a></span>
 <a class="l" name="92" href="#92">92</a><span class="c">#</span>
 <a class="l" name="93" href="#93">93</a>
-<a class="l" name="94" href="#94">94</a><b>print</b> &lt;&lt;EOF<span class="s">;</span>
+<a class="l" name="94" href="#94">94</a><b>print</b> &lt;&lt;EOF;<span class="s"></span>
 <a class="l" name="95" href="#95">95</a><span class="s">The price is $<a href="/source/s?defs=Price" class="intelliWindow-symbol" data-definition-place="undefined-in-file">Price</a>.</span>
 <a class="l" name="96" href="#96">96</a><span class="s"></span>EOF
-<a class="l" name="97" href="#97">97</a><b>print</b> &lt;&lt; &quot;EOF<span class="s">&quot;; # same as above</span>
+<a class="l" name="97" href="#97">97</a><b>print</b> &lt;&lt; &quot;EOF&quot;; <span class="c"># same as above</span><span class="s"></span>
 <a class="l" name="98" href="#98">98</a><span class="s">The price is $<a href="/source/s?defs=Price" class="intelliWindow-symbol" data-definition-place="undefined-in-file">Price</a>.</span>
 <a class="l" name="99" href="#99">99</a><span class="s"></span>EOF
 <a class="hl" name="100" href="#100">100</a>
-<a class="l" name="101" href="#101">101</a><b>my</b> $<a href="/source/s?defs=cost" class="intelliWindow-symbol" data-definition-place="undefined-in-file">cost</a> = &lt;&lt;&apos;VISTA<span class="s">&apos;;  # hasta la ...</span>
+<a class="l" name="101" href="#101">101</a><b>my</b> $<a href="/source/s?defs=cost" class="intelliWindow-symbol" data-definition-place="undefined-in-file">cost</a> = &lt;&lt;&apos;VISTA&apos;;  <span class="c"># hasta la ...</span><span class="s"></span>
 <a class="l" name="102" href="#102">102</a><span class="s">That&apos;ll be $10 please, ma&apos;am.</span>
 <a class="l" name="103" href="#103">103</a><span class="s"></span>VISTA
-<a class="l" name="104" href="#104">104</a>$<a href="/source/s?defs=cost" class="intelliWindow-symbol" data-definition-place="undefined-in-file">cost</a> = &lt;&lt;\VISTA<span class="s">;   # Same thing!</span>
+<a class="l" name="104" href="#104">104</a>$<a href="/source/s?defs=cost" class="intelliWindow-symbol" data-definition-place="undefined-in-file">cost</a> = &lt;&lt;\VISTA;   <span class="c"># Same thing!</span><span class="s"></span>
 <a class="l" name="105" href="#105">105</a><span class="s">That&apos;ll be $10 please, ma&apos;am.</span>
 <a class="l" name="106" href="#106">106</a><span class="s"></span>VISTA
 <a class="l" name="107" href="#107">107</a>
-<a class="l" name="108" href="#108">108</a><b>print</b> &lt;&lt; `EOC<span class="s">`; # execute command and get results</span>
+<a class="l" name="108" href="#108">108</a><b>print</b> &lt;&lt; `EOC`; <span class="c"># execute command and get results</span><span class="s"></span>
 <a class="l" name="109" href="#109">109</a><span class="s">echo hi there</span>
 <a class="hl" name="110" href="#110">110</a><span class="s"></span>EOC
 <a class="l" name="111" href="#111">111</a>
 <a class="l" name="112" href="#112">112</a><b>if</b> ($<a href="/source/s?defs=some_var" class="intelliWindow-symbol" data-definition-place="undefined-in-file">some_var</a>) {
-<a class="l" name="113" href="#113">113</a>	<b>print</b> &lt;&lt;~EOF<span class="s">;</span>
+<a class="l" name="113" href="#113">113</a>	<b>print</b> &lt;&lt;~EOF;<span class="s"></span>
 <a class="l" name="114" href="#114">114</a><span class="s">	This is a here-doc</span>
 <a class="l" name="115" href="#115">115</a><span class="s"></span>	EOF
 <a class="l" name="116" href="#116">116</a>}
 <a class="l" name="117" href="#117">117</a>
-<a class="l" name="118" href="#118">118</a><b>print</b> &lt;&lt;~EOF<span class="s">;</span>
+<a class="l" name="118" href="#118">118</a><b>print</b> &lt;&lt;~EOF;<span class="s"></span>
 <a class="l" name="119" href="#119">119</a><span class="s">	This text is not indented</span>
 <a class="hl" name="120" href="#120">120</a><span class="s">	This text is indented with two spaces</span>
 <a class="l" name="121" href="#121">121</a><span class="s">		This text is indented with two tabs</span>
 <a class="l" name="122" href="#122">122</a><span class="s"></span>EOF
 <a class="l" name="123" href="#123">123</a>
-<a class="l" name="124" href="#124">124</a><b>print</b> &lt;&lt;~ &apos;EOF<span class="s">&apos;;</span>
+<a class="l" name="124" href="#124">124</a><b>print</b> &lt;&lt;~ &apos;EOF&apos;;<span class="s"></span>
 <a class="l" name="125" href="#125">125</a><span class="s">	This text is not indented</span>
 <a class="l" name="126" href="#126">126</a><span class="s">	This text is indented with two spaces</span>
 <a class="l" name="127" href="#127">127</a><span class="s">		This text is indented with two tabs</span>
 <a class="l" name="128" href="#128">128</a><span class="s"></span>EOF
 <a class="l" name="129" href="#129">129</a>
-<a class="hl" name="130" href="#130">130</a><b>print</b> &lt;&lt;&quot;foo&quot;, &lt;&lt;&quot;bar<span class="s">&quot;; # you can stack them</span>
+<a class="hl" name="130" href="#130">130</a><b>print</b> &lt;&lt;&quot;foo&quot;, &lt;&lt;&quot;bar&quot;; <span class="c"># you can stack them</span><span class="s"></span>
 <a class="l" name="131" href="#131">131</a><span class="s">I said foo.</span>
-<a class="l" name="132" href="#132">132</a><span class="s">foo</span>
+<a class="l" name="132" href="#132">132</a><span class="s"></span>foo<span class="s"></span>
 <a class="l" name="133" href="#133">133</a><span class="s">I said bar.</span>
 <a class="l" name="134" href="#134">134</a><span class="s"></span>bar
 <a class="l" name="135" href="#135">135</a>
-<a class="l" name="136" href="#136">136</a><a href="/source/s?defs=myfunc" class="intelliWindow-symbol" data-definition-place="undefined-in-file">myfunc</a>(&lt;&lt; &quot;THIS&quot;, 23, &lt;&lt;&apos;THAT<span class="s">&apos;);</span>
+<a class="l" name="136" href="#136">136</a><a href="/source/s?defs=myfunc" class="intelliWindow-symbol" data-definition-place="undefined-in-file">myfunc</a>(&lt;&lt; &quot;THIS&quot;, <span class="n">23</span>, &lt;&lt;&apos;THAT&apos;);<span class="s"></span>
 <a class="l" name="137" href="#137">137</a><span class="s">Here&apos;s a line</span>
 <a class="l" name="138" href="#138">138</a><span class="s">or two.</span>
-<a class="l" name="139" href="#139">139</a><span class="s">THIS</span>
+<a class="l" name="139" href="#139">139</a><span class="s"></span>THIS<span class="s"></span>
 <a class="hl" name="140" href="#140">140</a><span class="s">and here&apos;s another.</span>
 <a class="l" name="141" href="#141">141</a><span class="s"></span>THAT
 <a class="l" name="142" href="#142">142</a>
@@ -299,7 +299,7 @@
 <a class="l" name="292" href="#292">292</a><b>qr</b><span class="s">{\.[a-z]+$}</span>i;
 <a class="l" name="293" href="#293">293</a>
 <a class="l" name="294" href="#294">294</a><span class="c"># should back to YYINITIAL after HERE document</span>
-<a class="l" name="295" href="#295">295</a><b>print</b> &lt;&lt;EOF<span class="s">;</span>
+<a class="l" name="295" href="#295">295</a><b>print</b> &lt;&lt;EOF;<span class="s"></span>
 <a class="l" name="296" href="#296">296</a><span class="s">	Some text</span>
 <a class="l" name="297" href="#297">297</a><span class="s"></span>EOF
 <a class="l" name="298" href="#298">298</a><span class="s">/\b sentinel \b/</span> &amp;&amp; <b>print</b>; <span class="c"># This should heuristically match as m//</span>
@@ -360,5 +360,19 @@
 <a class="l" name="353" href="#353">353</a><span class="c"># some comment</span>
 <a class="l" name="354" href="#354">354</a><b>push</b> @<a href="/source/s?defs=arr" class="intelliWindow-symbol" data-definition-place="undefined-in-file">arr</a>, <span class="s">&quot;&apos;$<a href="/source/s?defs=key" class="intelliWindow-symbol" data-definition-place="undefined-in-file">key</a>&apos;=&gt;&quot;</span> . <span class="s">&apos;q[&apos;</span> . $<a href="/source/s?defs=val" class="intelliWindow-symbol" data-definition-place="undefined-in-file">val</a> . <span class="s">&apos;],&apos;</span>;
 <a class="l" name="355" href="#355">355</a><span class="c">#qq[$var]</span>
-<a class="l" name="356" href="#356">356</a></body>
+<a class="l" name="356" href="#356">356</a>
+<a class="l" name="357" href="#357">357</a><span class="c"># more HERE-document tests</span>
+<a class="l" name="358" href="#358">358</a><a href="/source/s?defs=myfunc2" class="intelliWindow-symbol" data-definition-place="undefined-in-file">myfunc2</a>(&lt;&lt; &quot;THIS&quot;, $<a href="/source/s?defs=var" class="intelliWindow-symbol" data-definition-place="undefined-in-file">var</a>, &lt;&lt;~&apos;THAT&apos;, $<a href="/source/s?defs=var" class="intelliWindow-symbol" data-definition-place="undefined-in-file">var</a>, &lt;&lt;OTHER, &lt;&lt;\ELSE, &lt;&lt;`Z`);<span class="s"></span>
+<a class="l" name="359" href="#359">359</a><span class="s">Here&apos;s a $<a href="/source/s?defs=line1" class="intelliWindow-symbol" data-definition-place="undefined-in-file">line1</a></span>
+<a class="hl" name="360" href="#360">360</a><span class="s"></span>THIS<span class="s"></span>
+<a class="l" name="361" href="#361">361</a><span class="s">	Here&apos;s a $line2</span>
+<a class="l" name="362" href="#362">362</a><span class="s"></span>	THAT<span class="s"></span>
+<a class="l" name="363" href="#363">363</a><span class="s">Here&apos;s a $<a href="/source/s?defs=line3" class="intelliWindow-symbol" data-definition-place="undefined-in-file">line3</a></span>
+<a class="l" name="364" href="#364">364</a><span class="s"></span>OTHER<span class="s"></span>
+<a class="l" name="365" href="#365">365</a><span class="s">Here&apos;s a $line4</span>
+<a class="l" name="366" href="#366">366</a><span class="s"></span>ELSE<span class="s"></span>
+<a class="l" name="367" href="#367">367</a><span class="s">Here&apos;s a $<a href="/source/s?defs=line5" class="intelliWindow-symbol" data-definition-place="undefined-in-file">line5</a></span>
+<a class="l" name="368" href="#368">368</a><span class="s"></span>Z
+<a class="l" name="369" href="#369">369</a><span class="s">/\b sentinel \b/</span> &amp;&amp; <b>print</b>; <span class="c"># This should heuristically match as m//</span>
+<a class="hl" name="370" href="#370">370</a></body>
 </html>

--- a/test/org/opensolaris/opengrok/analysis/perl/samplexrefres.html
+++ b/test/org/opensolaris/opengrok/analysis/perl/samplexrefres.html
@@ -374,5 +374,10 @@
 <a class="l" name="367" href="#367">367</a><span class="s">Here&apos;s a $<a href="/source/s?defs=line5" class="intelliWindow-symbol" data-definition-place="undefined-in-file">line5</a></span>
 <a class="l" name="368" href="#368">368</a><span class="s"></span>Z
 <a class="l" name="369" href="#369">369</a><span class="s">/\b sentinel \b/</span> &amp;&amp; <b>print</b>; <span class="c"># This should heuristically match as m//</span>
-<a class="hl" name="370" href="#370">370</a></body>
+<a class="hl" name="370" href="#370">370</a>
+<a class="l" name="371" href="#371">371</a><span class="c"># more quote-like tests</span>
+<a class="l" name="372" href="#372">372</a><b>for</b> <b>my</b> $k (<b>grep</b> <span class="s">/=/</span>, <b>split</b> <span class="s">/;/</span>, $d, -<span class="n">1</span>) {
+<a class="l" name="373" href="#373">373</a>	<b>print</b> <span class="s">&quot;1\n&quot;</span>;
+<a class="l" name="374" href="#374">374</a>}
+<a class="l" name="375" href="#375">375</a></body>
 </html>

--- a/testdata/sources/perl/main.pl
+++ b/testdata/sources/perl/main.pl
@@ -353,3 +353,17 @@ print "%\abc\n", %\, "abc\n";
 # some comment
 push @arr, "'$key'=>" . 'q[' . $val . '],';
 #qq[$var]
+
+# more HERE-document tests
+myfunc2(<< "THIS", $var, <<~'THAT', $var, <<OTHER, <<\ELSE, <<`Z`);
+Here's a $line1
+THIS
+	Here's a $line2
+	THAT
+Here's a $line3
+OTHER
+Here's a $line4
+ELSE
+Here's a $line5
+Z
+/\b sentinel \b/ && print; # This should heuristically match as m//

--- a/testdata/sources/perl/main.pl
+++ b/testdata/sources/perl/main.pl
@@ -367,3 +367,8 @@ ELSE
 Here's a $line5
 Z
 /\b sentinel \b/ && print; # This should heuristically match as m//
+
+# more quote-like tests
+for my $k (grep /=/, split /;/, $d, -1) {
+	print "1\n";
+}

--- a/testdata/sources/perl/main.pl
+++ b/testdata/sources/perl/main.pl
@@ -319,7 +319,7 @@ print "1\n";
  format STDOUT =
 @<<<<<<   @||||||   @>>>>>>
 # comment <args to follow>
-"left",  substr($var, 0, 2), "right"
+"left",  substr($var, 0, 2), "\$right"
  ...
  print
 .
@@ -365,6 +365,7 @@ OTHER
 Here's a $line4
 ELSE
 Here's a $line5
+Here's a \$line6
 Z
 /\b sentinel \b/ && print; # This should heuristically match as m//
 

--- a/testdata/sources/perl/main.pl
+++ b/testdata/sources/perl/main.pl
@@ -134,8 +134,8 @@ I said bar.
 bar
 
 myfunc(<< "THIS", 23, <<'THAT');
-Here's a line
-or two.
+Here's a line or
+two
 THIS
 and here's another.
 THAT

--- a/testdata/sources/perl/main.pl
+++ b/testdata/sources/perl/main.pl
@@ -373,3 +373,12 @@ Z
 for my $k (grep /=/, split /;/, $d, -1) {
 	print "1\n";
 }
+
+# more format tests
+%a = (
+    format => "%s");
+ format=
+@<<<<<<   @||||||   @>>>>>>
+"left",  "middle", "right"
+.
+print "1\n";


### PR DESCRIPTION
Hello,

Please consider for integration this patch with an improvements to parsing of stacked HERE-documents as well as some quote-like operator fixes identified after inspecting the OpenGrok cross-referencing of a few large Perl projects (DBI, JSON, and Text-CSV).

Thank you. 

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
