### PR TITLE
Feature/common lexh

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -188,18 +188,26 @@ Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
             <attribute name="name"/>
             <attribute name="dir"/>
             <sequential> <!-- Name of input has to be .lex -->
+                <mkdir dir="${src.generatedsrc.dir}/@{dir}"/>
+                <!-- Copy source *.lex,*.lexh and global *.lexh to interm. dir -->
+                <copy todir="${src.generatedsrc.dir}/@{dir}">
+                    <fileset dir="${src.dir}/@{dir}" includes="*.lex,*.lexh"/>
+                    <fileset dir="${src.dir}/org/opensolaris/opengrok/analysis"
+                        includes="*.lexh"/>
+                </copy>
                 <!-- newer *.lexh files cause .lex file to be touched -->
                 <local name="lexh"/>
-                <fileset dir="${src.dir}/@{dir}" includes="*.lexh" id="id.lexh">
-                    <depend targetdir="${src.dir}/@{dir}">
+                <fileset dir="${src.generatedsrc.dir}/@{dir}" includes="*.lexh" id="id.lexh">
+                    <depend targetdir="${src.generatedsrc.dir}/@{dir}">
                         <mapper type="merge" to="@{name}.lex"/>
                     </depend>
                 </fileset>
                 <pathconvert pathsep="," property="lexh" refid="id.lexh"/>
-                <touch file="${src.dir}/@{dir}/@{name}.lex"
+                <touch file="${src.generatedsrc.dir}/@{dir}/@{name}.lex"
                     unless:blank="${lexh}"/>
                 <!-- now run the jflex task -->
-                <jflex file="${src.dir}/@{dir}/@{name}.lex" destdir="${src.generatedsrc.dir}" nobak="on" inputstreamctor="false"/>
+                <jflex file="${src.generatedsrc.dir}/@{dir}/@{name}.lex"
+                    destdir="${src.generatedsrc.dir}" nobak="on" inputstreamctor="false"/>
             </sequential>
         </macrodef>
         
@@ -211,18 +219,26 @@ Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
             <attribute name="name"/>    
             <attribute name="dir"/>
             <sequential>
+                <mkdir dir="${src.generatedsrc.dir}/@{dir}"/>
+                <!-- Copy source *.lex,*.lexh and global *.lexh to interm. dir -->
+                <copy todir="${src.generatedsrc.dir}/@{dir}">
+                    <fileset dir="${src.dir}/@{dir}" includes="*.lex,*.lexh"/>
+                    <fileset dir="${src.dir}/org/opensolaris/opengrok/analysis"
+                        includes="*.lexh"/>
+                </copy>
                 <!-- newer *.lexh files cause .lex file to be touched -->
                 <local name="lexh"/>
-                <fileset dir="${src.dir}/@{dir}" includes="*.lexh" id="id.lexh">
-                    <depend targetdir="${src.dir}/@{dir}">
+                <fileset dir="${src.generatedsrc.dir}/@{dir}" includes="*.lexh" id="id.lexh">
+                    <depend targetdir="${src.generatedsrc.dir}/@{dir}">
                         <mapper type="merge" to="@{name}.lex"/>
                     </depend>
                 </fileset>
                 <pathconvert pathsep="," property="lexh" refid="id.lexh"/>
-                <touch file="${src.dir}/@{dir}/@{name}.lex"
+                <touch file="${src.generatedsrc.dir}/@{dir}/@{name}.lex"
                     unless:blank="${lexh}"/>
                 <!-- now run the jflex task -->
-                <jflex file="${src.dir}/@{dir}/@{name}.lex" destdir="${src.generatedsrc.dir}" nobak="on" inputstreamctor="false"/>
+                <jflex file="${src.generatedsrc.dir}/@{dir}/@{name}.lex"
+                    destdir="${src.generatedsrc.dir}" nobak="on" inputstreamctor="false"/>
                 <!-- LUCENE-5897: Disallow scanner buffer expansion -->
                 <replaceregexp file="${src.generatedsrc.dir}/@{dir}/@{name}.java"
                                match="[ \t]*/\* is the buffer big enough\? \*/\s+if \(zzCurrentPos >= zzBuffer\.length.*?\}[ \t]*\r?\n"

--- a/opengrok-indexer/build.xml
+++ b/opengrok-indexer/build.xml
@@ -90,6 +90,13 @@ Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
         <loadfile srcFile="${git.archival.temp}" property="changeset"/>
     </target>
 
+    <target name="-collect-lex-lexh">
+        <mkdir dir="${tgt.dir}"/>
+        <copy todir="${tgt.dir}" flatten="true">
+            <fileset dir="${src.dir}" includes="**/*.lex,**/*.lexh"/>
+        </copy>
+    </target>
+
     <target name="-update-build-info"
             depends="-get-changeset-from-command,-get-changeset-from-file">
         <mkdir dir="${build.classes.dir}/org/opensolaris/opengrok"/>

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -162,7 +162,7 @@ Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
                         </goals>
                         <configuration>
                             <lexDefinitions>
-                                <lexDefinition>../src</lexDefinition>
+                                <lexDefinition>${basedir}/target/jflex-sources</lexDefinition>
                             </lexDefinitions>
                             <inputStreamCtor>false</inputStreamCtor>
                         </configuration>
@@ -232,6 +232,21 @@ Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
                 <version>1.8</version>
                 <executions>
                     <execution>
+                        <id>collect-lex-lexh</id>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <target>
+                                <property name="src.dir" value="../src"/>
+                                <property name="tgt.dir" value="${basedir}/target/jflex-sources"/>
+                                <ant target="-collect-lex-lexh"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>update-build-info</id>
                         <phase>generate-resources</phase>
                         <configuration>
                             <target>

--- a/src/org/opensolaris/opengrok/analysis/Common.lexh
+++ b/src/org/opensolaris/opengrok/analysis/Common.lexh
@@ -20,3 +20,172 @@
 /*
  * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
+
+WhspChar    = [ \t\f]
+WhiteSpace  = {WhspChar}+
+EOL         = ([\n\r] | \r\n)
+
+/*
+ * See org.opensolaris.opengrok.util.StringUtils FNAME_CHARS_PAT where the
+ * following regex is mirrored.
+ */
+FNameChar = [a-zA-Z0-9_\-\.]
+
+Path = "/"? [a-zA-Z]{FNameChar}* ("/" [a-zA-Z]{FNameChar}*[a-zA-Z0-9])+
+
+/*
+ * From RFC-3986. See
+ * org.opensolaris.opengrok.util.StringUtils URI_CHARS_PAT where a regex
+ * in accordance with the following definition is maintained.
+ *
+ * URI         = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
+ */
+BrowseableURI  = {BrowseableURI_scheme} {URI_tail}
+URI_tail       = ":" {URI_hier_part} ("?" {URI_query})? ("#" {URI_fragment})?
+
+/*
+ * hier-part   = "//" authority path-abempty
+ *                / path-absolute
+ *                / path-rootless
+ *                / path-empty ; N.b. not used in OpenGrok
+ */
+URI_hier_part  = ("//" {URI_authority} {URI_path_abempty} |
+    "/" ({URI_path_absolute} | {URI_path_rootless}))
+
+/*
+ * scheme        = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+ */
+BrowseableURI_scheme = ([Hh][Tt][Tt][Pp][Ss]? | [Ff][Tt][Pp])
+
+/*
+ * authority     = [ userinfo "@" ] host [ ":" port ]
+ * userinfo      = *( unreserved / pct-encoded / sub-delims / ":" )
+ * host          = IP-literal / IPv4address / reg-name
+ * port          = *DIGIT
+ */
+URI_authority    = ({URI_userinfo} "@")? {URI_host} (":" {URI_port})?
+URI_userinfo     = ({URI_unreserved} | {URI_pct_encoded} | {URI_sub_delims} |
+    ":")*
+URI_host         = ({URI_IP_literal} | {URI_IPv4address} | {URI_reg_name})
+URI_port         = {DIGIT}*
+
+/*
+ * IP-literal    = "[" ( IPv6address / IPvFuture  ) "]"
+ */
+URI_IP_literal   = "[" ({URI_IPv6address} | {URI_IPvFuture}) "]"
+
+/*
+ * IPvFuture     = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
+ */
+URI_IPvFuture    = "v" {HEXDIG}+ "." ({URI_unreserved} | {URI_sub_delims} |
+    ":")+
+
+/*
+ * IPv6address   =                            6( h16 ":" ) ls32
+ *               /                       "::" 5( h16 ":" ) ls32
+ *               / [               h16 ] "::" 4( h16 ":" ) ls32
+ *               / [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
+ *               / [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
+ *               / [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
+ *               / [ *4( h16 ":" ) h16 ] "::"              ls32
+ *               / [ *5( h16 ":" ) h16 ] "::"              h16
+ *               / [ *6( h16 ":" ) h16 ] "::"
+ */
+URI_IPv6address = (
+    ( {URI_h16} ":" ){6} {URI_ls32} |
+                                      "::" ({URI_h16} ":"){5} {URI_ls32} |
+                         ({URI_h16})? "::" ({URI_h16} ":"){4} {URI_ls32} |
+    (({URI_h16} ":"){0,1} {URI_h16})? "::" ({URI_h16} ":"){3} {URI_ls32} |
+    (({URI_h16} ":"){0,2} {URI_h16})? "::" ({URI_h16} ":"){2} {URI_ls32} |
+    (({URI_h16} ":"){0,3} {URI_h16})? "::"  {URI_h16} ":"     {URI_ls32} |
+    (({URI_h16} ":"){0,4} {URI_h16})? "::"                    {URI_ls32} |
+    (({URI_h16} ":"){0,5} {URI_h16})? "::"  {URI_h16} |
+    (({URI_h16} ":"){0,6} {URI_h16})? "::"
+    )
+/*
+ * h16           = 1*4HEXDIG
+ * ls32          = ( h16 ":" h16 ) / IPv4address
+ * IPv4address   = dec-octet "." dec-octet "." dec-octet "." dec-octet
+ */
+URI_h16          = {HEXDIG}{1,4}
+URI_ls32         = ({URI_h16} ":" {URI_h16} | {URI_IPv4address})
+URI_IPv4address  = ({URI_dec_octet} "." {URI_dec_octet} "." {URI_dec_octet}
+    "." {URI_dec_octet})
+
+/*
+ * dec-octet     = DIGIT                 ; 0-9
+ *               / %x31-39 DIGIT         ; 10-99
+ *               / "1" 2DIGIT            ; 100-199
+ *               / "2" %x30-34 DIGIT     ; 200-249
+ *               / "25" %x30-35          ; 250-255
+ */
+URI_dec_octet    = ({DIGIT}  |     // 0-9
+    [\u{31}-\u{39}] {DIGIT}  |     // 10-99
+    "1" {DIGIT}{DIGIT}  |          // 100-199
+    "2" [\u{30}-\u{34}] {DIGIT}  | // 200-249
+    "25" [\u{30}-\u{35}])          // 250-255
+
+/*
+ * reg-name      = *( unreserved / pct-encoded / sub-delims )
+ */
+URI_reg_name     = ({URI_unreserved} | {URI_pct_encoded} | {URI_sub_delims})*
+
+/*
+ * path          = path-abempty    ; begins with "/" or is empty
+ *               / path-absolute   ; begins with "/" but not "//"
+ *               / path-noscheme   ; begins with a non-colon segment
+ *               / path-rootless   ; begins with a segment
+ *               / path-empty      ; zero characters
+ *
+ * path-abempty  = *( "/" segment )
+ * path-absolute = "/" [ segment-nz *( "/" segment ) ]
+ * path-noscheme = segment-nz-nc *( "/" segment )  ; N.b. not used in OpenGrok
+ * path-rootless = segment-nz *( "/" segment )
+ * path-empty    = 0<pchar>  ; N.b. not used in OpenGrok
+ */
+URI_path_abempty  = ("/" {URI_segment})*
+URI_path_absolute = "/" ({URI_segment_nz} ("/" {URI_segment})*)?
+URI_path_rootless = {URI_segment_nz} ("/" {URI_segment})*
+
+/*
+ * segment       = *pchar
+ * segment-nz    = 1*pchar
+ * segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
+ *               ; non-zero-length segment without any colon ":"
+ *               ; N.b. not used in OpenGrok
+ * pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+ */
+URI_segment      = {URI_pchar}*
+URI_segment_nz   = {URI_pchar}+
+URI_pchar        = ({URI_unreserved} | {URI_pct_encoded} | {URI_sub_delims} |
+    [:@])
+
+/*
+ * query         = *( pchar / "/" / "?" )
+ */
+URI_query        = ({URI_pchar} | [/\?])*
+
+/*
+ * fragment      = *( pchar / "/" / "?" )
+ */
+URI_fragment     = ({URI_pchar} | [/\?])*
+
+/*
+ * pct-encoded   = "%" HEXDIG HEXDIG
+ */
+URI_pct_encoded  = "%" {HEXDIG} {HEXDIG}
+
+/*
+ * unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+ * reserved      = gen-delims / sub-delims  ; N.b. not used in OpenGrok
+ * gen-delims    = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+ *               ; N.b. not used in OpenGrok
+ * sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
+ *               / "*" / "+" / "," / ";" / "="
+ */
+URI_unreserved   = ({ASCII_ALPHA} | {DIGIT} | [\-\._~])
+URI_sub_delims   = [\!\$&\'\(\)\*\+,;=]
+
+ASCII_ALPHA  = [A-Za-z]
+HEXDIG = [0-9A-Fa-f]
+DIGIT  = [0-9]

--- a/src/org/opensolaris/opengrok/analysis/Common.lexh
+++ b/src/org/opensolaris/opengrok/analysis/Common.lexh
@@ -1,0 +1,22 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ */

--- a/src/org/opensolaris/opengrok/analysis/CommonTokenizer.lexh
+++ b/src/org/opensolaris/opengrok/analysis/CommonTokenizer.lexh
@@ -1,0 +1,22 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ */

--- a/src/org/opensolaris/opengrok/analysis/CommonXref.lexh
+++ b/src/org/opensolaris/opengrok/analysis/CommonXref.lexh
@@ -1,0 +1,22 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ */

--- a/src/org/opensolaris/opengrok/analysis/ada/AdaProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaProductions.lexh
@@ -26,10 +26,6 @@
  * Regex productions shared between AdaXref and AdaSymbolTokenizer
  */
 
-WhspChar      = [ \t\f]
-WhiteSpace    = {WhspChar}+
-EOL = \r|\n|\r\n
-
 /*
  * Identifiers syntax
  * 2.3-1: Identifiers are used as names.
@@ -136,12 +132,8 @@ String_literal = [\"] ([\"][\"] | [^\"])* [\"]
  */
 Comment_token = "--"
 
-URIChar = [\?\#\+\%\&\:\/\.\@\_\;\=\$\,\-\!\~\*\\]
-
-FNameChar = [a-zA-Z0-9_\-\.]
 FileExt = ([Aa][Dd][AaBbSs] | [Dd][Ii][Ff][Ff] | [Pp][Aa][Tt][Cc][Hh])
 File = [a-zA-Z]{FNameChar}* "." {FileExt}
-Path = "/"? [a-zA-Z]{FNameChar}* ("/" [a-zA-Z]{FNameChar}*[a-zA-Z0-9])+
 
 %state SCOMMENT
 
@@ -229,7 +221,7 @@ Path = "/"? [a-zA-Z]{FNameChar}* ("/" [a-zA-Z]{FNameChar}*[a-zA-Z0-9])+
         }
     }
 
-    ("http" | "https" | "ftp" ) "://" ({FNameChar}|{URIChar})+[a-zA-Z0-9/]    {
+    {BrowseableURI}    {
         if (takeAllContent()) {
             appendLink(yytext());
         }

--- a/src/org/opensolaris/opengrok/analysis/ada/AdaSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaSymbolTokenizer.lex
@@ -46,6 +46,7 @@ import org.opensolaris.opengrok.web.Util;
     super(in);
     h = new AdaLexHelper(this);
 %init}
+%include CommonTokenizer.lexh
 %{
     private final AdaLexHelper h;
 
@@ -120,4 +121,5 @@ this.finalOffset =  zzEndRead;
 return false;
 %eofval}
 
+%include Common.lexh
 %include AdaProductions.lexh

--- a/src/org/opensolaris/opengrok/analysis/ada/AdaXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaXref.lex
@@ -45,6 +45,7 @@ import org.opensolaris.opengrok.web.Util;
 %init{
     h = new AdaLexHelper(this);
 %init}
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override
@@ -112,4 +113,5 @@ import org.opensolaris.opengrok.web.Util;
     protected String getUrlPrefix() { return urlPrefix; }
 %}
 
+%include Common.lexh
 %include AdaProductions.lexh

--- a/src/org/opensolaris/opengrok/util/StringUtils.java
+++ b/src/org/opensolaris/opengrok/util/StringUtils.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.util;
@@ -31,6 +32,35 @@ import java.util.regex.Pattern;
  * @author austvik
  */
 public final class StringUtils {
+
+    /**
+     * Edit and paste (in NetBeans) for easy escaping:
+     * {@code [a-zA-Z0-9_\-\.] }.
+     */
+    private static final String FNAME_CHARS_PAT =
+        "[a-zA-Z0-9_\\-\\.]";
+
+    private static final Pattern FNAME_CHARS_ANYMATCH =
+        Pattern.compile(FNAME_CHARS_PAT);
+
+    private static final Pattern FNAME_CHARS_STARTSMATCH =
+        Pattern.compile("^" + FNAME_CHARS_PAT);
+
+    /**
+     * Edit and paste (in NetBeans) for easy escaping:
+     * {@code [a-zA-Z0-9\-\._~%:/\?\#\[\]@!\$&\'\(\)\*\+,;=] }
+     * <p>
+     * Backslash, '\', was in {URIChar} in many .lex files, but that is not
+     * a valid URI character per RFC-3986.
+     */
+    private static final String URI_CHARS_PAT =
+        "[a-zA-Z0-9\\-\\._~%:/\\?\\#\\[\\]@!\\$&\\'\\(\\)\\*\\+,;=]";
+
+    private static final Pattern URI_CHARS_ANYMATCH =
+        Pattern.compile(URI_CHARS_PAT);
+
+    private static final Pattern URI_CHARS_STARTSMATCH =
+        Pattern.compile("^" + URI_CHARS_PAT);
 
     private StringUtils() {
         // Only static utility methods
@@ -130,5 +160,45 @@ public final class StringUtils {
             n--;
         }
         return pos;
+    }
+
+    /**
+     * Determines if the {@code value} contains characters matching
+     * Common.lexh's {FNameChar}.
+     * @param value the input to test
+     * @return true if {@code value} matches anywhere
+     */
+    public static boolean containsFnameChars(String value) {
+        return FNAME_CHARS_ANYMATCH.matcher(value).matches();
+    }
+
+    /**
+     * Determines if the {@code value} starts with characters matching
+     * Common.lexh's {FNameChar}.
+     * @param value the input to test
+     * @return true if {@code value} matches at its start
+     */
+    public static boolean startsWithFnameChars(String value) {
+        return FNAME_CHARS_STARTSMATCH.matcher(value).matches();
+    }
+
+    /**
+     * Determines if the {@code value} contains characters matching
+     * RFC-3986 and Common.lexh's definitions for allowable URI characters.
+     * @param value the input to test
+     * @return true if {@code value} matches anywhere
+     */
+    public static boolean containsURIChars(String value) {
+        return URI_CHARS_ANYMATCH.matcher(value).matches();
+    }
+
+    /**
+     * Determines if the {@code value} starts with characters matching
+     * RFC-3986 and Common.lexh's definitions for allowable URI characters.
+     * @param value the input to test
+     * @return true if {@code value} matches at its start
+     */
+    public static boolean startsWithURIChars(String value) {
+        return URI_CHARS_STARTSMATCH.matcher(value).matches();
     }
 }

--- a/test/org/opensolaris/opengrok/analysis/ada/ada_xrefres.html
+++ b/test/org/opensolaris/opengrok/analysis/ada/ada_xrefres.html
@@ -47,5 +47,9 @@
 <a class="hl" name="40" href="#40">40</a>	<b>Put_Line</b>();
 <a class="l" name="41" href="#41">41</a>	<b>Put_Line</b>(<span class="s">&quot;Archimedes said &quot;&quot;Εύρηκα&quot;&quot;&quot;</span>);
 <a class="l" name="42" href="#42">42</a><b>end</b> <a href="/source/s?defs=Hello" class="intelliWindow-symbol" data-definition-place="undefined-in-file">Hello</a>;
-<a class="l" name="43" href="#43">43</a></body>
+<a class="l" name="43" href="#43">43</a>
+<a class="l" name="44" href="#44">44</a><span class="c">-- Test a URL that is not matched fully by a rule using just {URIChar} and</span>
+<a class="l" name="45" href="#45">45</a><span class="c">-- {FnameChar}:</span>
+<a class="l" name="46" href="#46">46</a><span class="c">-- <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms633591(v=vs.85).aspx">https://msdn.microsoft.com/en-us/library/windows/desktop/ms633591(v=vs.85).aspx</a></span>
+<a class="l" name="47" href="#47">47</a></body>
 </html>

--- a/test/org/opensolaris/opengrok/analysis/ada/sample.adb
+++ b/test/org/opensolaris/opengrok/analysis/ada/sample.adb
@@ -40,3 +40,7 @@ begin
 	Put_Line();
 	Put_Line("Archimedes said ""Εύρηκα""");
 end Hello;
+
+-- Test a URL that is not matched fully by a rule using just {URIChar} and
+-- {FnameChar}:
+-- https://msdn.microsoft.com/en-us/library/windows/desktop/ms633591(v=vs.85).aspx


### PR DESCRIPTION
Hello,

Please consider for integration this patch to define some "Common" lexh files and to update the build to copy lex and lexh files (language-specific and Common) to intermediate, language-specific areas for running jflex.

In this patch, I also demonstrate via the Ada test an insufficiency with the current URI matching rules that use {URIChar} (all languages); then define in Common.lexh a new {BrowseableURI} regex per RFC-3986; and then update the Ada analyzers to use the Common*.lexh files and the superior {BrowseableURI} regex.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
