### PR TITLE
Include CommonTokenizer.lexh, and revise tokenizers as %int lexers

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/CommonTokenizer.lexh
+++ b/src/org/opensolaris/opengrok/analysis/CommonTokenizer.lexh
@@ -20,3 +20,11 @@
 /*
  * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
+
+%{
+    /**
+     * Gets the YYEOF value.
+     * @return YYEOF
+     */
+    public int getYYEOF() { return YYEOF; }
+%}

--- a/src/org/opensolaris/opengrok/analysis/JFlexTokenizer.java
+++ b/src/org/opensolaris/opengrok/analysis/JFlexTokenizer.java
@@ -83,7 +83,6 @@ public abstract class JFlexTokenizer extends Tokenizer {
     protected CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
     protected OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
     protected PositionIncrementAttribute posIncrAtt = addAttribute(PositionIncrementAttribute.class);
-    protected int finalOffset;
 
     /**
      * This will re-initialize internal AttributeImpls, or it returns false if

--- a/src/org/opensolaris/opengrok/analysis/JFlexTokenizer.java
+++ b/src/org/opensolaris/opengrok/analysis/JFlexTokenizer.java
@@ -45,7 +45,7 @@ public abstract class JFlexTokenizer extends Tokenizer {
     protected Stack<Integer> stack = new Stack<>();
 
     // default jflex scanner methods and variables
-    abstract public boolean yylex() throws IOException;
+    abstract public int yylex() throws IOException;
 
     abstract public void yyreset(Reader reader);
 
@@ -55,6 +55,8 @@ public abstract class JFlexTokenizer extends Tokenizer {
 
     abstract public int yystate();    
         
+    abstract public int getYYEOF();
+
     //TODO can be removed once we figure out jflex generation of empty constructor
     protected JFlexTokenizer(Reader in) {
         super();
@@ -93,7 +95,7 @@ public abstract class JFlexTokenizer extends Tokenizer {
     @Override
     public final boolean incrementToken() throws IOException {        
         clearAttributes();
-        return this.yylex();
+        return this.yylex() != getYYEOF();
     }
 
     protected void setAttribs(String str, int start, int end) {

--- a/src/org/opensolaris/opengrok/analysis/ada/AdaProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaProductions.lexh
@@ -142,7 +142,7 @@ File = [a-zA-Z]{FNameChar}* "." {FileExt}
     {Identifier}    {
         String id = yytext();
         if (takeSymbol(id, 0, false) && returnOnSymbol()) {
-            return getSymbolReturn();
+            return yystate();
         }
     }
 

--- a/src/org/opensolaris/opengrok/analysis/ada/AdaSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaSymbolTokenizer.lex
@@ -47,10 +47,6 @@ import org.opensolaris.opengrok.web.Util;
     h = new AdaLexHelper(this);
 %init}
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %{
     private final AdaLexHelper h;
 

--- a/src/org/opensolaris/opengrok/analysis/ada/AdaSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaSymbolTokenizer.lex
@@ -40,13 +40,17 @@ import org.opensolaris.opengrok.web.Util;
 %implements AdaLexListener
 %unicode
 %ignorecase
-%type boolean
+%int
 %char
 %init{
     super(in);
     h = new AdaLexHelper(this);
 %init}
 %include CommonTokenizer.lexh
+%eofval{
+    this.finalOffset = zzEndRead;
+    return YYEOF;
+%eofval}
 %{
     private final AdaLexHelper h;
 
@@ -114,10 +118,6 @@ import org.opensolaris.opengrok.web.Util;
         return lastSymbol != null;
     }
 
-    protected boolean getSymbolReturn() {
-        return true;
-    }
-
     protected String getUrlPrefix() { return null; }
 
     protected void appendProject() { /* noop */ }
@@ -126,10 +126,6 @@ import org.opensolaris.opengrok.web.Util;
 
     protected void writeEMailAddress(String s) { /* noop */ }
 %}
-%eofval{
-this.finalOffset =  zzEndRead;
-return false;
-%eofval}
 
 %include Common.lexh
 %include AdaProductions.lexh

--- a/src/org/opensolaris/opengrok/analysis/ada/AdaXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaXref.lex
@@ -118,10 +118,6 @@ import org.opensolaris.opengrok.web.Util;
         return false;
     }
 
-    protected int getSymbolReturn() {
-        return 0; // irrelevant value because returnOnSymbol() is false
-    }
-
     protected String getUrlPrefix() { return urlPrefix; }
 %}
 

--- a/src/org/opensolaris/opengrok/analysis/c/CSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/c/CSymbolTokenizer.lex
@@ -39,10 +39,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*

--- a/src/org/opensolaris/opengrok/analysis/c/CSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/c/CSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -36,9 +37,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -52,7 +55,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id)) {
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(QSTRING); }
@@ -78,6 +81,5 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
-<<EOF>>   { this.finalOffset=zzEndRead;return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/c/CxxSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/c/CxxSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.c;
@@ -33,9 +34,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -49,7 +52,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 {Identifier} {String id = yytext();
                 if(!CxxConsts.kwd.contains(id)) {
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(QSTRING); }
@@ -75,6 +78,5 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
-<<EOF>>   { this.finalOffset =  zzEndRead; return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/c/CxxSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/c/CxxSymbolTokenizer.lex
@@ -36,10 +36,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*

--- a/src/org/opensolaris/opengrok/analysis/clojure/ClojureSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/clojure/ClojureSymbolTokenizer.lex
@@ -41,10 +41,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 %{

--- a/src/org/opensolaris/opengrok/analysis/clojure/ClojureSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/clojure/ClojureSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -38,9 +39,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -58,7 +61,7 @@ Identifier = [\-\+\*\!\@\$\%\&\/\?\.\,\:\{\}\=a-zA-Z0-9_\<\>]+
 {Identifier} {String id = yytext();
               if (!Consts.kwd.contains(id.toLowerCase())) {
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
 ";"     { yybegin(SCOMMENT); }
@@ -82,6 +85,5 @@ Identifier = [\-\+\*\!\@\$\%\&\/\?\.\,\:\{\}\=a-zA-Z0-9_\<\>]+
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT> {
-<<EOF>>   { return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/csharp/CSharpSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/csharp/CSharpSymbolTokenizer.lex
@@ -41,10 +41,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 

--- a/src/org/opensolaris/opengrok/analysis/csharp/CSharpSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/csharp/CSharpSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -38,9 +39,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
@@ -53,7 +56,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(QSTRING); }
@@ -84,6 +87,5 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING, VSTRING> {
-<<EOF>>   { return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/document/TroffFullTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/document/TroffFullTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.document;
@@ -36,9 +37,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %caseless
 %char
@@ -54,10 +57,9 @@ Printable = [\@\$\%\^\&\-+=\?\.\:]
 \\f[ABCIR]  {}
 ^"...\\\"" {}
 
-\\&.        {setAttribs(".", yychar, yychar + yylength()); return true;}
+\\&.        {setAttribs(".", yychar, yychar + yylength()); return yystate();}
 {Identifier}|{Number}|{Printable} {
     setAttribs(yytext().toLowerCase(), yychar, yychar + yylength());
-    return true;
+    return yystate();
 }
-<<EOF>>   { return false;}
 [^]    {}

--- a/src/org/opensolaris/opengrok/analysis/document/TroffFullTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/document/TroffFullTokenizer.lex
@@ -39,10 +39,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %caseless
 %char
 

--- a/src/org/opensolaris/opengrok/analysis/erlang/ErlangSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/erlang/ErlangSymbolTokenizer.lex
@@ -41,10 +41,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [A-Z_] [a-zA-Z0-9_@]*

--- a/src/org/opensolaris/opengrok/analysis/erlang/ErlangSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/erlang/ErlangSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -38,9 +39,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -54,7 +57,7 @@ Identifier = [A-Z_] [a-zA-Z0-9_@]*
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(QATOM); }
@@ -76,6 +79,5 @@ Identifier = [A-Z_] [a-zA-Z0-9_@]*
 }
 
 <YYINITIAL, STRING, QATOM, COMMENT> {
-<<EOF>>   { return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/fortran/FortranSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/fortran/FortranSymbolTokenizer.lex
@@ -37,10 +37,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*

--- a/src/org/opensolaris/opengrok/analysis/fortran/FortranSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/fortran/FortranSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.fortran;
@@ -34,9 +35,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -53,7 +56,7 @@ Label = [0-9]+
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id.toLowerCase())) {
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(QSTRING); }
@@ -78,6 +81,5 @@ Label = [0-9]+
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
-<<EOF>>   { return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/golang/GolangSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/golang/GolangSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -40,9 +41,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -57,7 +60,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_']*
         String id = yytext();
         if (!Consts.kwd.contains(id)) {
             setAttribs(id, yychar, yychar + yylength());
-            return true;
+            return yystate();
         }
     }
     \"   { yybegin(STRING);   }
@@ -84,6 +87,5 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_']*
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
-<<EOF>>   { this.finalOffset =  zzEndRead; return false;}
 [^] {}
 }

--- a/src/org/opensolaris/opengrok/analysis/golang/GolangSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/golang/GolangSymbolTokenizer.lex
@@ -43,10 +43,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_']*

--- a/src/org/opensolaris/opengrok/analysis/haskell/HaskellSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/haskell/HaskellSymbolTokenizer.lex
@@ -43,10 +43,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_']*

--- a/src/org/opensolaris/opengrok/analysis/haskell/HaskellSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/haskell/HaskellSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -40,9 +41,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -57,7 +60,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_']*
         String id = yytext();
         if (!Consts.kwd.contains(id)) {
             setAttribs(id, yychar, yychar + yylength());
-            return true;
+            return yystate();
         }
     }
     \"   { yybegin(STRING);   }

--- a/src/org/opensolaris/opengrok/analysis/java/JavaSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/java/JavaSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -37,10 +38,11 @@ super(in);
 %init}
 %unicode
 %buffer 32766
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-this.finalOffset =  zzEndRead;
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -54,7 +56,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(QSTRING); }
@@ -80,6 +82,6 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
-<<EOF>>   { this.finalOffset =  zzEndRead; return false;}
+
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/java/JavaSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/java/JavaSymbolTokenizer.lex
@@ -40,10 +40,6 @@ super(in);
 %buffer 32766
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*

--- a/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptSymbolTokenizer.lex
@@ -42,10 +42,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_$] [a-zA-Z0-9_$]*

--- a/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -39,9 +40,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -55,7 +58,7 @@ Identifier = [a-zA-Z_$] [a-zA-Z0-9_$]*
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(QSTRING); }
@@ -81,6 +84,5 @@ Identifier = [a-zA-Z_$] [a-zA-Z0-9_$]*
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
-<<EOF>>   { return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/json/JsonSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/json/JsonSymbolTokenizer.lex
@@ -42,10 +42,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 /* TODO : add unicode support */

--- a/src/org/opensolaris/opengrok/analysis/json/JsonSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/json/JsonSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -39,9 +40,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -58,7 +61,7 @@ Identifier = [a-zA-Z_$] [a-zA-Z0-9_$]*
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
 }
@@ -69,6 +72,5 @@ Identifier = [a-zA-Z_$] [a-zA-Z0-9_$]*
 }
 
 <YYINITIAL, STRING> {
-<<EOF>>   { return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/kotlin/KotlinSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/kotlin/KotlinSymbolTokenizer.lex
@@ -43,10 +43,6 @@ super(in);
 %buffer 32766
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [:jletter:] [:jletterdigit:]*

--- a/src/org/opensolaris/opengrok/analysis/kotlin/KotlinSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/kotlin/KotlinSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -40,10 +41,11 @@ super(in);
 %init}
 %unicode
 %buffer 32766
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-this.finalOffset =  zzEndRead;
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -58,7 +60,7 @@ Identifier = [:jletter:] [:jletterdigit:]*
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
 
  \"     { yybegin(STRING); }
@@ -91,6 +93,5 @@ Identifier = [:jletter:] [:jletterdigit:]*
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING, TSTRING> {
-<<EOF>>   { this.finalOffset =  zzEndRead; return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/lisp/LispSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/lisp/LispSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -38,9 +39,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -58,7 +61,7 @@ Identifier = [\-\+\*\!\@\$\%\&\/\?\.\,\:\{\}\=a-zA-Z0-9_\<\>]+
 {Identifier} {String id = yytext();
               if (!Consts.kwd.contains(id.toLowerCase())) {
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
 ";"     { yybegin(SCOMMENT); }
@@ -82,6 +85,5 @@ Identifier = [\-\+\*\!\@\$\%\&\/\?\.\,\:\{\}\=a-zA-Z0-9_\<\>]+
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT> {
-<<EOF>>   { return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/lisp/LispSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/lisp/LispSymbolTokenizer.lex
@@ -41,10 +41,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 %{

--- a/src/org/opensolaris/opengrok/analysis/lua/LuaSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/lua/LuaSymbolTokenizer.lex
@@ -43,10 +43,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_']*

--- a/src/org/opensolaris/opengrok/analysis/lua/LuaSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/lua/LuaSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -40,9 +41,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -57,7 +60,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_']*
         String id = yytext();
         if (!Consts.kwd.contains(id)) {
             setAttribs(id, yychar, yychar + yylength());
-            return true;
+            return yystate();
         }
     }
     \"     { yybegin(STRING);   }
@@ -89,6 +92,5 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_']*
 }
 
 <YYINITIAL, STRING, LSTRING, COMMENT, SCOMMENT, QSTRING> {
-<<EOF>>   { this.finalOffset =  zzEndRead; return false;}
 [^] {}
 }

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalSymbolTokenizer.lex
@@ -39,10 +39,6 @@ super(in);
 %unicode
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -36,10 +37,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 super(in);
 %init}
 %unicode
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-this.finalOffset =  zzEndRead;
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -53,7 +55,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(QSTRING); }
@@ -78,6 +80,5 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
-<<EOF>>   { this.finalOffset =  zzEndRead; return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlProductions.lexh
@@ -185,7 +185,7 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>"|"=>")
     maybeIntraState();
     String id = yytext();
     if (takeSymbol(id, 0, false) && returnOnSymbol()) {
-        return getSymbolReturn();
+        return yystate();
     }
  }
 
@@ -347,7 +347,7 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>"|"=>")
         maybeIntraState();
         //we ignore keywords if the identifier starts with a sigil ...
         h.sigilID(yytext());
-        if (returnOnSymbol()) return getSymbolReturn();
+        if (returnOnSymbol()) return yystate();
     }
 }
 
@@ -356,7 +356,7 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>"|"=>")
         maybeIntraState();
         //we ignore keywords if the identifier starts with a sigil ...
         h.bracedSigilID(yytext());
-        if (returnOnSymbol()) return getSymbolReturn();
+        if (returnOnSymbol()) return yystate();
     }
 
     {SPIdentifier1} |
@@ -385,7 +385,7 @@ Mpunc2IN = ([!=]"~" | [\:\?\=\+\-\<\>] | "=="|"!="|"<="|">="|"<=>"|"=>")
     {Sigils} {Identifier} {
         //we ignore keywords if the identifier starts with a sigil ...
         h.sigilID(yytext());
-        if (returnOnSymbol()) return getSymbolReturn();
+        if (returnOnSymbol()) return yystate();
     }
 }
 

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlSymbolTokenizer.lex
@@ -47,10 +47,6 @@ import org.opensolaris.opengrok.web.Util;
         HERE, HERExN, HEREin, HEREinxN);
 %init}
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset =  zzEndRead;
-    return YYEOF;
-%eofval}
 %{
     private final PerlLexHelper h;
 

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlSymbolTokenizer.lex
@@ -39,13 +39,18 @@ import org.opensolaris.opengrok.web.Util;
 %extends JFlexTokenizer
 %implements PerlLexListener
 %unicode
-%type boolean
+%int
 %char
 %init{
     super(in);
     h = new PerlLexHelper(QUO, QUOxN, QUOxL, QUOxLxN, this,
         HERE, HERExN, HEREin, HEREinxN);
 %init}
+%include CommonTokenizer.lexh
+%eofval{
+    this.finalOffset =  zzEndRead;
+    return YYEOF;
+%eofval}
 %{
     private final PerlLexHelper h;
 
@@ -126,10 +131,6 @@ import org.opensolaris.opengrok.web.Util;
         return lastSymbol != null;
     }
 
-    protected boolean getSymbolReturn() {
-        return true;
-    }
-
     protected String getUrlPrefix() { return null; }
 
     protected void appendProject() { /* noop */ }
@@ -138,9 +139,5 @@ import org.opensolaris.opengrok.web.Util;
 
     protected void writeEMailAddress(String s) { /* noop */ }
 %}
-%eofval{
-this.finalOffset =  zzEndRead;
-return false;
-%eofval}
 
 %include PerlProductions.lexh

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlXref.lex
@@ -130,10 +130,6 @@ import org.opensolaris.opengrok.web.Util;
         return false;
     }
 
-    protected int getSymbolReturn() {
-        return 0; // irrelevant value because returnOnSymbol() is false
-    }
-
     protected String getUrlPrefix() { return urlPrefix; }
 %}
 

--- a/src/org/opensolaris/opengrok/analysis/php/PhpSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/php/PhpSymbolTokenizer.lex
@@ -40,10 +40,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 %ignorecase
 %{

--- a/src/org/opensolaris/opengrok/analysis/php/PhpSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/php/PhpSymbolTokenizer.lex
@@ -18,6 +18,11 @@
  */
 
 /*
+ * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ */
+
+/*
  * Gets Php symbols - ignores comments, strings, keywords
  */
 
@@ -33,10 +38,11 @@ import java.util.*;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-this.finalOffset=zzEndRead;
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 %ignorecase
@@ -110,13 +116,13 @@ DocParamWithName = "uses"
     "$" {Identifier} {
         //we ignore keywords if the identifier starts with one of variable chars
         setAttribs(yytext().substring(1), yychar + 1, yychar + yylength());
-        return true;
+        return yystate();
     }
 
     {Identifier} {
         if (!Consts.kwd.contains(yytext())) {
             setAttribs(yytext(), yychar, yychar + yylength());
-            return true;
+            return yystate();
         }
     }
 
@@ -209,7 +215,7 @@ DocParamWithName = "uses"
 <STRINGVAR> {
     {Identifier} {
         setAttribs(yytext(), yychar, yychar + yylength());
-        return true;
+        return yystate();
     }
 
     \[ {Number} \] {
@@ -225,13 +231,13 @@ DocParamWithName = "uses"
         setAttribs(yytext().substring(2, yylength()-1), yychar + 2,
                 yychar + yylength() - 1);
         yypop();
-        return true;
+        return yystate();
     }
 
     "->" {Identifier} {
         setAttribs(yytext().substring(2), yychar + 2, yychar + yylength());
         yypop(); //because "$arr->a[0]" is the same as $arr->a . "[0]"
-        return true;
+        return yystate();
     }
 
     [^]          { yypushback(1); yypop(); }
@@ -240,7 +246,7 @@ DocParamWithName = "uses"
 <STRINGEXPR> {
     {Identifier} {
         setAttribs(yytext(), yychar, yychar + yylength());
-        return true;
+        return yystate();
     }
     \}  { yypop(); }
     \[  { yybegin(IN_SCRIPT); } /* don't push. when we find '}'
@@ -287,7 +293,7 @@ DocParamWithName = "uses"
     {Identifier} {
         if (!PSEUDO_TYPES.contains(yytext().toLowerCase())) {
             setAttribs(yytext(), yychar, yychar + yylength());
-            return true;
+            return yystate();
         }
     }
 
@@ -298,7 +304,7 @@ DocParamWithName = "uses"
     "$" {Identifier} {
         setAttribs(yytext().substring(1), yychar + 1, yychar + yylength());
         yybegin(DOCCOMMENT);
-        return true;
+        return yystate();
     }
 
     [^] { yybegin(DOCCOMMENT); yypushback(1); }

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainFullTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainFullTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.plain;
@@ -34,10 +35,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-this.finalOffset=zzEndRead;
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %caseless
 %char
@@ -50,5 +52,5 @@ Printable = [\@\$\%\^\&\-+=\?\.\:]
 %%
 {Identifier}|{Number}|{Printable} { // below assumes locale from the shell/container, instead of just US
                         setAttribs(yytext().toLowerCase(Locale.getDefault()), yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
 [^]    {}

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainFullTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainFullTokenizer.lex
@@ -37,10 +37,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %caseless
 %char
 

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainSymbolTokenizer.lex
@@ -35,10 +35,6 @@ super(in);
 %buffer 32766
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 %%

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.plain;
@@ -32,15 +33,16 @@ super(in);
 %init}
 %unicode
 %buffer 32766
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-this.finalOffset=zzEndRead;
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
 %%
 //TODO decide if we should let one char symbols
 [a-zA-Z_] [a-zA-Z0-9_]+ {setAttribs(yytext(), yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
 [^]    {}

--- a/src/org/opensolaris/opengrok/analysis/powershell/PowershellSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/powershell/PowershellSymbolTokenizer.lex
@@ -36,10 +36,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 EOL = \r|\n|\r\n

--- a/src/org/opensolaris/opengrok/analysis/python/PythonSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/python/PythonSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -38,9 +39,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -54,7 +57,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \"\"\" { yybegin(LSTRING); }
@@ -86,6 +89,5 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <YYINITIAL, STRING, LSTRING, SCOMMENT, QSTRING , LQSTRING> {
-<<EOF>>   { return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/python/PythonSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/python/PythonSymbolTokenizer.lex
@@ -41,10 +41,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*

--- a/src/org/opensolaris/opengrok/analysis/ruby/RubyProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/ruby/RubyProductions.lexh
@@ -260,7 +260,7 @@ Here_EOF3 = [\`][^\r\n\`]*[\`]
         maybeIntraState();
         String id = yytext();
         if (takeSymbol(id, 0, true) && returnOnSymbol()) {
-            return getSymbolReturn();
+            return yystate();
         }
     }
 
@@ -268,7 +268,7 @@ Here_EOF3 = [\`][^\r\n\`]*[\`]
         maybeIntraState();
         String id = yytext();
         if (takeSymbol(id, 0, false) && returnOnSymbol()) {
-            return getSymbolReturn();
+            return yystate();
         }
     }
 

--- a/src/org/opensolaris/opengrok/analysis/ruby/RubySymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/ruby/RubySymbolTokenizer.lex
@@ -40,12 +40,17 @@ import org.opensolaris.opengrok.web.Util;
 %extends JFlexTokenizer
 %implements RubyLexListener
 %unicode
-%type boolean
+%int
 %char
 %init{
     super(in);
     h = getNewHelper();
 %init}
+%include CommonTokenizer.lexh
+%eofval{
+    this.finalOffset = zzEndRead;
+    return YYEOF;
+%eofval}
 %{
     protected Stack<RubyLexHelper> helpers;
 
@@ -141,10 +146,6 @@ import org.opensolaris.opengrok.web.Util;
         return lastSymbol != null;
     }
 
-    protected boolean getSymbolReturn() {
-        return true;
-    }
-
     protected String getUrlPrefix() { return null; }
 
     protected void appendProject() { /* noop */ }
@@ -153,9 +154,5 @@ import org.opensolaris.opengrok.web.Util;
 
     protected void writeEMailAddress(String s) { /* noop */ }
 %}
-%eofval{
-this.finalOffset =  zzEndRead;
-return false;
-%eofval}
 
 %include RubyProductions.lexh

--- a/src/org/opensolaris/opengrok/analysis/ruby/RubySymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/ruby/RubySymbolTokenizer.lex
@@ -47,10 +47,6 @@ import org.opensolaris.opengrok.web.Util;
     h = getNewHelper();
 %init}
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %{
     protected Stack<RubyLexHelper> helpers;
 

--- a/src/org/opensolaris/opengrok/analysis/ruby/RubyXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/ruby/RubyXref.lex
@@ -141,10 +141,6 @@ import org.opensolaris.opengrok.web.Util;
         return false;
     }
 
-    protected int getSymbolReturn() {
-        return 0; // irrelevant value because returnOnSymbol() is false
-    }
-
     protected String getUrlPrefix() { return urlPrefix; }
 %}
 

--- a/src/org/opensolaris/opengrok/analysis/rust/RustSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/rust/RustSymbolTokenizer.lex
@@ -40,10 +40,6 @@ super(in);
 %unicode
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*

--- a/src/org/opensolaris/opengrok/analysis/rust/RustSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/rust/RustSymbolTokenizer.lex
@@ -20,6 +20,7 @@
 /*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2016 Nikolay Denev.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -37,10 +38,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 super(in);
 %init}
 %unicode
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-this.finalOffset =  zzEndRead;
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -54,7 +56,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(QSTRING); }
@@ -80,6 +82,5 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
-<<EOF>>   { this.finalOffset =  zzEndRead; return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/scala/ScalaSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/scala/ScalaSymbolTokenizer.lex
@@ -39,10 +39,6 @@ super(in);
 %unicode
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*

--- a/src/org/opensolaris/opengrok/analysis/scala/ScalaSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/scala/ScalaSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -36,10 +37,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 super(in);
 %init}
 %unicode
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-this.finalOffset =  zzEndRead;
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -53,7 +55,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(QSTRING); }
@@ -79,6 +81,5 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
-<<EOF>>   { this.finalOffset =  zzEndRead; return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/sh/ShSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/sh/ShSymbolTokenizer.lex
@@ -36,10 +36,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*

--- a/src/org/opensolaris/opengrok/analysis/sh/ShSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/sh/ShSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.sh;
@@ -33,9 +34,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -49,7 +52,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 {Identifier} {String id = yytext();
                 if(!Consts.shkwd.contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(QSTRING); }
@@ -59,7 +62,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 <STRING> {
 "$" {Identifier} {
     setAttribs(yytext().substring(1), yychar + 1, yychar + yylength());
-    return true;
+    return yystate();
 }
 
 "${" {Identifier} "}" {
@@ -68,7 +71,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
     setAttribs(yytext().substring(startOffset, endOffset),
                yychar + startOffset,
                yychar + endOffset);
-    return true;
+    return yystate();
 }
 
  \"     { yybegin(YYINITIAL); }
@@ -84,6 +87,5 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <YYINITIAL, STRING, SCOMMENT, QSTRING> {
-<<EOF>>   { return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/swift/SwiftSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/swift/SwiftSymbolTokenizer.lex
@@ -43,10 +43,6 @@ super(in);
 %buffer 32766
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 /* TODO add unicode as stated in https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html#//apple_ref/swift/grammar/identifier-head */

--- a/src/org/opensolaris/opengrok/analysis/swift/SwiftSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/swift/SwiftSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -40,10 +41,11 @@ super(in);
 %init}
 %unicode
 %buffer 32766
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-this.finalOffset =  zzEndRead;
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -59,7 +61,7 @@ Identifier = [:jletter:] [:jletterdigit:]*
 {Identifier} {String id = yytext();
                 if(!Consts.kwd.contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
 
  \"     { yybegin(STRING); }
@@ -93,6 +95,5 @@ Identifier = [:jletter:] [:jletterdigit:]*
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING, TSTRING> {
-<<EOF>>   { this.finalOffset =  zzEndRead; return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/tcl/TclSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/tcl/TclSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -38,9 +39,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -54,7 +57,7 @@ Identifier = [\:\=a-zA-Z0-9_]+
 {Identifier} {String id = yytext();
               if (!Consts.kwd.contains(id)) {
                     setAttribs(id, yychar, yychar + yylength());
-                    return true; }
+                    return yystate(); }
               }
  \"     { yybegin(STRING); }
 "#"     { yybegin(SCOMMENT); }
@@ -70,6 +73,5 @@ Identifier = [\:\=a-zA-Z0-9_]+
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT> {
-<<EOF>>   { return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/tcl/TclSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/tcl/TclSymbolTokenizer.lex
@@ -41,10 +41,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [\:\=a-zA-Z0-9_]+

--- a/src/org/opensolaris/opengrok/analysis/uue/UuencodeFullTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/uue/UuencodeFullTokenizer.lex
@@ -40,10 +40,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %caseless
 %char
 %{

--- a/src/org/opensolaris/opengrok/analysis/uue/UuencodeFullTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/uue/UuencodeFullTokenizer.lex
@@ -20,6 +20,7 @@
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2013 Constantine A. Murenin <C++@Cns.SU>
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.uue;
@@ -37,9 +38,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %caseless
 %char
@@ -57,7 +60,6 @@ Printable = [\@\$\%\^\&\-+=\?\.\:]
 %state BEGIN MODE NAME UUE
 
 %%
-<<EOF>>   { return false; }
 
 <YYINITIAL> {
   ^ ( "begin " | "begin-" ) {
@@ -67,12 +69,12 @@ Printable = [\@\$\%\^\&\-+=\?\.\:]
     yybegin(BEGIN);
     yypushback(1);
     setAttribs(yytext().toLowerCase(), yychar, yychar + yylength());
-    return true;
+    return yystate();
   }
 
   {Identifier}|{Number}|{Printable} {
     setAttribs(yytext().toLowerCase(), yychar, yychar + yylength());
-    return true;
+    return yystate();
   }
 
   [^] {}
@@ -90,7 +92,7 @@ Printable = [\@\$\%\^\&\-+=\?\.\:]
       yybegin(YYINITIAL);
     b64 = true;
     setAttribs(yytext(), yychar, yychar + yylength());
-    return true;
+    return yystate();
   }
   "base64 " {
     if (b64)
@@ -99,7 +101,7 @@ Printable = [\@\$\%\^\&\-+=\?\.\:]
       yybegin(YYINITIAL);
     yypushback(1);
     setAttribs(yytext().toLowerCase(), yychar, yychar + yylength());
-    return true;
+    return yystate();
   }
   [^] { yybegin(YYINITIAL); yypushback(1); }
 }
@@ -109,7 +111,7 @@ Printable = [\@\$\%\^\&\-+=\?\.\:]
   {Identifier}|{Number}|{Printable} {
     modeFound = true;
     setAttribs(yytext().toLowerCase(), yychar, yychar + yylength());
-    return true;
+    return yystate();
   }
   [^] { yybegin(YYINITIAL); yypushback(1); }
 }
@@ -124,7 +126,7 @@ Printable = [\@\$\%\^\&\-+=\?\.\:]
   {Identifier}|{Number}|{Printable} {
     nameFound = true;
     setAttribs(yytext().toLowerCase(), yychar, yychar + yylength());
-    return true;
+    return yystate();
   }
   [^\n] { yybegin(YYINITIAL); yypushback(1); }
 }
@@ -136,7 +138,7 @@ Printable = [\@\$\%\^\&\-+=\?\.\:]
     if (t.equals("end") && !b64) {
       yybegin(YYINITIAL);
       setAttribs(yytext().toLowerCase(), yychar, yychar + yylength());
-      return true;
+      return yystate();
     } else if (t.equals("====") && b64)
       yybegin(YYINITIAL);
   }

--- a/src/org/opensolaris/opengrok/analysis/vb/VBSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/vb/VBSymbolTokenizer.lex
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -38,9 +39,11 @@ import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 %init{
 super(in);
 %init}
-%type boolean
+%int
+%include CommonTokenizer.lexh
 %eofval{
-return false;
+    this.finalOffset = zzEndRead;
+    return YYEOF;
 %eofval}
 %char
 
@@ -54,7 +57,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 {Identifier} {String id = yytext();
                 if(!Consts.getReservedKeywords().contains(id)){
                         setAttribs(id, yychar, yychar + yylength());
-                        return true; }
+                        return yystate(); }
               }
  \"     { yybegin(STRING); }
  \'     { yybegin(COMMENT); }
@@ -70,6 +73,5 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <YYINITIAL, STRING, COMMENT> {
-<<EOF>>   { return false;}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/vb/VBSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/vb/VBSymbolTokenizer.lex
@@ -41,10 +41,6 @@ super(in);
 %init}
 %int
 %include CommonTokenizer.lexh
-%eofval{
-    this.finalOffset = zzEndRead;
-    return YYEOF;
-%eofval}
 %char
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]*

--- a/test/org/opensolaris/opengrok/analysis/haskell/HaskellSymbolTokenizerTest.java
+++ b/test/org/opensolaris/opengrok/analysis/haskell/HaskellSymbolTokenizerTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.haskell;
 
@@ -61,7 +62,7 @@ public class HaskellSymbolTokenizerTest {
         ts.yyreset(r);
         CharTermAttribute term = ts.addAttribute(CharTermAttribute.class);
         try {
-            while (ts.yylex()) {
+            while (ts.yylex() != ts.getYYEOF()) {
                 l.add(term.toString());
             }
         } catch (IOException ex) {

--- a/test/org/opensolaris/opengrok/analysis/java/JavaSymbolTokenizerTest.java
+++ b/test/org/opensolaris/opengrok/analysis/java/JavaSymbolTokenizerTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.java;
 
@@ -61,7 +62,7 @@ public class JavaSymbolTokenizerTest {
         ts.yyreset(r);
         CharTermAttribute term = ts.addAttribute(CharTermAttribute.class);
         try {
-            while (ts.yylex()) {
+            while (ts.yylex() != ts.getYYEOF()) {
                 l.add(term.toString());
             }
         } catch (IOException ex) {

--- a/test/org/opensolaris/opengrok/analysis/php/PhpSymbolTokenizerTest.java
+++ b/test/org/opensolaris/opengrok/analysis/php/PhpSymbolTokenizerTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.php;
 
@@ -59,7 +60,7 @@ public class PhpSymbolTokenizerTest {
         ts.yyreset(r);
         CharTermAttribute term = ts.addAttribute(CharTermAttribute.class);
         try {
-            while (ts.yylex()) {
+            while (ts.yylex() != ts.getYYEOF()) {
                 l.add(term.toString());
             }
         } catch (IOException ex) {


### PR DESCRIPTION
Hello,

Please consider for integration this patch to include CommonTokenizer.lexh in the language Tokenizer lex files.

This patch also converts the tokenizers to `%type int` lexers to align them with the Xref lexers and to demonstrate the start of a decoupling of the Lucene Tokenizer logic (while still keeping it as a principal technology of course) from the JFlex-based lexers.

Also:
- Remove redundant `<<EOF>>` rules when `%eofval{` is also defined. The former would have won, so move those statements into the `%eofval{` block.
- Ensure all tokenizers set finalOffset in `%eofval{`. The value is not actually used, but retiring it is left for another patch.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
