### PR TITLE
Add getYYEOF() to CommonXref.lexh to avoid reflection.

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/CommonXref.lexh
+++ b/src/org/opensolaris/opengrok/analysis/CommonXref.lexh
@@ -20,3 +20,11 @@
 /*
  * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
+
+%{
+    /**
+     * Gets the YYEOF value.
+     * @return YYEOF
+     */
+    public int getYYEOF() { return YYEOF; }
+%}

--- a/src/org/opensolaris/opengrok/analysis/JFlexXref.java
+++ b/src/org/opensolaris/opengrok/analysis/JFlexXref.java
@@ -65,10 +65,6 @@ public abstract class JFlexXref {
     private int scopeLevel = 0;
 
     /**
-     * EOF value returned by yylex().
-     */
-    private final int yyeof;
-    /**
      * See {@link RuntimeEnvironment#getUserPage()}. Per default initialized in
      * the constructor and here to be consistent and avoid lot of unnecessary
      * lookups.
@@ -140,30 +136,13 @@ public abstract class JFlexXref {
         new Style("subroutine", "xsr", "Subroutine"),};
 
     protected JFlexXref() {
-        try {
-            // TODO when bug #16053 is fixed, we should add a getter to a file
-            // that's included from all the Xref classes so that we avoid the
-            // reflection.
-            Field f = getClass().getField("YYEOF");
-            yyeof = f.getInt(null);
-            userPageLink = RuntimeEnvironment.getInstance().getUserPage();
-            if (userPageLink != null && userPageLink.length() == 0) {
-                userPageLink = null;
-            }
-            userPageSuffix = RuntimeEnvironment.getInstance().getUserPageSuffix();
-            if (userPageSuffix != null && userPageSuffix.length() == 0) {
-                userPageSuffix = null;
-            }
-        } catch (NoSuchFieldException | SecurityException 
-                | IllegalArgumentException | IllegalAccessException e) {
-            // The auto-generated constructors for the Xref classes don't
-            // expect a checked exception, so wrap it in an AssertionError.
-            // This should never happen, since all the Xref classes will get
-            // a public static YYEOF field from JFlex.
-                        
-            // NOPMD (stack trace is preserved by initCause(), but
-            // PMD thinks it's lost)            
-            throw new AssertionError("Couldn't initialize yyeof", e); 
+        userPageLink = RuntimeEnvironment.getInstance().getUserPage();
+        if (userPageLink != null && userPageLink.length() == 0) {
+            userPageLink = null;
+        }
+        userPageSuffix = RuntimeEnvironment.getInstance().getUserPageSuffix();
+        if (userPageSuffix != null && userPageSuffix.length() == 0) {
+            userPageSuffix = null;
         }
     }
 
@@ -325,6 +304,12 @@ public abstract class JFlexXref {
     public abstract int yystate();
 
     /**
+     * Gets the YYEOF value.
+     * @return YYEOF
+     */
+    public abstract int getYYEOF();
+
+    /**
      * Write xref to the specified {@code Writer}.
      *
      * @param out xref destination
@@ -335,7 +320,7 @@ public abstract class JFlexXref {
         writeSymbolTable();
         setLineNumber(0);
         startNewLine();
-        while (yylex() != yyeof) { // NOPMD while statement intentionally empty
+        while (yylex() != getYYEOF()) { // NOPMD while statement intentionally empty
             // nothing to do here, yylex() will do the work
         }
 

--- a/src/org/opensolaris/opengrok/analysis/c/CXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/c/CXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -41,6 +42,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override

--- a/src/org/opensolaris/opengrok/analysis/c/CxxXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/c/CxxXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -41,6 +42,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override

--- a/src/org/opensolaris/opengrok/analysis/clojure/ClojureXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/clojure/ClojureXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -38,6 +39,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   private int nestedComment;
 

--- a/src/org/opensolaris/opengrok/analysis/csharp/CSharpXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/csharp/CSharpXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -40,6 +41,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   /* Must match WhiteSpace regex */
   private final static String WHITE_SPACE = "[ \t\f\r]+";

--- a/src/org/opensolaris/opengrok/analysis/document/MandocXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/document/MandocXref.lex
@@ -38,6 +38,7 @@ import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 %extends JFlexXref
 %unicode
 %int
+%include CommonXref.lexh
 %{
     protected boolean didStartTee;
     protected boolean didStartMandoc;

--- a/src/org/opensolaris/opengrok/analysis/document/TroffXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/document/TroffXref.lex
@@ -36,6 +36,7 @@ import org.opensolaris.opengrok.web.Util;
 %extends JFlexXref
 %unicode
 %int
+%include CommonXref.lexh
 %{ 
   int p;
   int span;

--- a/src/org/opensolaris/opengrok/analysis/erlang/ErlangXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/erlang/ErlangXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -39,6 +40,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override

--- a/src/org/opensolaris/opengrok/analysis/fortran/FortranXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/fortran/FortranXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -38,6 +39,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override

--- a/src/org/opensolaris/opengrok/analysis/golang/GolangXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/golang/GolangXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -40,6 +41,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override

--- a/src/org/opensolaris/opengrok/analysis/haskell/HaskellXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/haskell/HaskellXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -40,6 +41,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override

--- a/src/org/opensolaris/opengrok/analysis/java/JavaXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/java/JavaXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -39,6 +40,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   /* Must match WhiteSpace regex */
   private final static String WHITE_SPACE = "[ \t\f\r]+";

--- a/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -39,6 +40,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   /* Must match WhiteSpace regex */
   private final static String WHITE_SPACE = "[ \t\f\r]+";

--- a/src/org/opensolaris/opengrok/analysis/json/JsonXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/json/JsonXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -39,6 +40,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   /* Must match WhiteSpace regex */
   private final static String WHITE_SPACE = "[ \t\f\r]+";

--- a/src/org/opensolaris/opengrok/analysis/kotlin/KotlinXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/kotlin/KotlinXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.kotlin;
@@ -36,6 +37,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   /* Must match WhiteSpace regex */
   private final static String WHITE_SPACE = "[ \n\t\f]+";

--- a/src/org/opensolaris/opengrok/analysis/lisp/LispXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/lisp/LispXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -38,6 +39,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   private int nestedComment;
 

--- a/src/org/opensolaris/opengrok/analysis/lua/LuaXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/lua/LuaXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -40,6 +41,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -39,6 +40,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   /* Must match WhiteSpace regex */
   private final static String WHITE_SPACE = "[ \t\f\r]+";

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlXref.lex
@@ -46,6 +46,7 @@ import org.opensolaris.opengrok.web.Util;
     h = new PerlLexHelper(QUO, QUOxN, QUOxL, QUOxLxN, this,
         HERE, HERExN, HEREin, HEREinxN);
 %init}
+%include CommonXref.lexh
 %{
     private final PerlLexHelper h;
 

--- a/src/org/opensolaris/opengrok/analysis/php/PhpXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/php/PhpXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -40,6 +41,7 @@ import java.util.*;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   private final static Set<String> PSEUDO_TYPES;
   private Stack<String> docLabels = new Stack<String>();

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.plain;
@@ -34,6 +35,7 @@ import java.io.Reader;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override

--- a/src/org/opensolaris/opengrok/analysis/plain/XMLXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/plain/XMLXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.plain;
@@ -36,6 +37,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override

--- a/src/org/opensolaris/opengrok/analysis/powershell/PowershellXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/powershell/PowershellXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.powershell;
@@ -36,6 +37,7 @@ import java.util.regex.Matcher;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   private final Stack<Integer> stateStack = new Stack<Integer>();
   private final Stack<String> styleStack = new Stack<String>();

--- a/src/org/opensolaris/opengrok/analysis/python/PythonXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/python/PythonXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -39,6 +40,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override

--- a/src/org/opensolaris/opengrok/analysis/ruby/RubyXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/ruby/RubyXref.lex
@@ -46,6 +46,7 @@ import org.opensolaris.opengrok.web.Util;
 %init{
     h = getNewHelper();
 %init}
+%include CommonXref.lexh
 %{
     protected Stack<RubyLexHelper> helpers;
 

--- a/src/org/opensolaris/opengrok/analysis/rust/RustXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/rust/RustXref.lex
@@ -20,6 +20,7 @@
 /*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2016 Nikolay Denev.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -40,6 +41,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override

--- a/src/org/opensolaris/opengrok/analysis/scala/ScalaXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/scala/ScalaXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -39,6 +40,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   /* Must match WhiteSpace regex */
   private final static String WHITE_SPACE = "[ \t\f\r]+";

--- a/src/org/opensolaris/opengrok/analysis/sh/ShXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/sh/ShXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.sh;
@@ -34,6 +35,7 @@ import java.util.Stack;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   private final Stack<Integer> stateStack = new Stack<Integer>();
   private final Stack<String> styleStack = new Stack<String>();

--- a/src/org/opensolaris/opengrok/analysis/sql/PLSQLXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/sql/PLSQLXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.sql;
@@ -35,6 +36,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
     private int commentLevel;
 

--- a/src/org/opensolaris/opengrok/analysis/sql/SQLXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/sql/SQLXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.sql;
@@ -35,6 +36,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
     private int commentLevel;
 

--- a/src/org/opensolaris/opengrok/analysis/swift/SwiftXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/swift/SwiftXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.swift;
@@ -36,6 +37,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   /* Must match WhiteSpace regex */
   private final static String WHITE_SPACE = "[ \n\t\f]+";

--- a/src/org/opensolaris/opengrok/analysis/tcl/TclXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/tcl/TclXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -39,6 +40,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   // TODO move this into an include file when bug #16053 is fixed
   @Override

--- a/src/org/opensolaris/opengrok/analysis/uue/UuencodeXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/uue/UuencodeXref.lex
@@ -20,6 +20,7 @@
 /*
  * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2013 Constantine A. Murenin <C++@Cns.SU>
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.uue;
@@ -35,6 +36,7 @@ import org.opensolaris.opengrok.web.Util;
 %extends JFlexXref
 %unicode
 %int
+%include CommonXref.lexh
 %{ 
 
   // TODO move this into an include file when bug #16053 is fixed

--- a/src/org/opensolaris/opengrok/analysis/vb/VBXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/vb/VBXref.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -39,6 +40,7 @@ import org.opensolaris.opengrok.web.Util;
 %unicode
 %ignorecase
 %int
+%include CommonXref.lexh
 %{
   /* Must match WhiteSpace regex */
   private final static String WHITE_SPACE = "[ \t\f\r]+";


### PR DESCRIPTION
Hello,

Please consider for integration this patch to include CommonXref.lexh in the language Xref lex files, with a definition of getYYEOF() and the removal of the reflection in the constructor of JFlexXref.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
