### PR TITLE
Add missing %ignorecase to AdaSymbolTokenizer

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/ada/AdaSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaSymbolTokenizer.lex
@@ -39,6 +39,7 @@ import org.opensolaris.opengrok.web.Util;
 %extends JFlexTokenizer
 %implements AdaLexListener
 %unicode
+%ignorecase
 %type boolean
 %char
 %init{


### PR DESCRIPTION
Hello,

Please consider for integration this small fix to add the %ignorecase setting to AdaSymbolTokenizer. No productions were affected, but the settings for this language's lexers are meant to be the same.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
