### PR TITLE
Remove a bit of redundancy

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/JFlexXref.java
+++ b/src/org/opensolaris/opengrok/analysis/JFlexXref.java
@@ -479,7 +479,7 @@ public abstract class JFlexXref {
      *
      * @throws IOException on error when writing the xref
      */
-    protected void startNewLine() throws IOException {
+    public void startNewLine() throws IOException {
         String iconId = null;
         int line = getLineNumber() + 1;
         boolean skipNl = false;
@@ -738,6 +738,16 @@ public abstract class JFlexXref {
     public void yypush(int newState, String popString) {
         this.stack.push(yystate());
         this.stackPopString.push(popString);
+        yybegin(newState);
+    }
+
+    /**
+     * save current yy state to stack
+     * @param newState state id
+     */
+    public void yypush(int newState) {
+        this.stack.push(yystate());
+        this.stackPopString.push(null);
         yybegin(newState);
     }
 

--- a/src/org/opensolaris/opengrok/analysis/JFlexXref.java
+++ b/src/org/opensolaris/opengrok/analysis/JFlexXref.java
@@ -746,9 +746,7 @@ public abstract class JFlexXref {
      * @param newState state id
      */
     public void yypush(int newState) {
-        this.stack.push(yystate());
-        this.stackPopString.push(null);
-        yybegin(newState);
+        yypush(newState, null);
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/ada/AdaLexHelper.java
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaLexHelper.java
@@ -28,9 +28,6 @@ import java.io.IOException;
  * Represents an API for object's using {@link AdaLexHelper}
  */
 interface AdaLexListener {
-    void pushState(int state);
-    void popState() throws IOException;
-    void switchState(int state);
     void take(String value) throws IOException;
     void takeNonword(String value) throws IOException;
 
@@ -58,13 +55,12 @@ interface AdaLexListener {
      */
     void takeKeyword(String value) throws IOException;
 
-    void doStartNewLine() throws IOException;
-
     /**
-     * Pushes back to the scanner a specified number of characters
-     * @param numChars
+     * Indicates that the current line is ended.
+     *
+     * @throws IOException thrown on error when handling the EOL
      */
-    void pushback(int numChars);
+    void startNewLine() throws IOException;
 }
 
 /**
@@ -118,7 +114,7 @@ class AdaLexHelper {
             String sub = value.substring(off, i);
             listener.takeNonword(sub);
             if (lineSuffix != null) listener.take(lineSuffix);
-            listener.doStartNewLine();
+            listener.startNewLine();
             if (linePrefix != null) listener.take(linePrefix);
             off = i + w;
         } while (off < value.length());

--- a/src/org/opensolaris/opengrok/analysis/ada/AdaProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaProductions.lexh
@@ -167,7 +167,7 @@ Path = "/"? [a-zA-Z]{FNameChar}* ("/" [a-zA-Z]{FNameChar}*[a-zA-Z0-9])+
     }
 
     {Comment_token}    {
-        pushState(SCOMMENT);
+        yypush(SCOMMENT);
         take(HtmlConsts.SPAN_C);
         takeNonword(yytext());
     }
@@ -186,7 +186,7 @@ Path = "/"? [a-zA-Z]{FNameChar}* ("/" [a-zA-Z]{FNameChar}*[a-zA-Z0-9])+
 <YYINITIAL> {
     {WhiteSpace}{EOL} |
     {EOL}    {
-        doStartNewLine();
+        startNewLine();
     }
 }
 

--- a/src/org/opensolaris/opengrok/analysis/ada/AdaSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaSymbolTokenizer.lex
@@ -50,16 +50,12 @@ import org.opensolaris.opengrok.web.Util;
 
     private String lastSymbol;
 
-    public void pushState(int state) { yypush(state); }
-
-    public void popState() throws IOException { yypop(); }
-
-    public void switchState(int state) { yybegin(state); }
-
+    @Override
     public void take(String value) throws IOException {
         // noop
     }
 
+    @Override
     public void takeNonword(String value) throws IOException {
         // noop
     }
@@ -68,6 +64,7 @@ import org.opensolaris.opengrok.web.Util;
         // noop
     }
 
+    @Override
     public boolean takeSymbol(String value, int captureOffset,
         boolean ignoreKwd)
             throws IOException {
@@ -82,20 +79,19 @@ import org.opensolaris.opengrok.web.Util;
         return false;
     }
 
+    @Override
     public void skipSymbol() {
         lastSymbol = null;
     }
 
+    @Override
     public void takeKeyword(String value) throws IOException {
         lastSymbol = null;
     }
 
-    public void doStartNewLine() throws IOException {
+    @Override
+    public void startNewLine() throws IOException {
         // noop
-    }
-
-    public void pushback(int numChars) {
-        yypushback(numChars);
     }
 
     protected boolean takeAllContent() {

--- a/src/org/opensolaris/opengrok/analysis/ada/AdaXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaXref.lex
@@ -54,16 +54,12 @@ import org.opensolaris.opengrok.web.Util;
 
     private final AdaLexHelper h;
 
-    public void pushState(int state) { yypush(state, null); }
-
-    public void popState() throws IOException { yypop(); }
-
-    public void switchState(int state) { yybegin(state); }
-
+    @Override
     public void take(String value) throws IOException {
         out.write(value);
     }
 
+    @Override
     public void takeNonword(String value) throws IOException {
         out.write(htmlize(value));
     }
@@ -75,6 +71,7 @@ import org.opensolaris.opengrok.web.Util;
         }
     }
 
+    @Override
     public boolean takeSymbol(String value, int captureOffset,
         boolean ignoreKwd)
             throws IOException {
@@ -90,20 +87,14 @@ import org.opensolaris.opengrok.web.Util;
         }
     }
 
+    @Override
     public void skipSymbol() {
         // noop
     }
 
+    @Override
     public void takeKeyword(String value) throws IOException {
         writeKeyword(value, yyline);
-    }
-
-    public void doStartNewLine() throws IOException {
-        startNewLine();
-    }
-
-    public void pushback(int numChars) {
-        yypushback(numChars);
     }
 
     protected boolean takeAllContent() {

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
@@ -215,7 +215,7 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>"|"=>")
  [\"\`] { h.qop(yytext(), 0, false); }
  \'     { h.qop(yytext(), 0, true); }
  \#     {
-        pushState(SCOMMENT);
+        yypush(SCOMMENT);
         take(Consts.SC);
         take("#");
  }
@@ -276,7 +276,7 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>"|"=>")
 
  // POD start
  ^ "=" [a-zA-Z_] [a-zA-Z0-9_]*    {
-        pushState(POD);
+        yypush(POD);
         take(Consts.SC);
         take(yytext());
  }
@@ -284,7 +284,7 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>"|"=>")
  // FORMAT start
  ^ {MaybeWhsp} "format" ({WhiteSpace} {Identifier})? {MaybeWhsp} "=" /
      {MaybeWhsp}{EOL}    {
-    pushState(FMT);
+    yypush(FMT);
     if (takeAllContent()) {
         // split off the "  format" as `initial' for keyword processing
         String capture = yytext();
@@ -403,7 +403,7 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>"|"=>")
         if (h.isQuoteEnding(capture)) {
             yypop();
             if (h.areModifiersOK())
-                pushState(QM);
+                yypush(QM);
             take(Consts.ZS);
         }
     }
@@ -413,7 +413,7 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>"|"=>")
     {WhiteSpace}{EOL} |
     {EOL} {
         take(Consts.ZS);
-        doStartNewLine();
+        startNewLine();
         take(Consts.SS);
     }
 }
@@ -444,7 +444,7 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>"|"=>")
 
   {WhiteSpace}{EOL} |
   {EOL}    {
-    doStartNewLine();
+    startNewLine();
   }
 }
 
@@ -486,7 +486,7 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>"|"=>")
         if (h.maybeStartHere()) {
             yypushback(capture.length());
         } else {
-            doStartNewLine();
+            startNewLine();
         }
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlSymbolTokenizer.lex
@@ -51,16 +51,12 @@ super(in);
 
     private String lastSymbol;
 
-    public void pushState(int state) { yypush(state); }
-
-    public void popState() throws IOException { yypop(); }
-
-    public void switchState(int state) { yybegin(state); }
-
+    @Override
     public void take(String value) throws IOException {
         // noop
     }
 
+    @Override
     public void takeNonword(String value) throws IOException {
         // noop
     }
@@ -69,6 +65,7 @@ super(in);
         // noop
     }
 
+    @Override
     public boolean takeSymbol(String value, int captureOffset,
         boolean ignoreKwd)
             throws IOException {
@@ -83,26 +80,26 @@ super(in);
         return false;
     }
 
+    @Override
     public void skipSymbol() {
         lastSymbol = null;
     }
 
+    @Override
     public void takeKeyword(String value) throws IOException {
         lastSymbol = null;
     }
 
-    public void doStartNewLine() throws IOException {
+    @Override
+    public void startNewLine() throws IOException {
         // noop
     }
 
+    @Override
     public void abortQuote() throws IOException {
         yypop();
         if (h.areModifiersOK()) yypush(QM);
         take(Consts.ZS);
-    }
-
-    public void pushback(int numChars) {
-        yypushback(numChars);
     }
 
     // If the state is YYINITIAL, then transitions to INTRA; otherwise does

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlXref.lex
@@ -53,16 +53,12 @@ import org.opensolaris.opengrok.web.Util;
 
     private final PerlLexHelper h;
 
-    public void pushState(int state) { yypush(state, null); }
-
-    public void popState() throws IOException { yypop(); }
-
-    public void switchState(int state) { yybegin(state); }
-
+    @Override
     public void take(String value) throws IOException {
         out.write(value);
     }
 
+    @Override
     public void takeNonword(String value) throws IOException {
         out.write(htmlize(value));
     }
@@ -74,6 +70,7 @@ import org.opensolaris.opengrok.web.Util;
         }
     }
 
+    @Override
     public boolean takeSymbol(String value, int captureOffset,
         boolean ignoreKwd)
             throws IOException {
@@ -89,26 +86,21 @@ import org.opensolaris.opengrok.web.Util;
         }
     }
 
+    @Override
     public void skipSymbol() {
         // noop
     }
 
+    @Override
     public void takeKeyword(String value) throws IOException {
         writeKeyword(value, yyline);
     }
 
-    public void doStartNewLine() throws IOException {
-        startNewLine();
-    }
-
+    @Override
     public void abortQuote() throws IOException {
         yypop();
         if (h.areModifiersOK()) yypush(QM, null);
         take(Consts.ZS);
-    }
-
-    public void pushback(int numChars) {
-        yypushback(numChars);
     }
 
     // If the state is YYINITIAL, then transitions to INTRA; otherwise does


### PR DESCRIPTION
Hello,

Please consider for integration this patch with a minor cleanup of some redundancy in shared lex logic between Xrefs and SymbolTokenizers by:

* Adding JFlexXref yypush(string) overload to align with JFlexTokenizer's.
* Publicizing JFlexXref startNewLine() so a separate, public method mediator is not needed.

Also:
* Remove unneeded pushback() and switchState() mediators which I mistakenly thought were needed.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
