### PR TITLE
Accept any path for #include statement for issue #471

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/c/CSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/c/CSymbolTokenizer.lex
@@ -45,6 +45,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 
 %state STRING COMMENT SCOMMENT QSTRING
 
+%include Common.lexh
 %%
 
 <YYINITIAL> {
@@ -73,9 +74,10 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <SCOMMENT> {
-\n      { yybegin(YYINITIAL);}
+{EOL}   { yybegin(YYINITIAL); }
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
+{WhiteSpace}    {}
 [^]    {}
 }

--- a/src/org/opensolaris/opengrok/analysis/c/CXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/c/CXref.lex
@@ -40,10 +40,18 @@ import org.opensolaris.opengrok.web.Util;
 %class CXref
 %extends JFlexXref
 %unicode
-%ignorecase
 %int
 %include CommonXref.lexh
 %{
+  private static final Pattern MATCH_INCLUDE = Pattern.compile(
+      "^(#.*)(include)(.*)([<\"])(.*)([>\"])$");
+  private static final int INCL_HASH_G = 1;
+  private static final int INCLUDE_G = 2;
+  private static final int INCL_POST_G = 3;
+  private static final int INCL_PUNC0_G = 4;
+  private static final int INCL_PATH_G = 5;
+  private static final int INCL_PUNCZ_G = 6;
+
   // TODO move this into an include file when bug #16053 is fixed
   @Override
   protected int getLineNumber() { return yyline; }
@@ -53,7 +61,10 @@ import org.opensolaris.opengrok.web.Util;
 
 Identifier = [a-zA-Z_] [a-zA-Z0-9_]+
 
-File = [a-zA-Z]{FNameChar}* "." ([chts]|"conf"|"java"|"cpp"|"hpp"|"CC"|"txt"|"htm"|"html"|"pl"|"xml"|"cc"|"cxx"|"c++"|"hh"|"hxx"|"h++"|"diff"|"patch")
+File = [a-zA-Z]{FNameChar}* "." ([cChHsStT] | [Cc][Oo][Nn][Ff] |
+    [Jj][Aa][Vv][Aa] | [CcHh][Pp][Pp] | [Cc][Cc] | [Tt][Xx][Tt] |
+    [Hh][Tt][Mm][Ll]? | [Pp][Ll] | [Xx][Mm][Ll] | [CcHh][\+][\+] | [Hh][Hh] |
+    [CcHh][Xx][Xx] | [Dd][Ii][Ff][Ff] | [Pp][Aa][Tt][Cc][Hh])
 
 Number = (0[xX][0-9a-fA-F]+|[0-9]+\.[0-9]+|[1-9][0-9]*)(([eE][+-]?[0-9]+)?[ufdlUFDL]*)?
 
@@ -74,16 +85,19 @@ Number = (0[xX][0-9a-fA-F]+|[0-9]+\.[0-9]+|[1-9][0-9]*)(([eE][+-]?[0-9]+)?[ufdlU
     writeSymbol(id, Consts.kwd, yyline);
 }
 
-"#" {WhspChar}* "include" {WhspChar}* "<" ({File}|{FPath}|{Identifier}) ">" {
-        Matcher match = Pattern.compile("(#.*)(include)(.*)<(.*)>").matcher(yytext());
+"#" {WhspChar}* "include" {WhspChar}* ("<"[^>\n\r]+">" | \"[^\"\n\r]+\")    {
+        String capture = yytext();
+        Matcher match = MATCH_INCLUDE.matcher(capture);
         if (match.matches()) {
-            out.write(match.group(1));
-            writeSymbol(match.group(2), Consts.kwd, yyline);
-            out.write(match.group(3));
-            out.write("&lt;");
-            String path = match.group(4);
+            out.write(match.group(INCL_HASH_G));
+            writeSymbol(match.group(INCLUDE_G), Consts.kwd, yyline);
+            out.write(match.group(INCL_POST_G));
+            out.write(htmlize(match.group(INCL_PUNC0_G)));
+            String path = match.group(INCL_PATH_G);
             out.write(Util.breadcrumbPath(urlPrefix + "path=", path));
-            out.write("&gt;");
+            out.write(htmlize(match.group(INCL_PUNCZ_G)));
+        } else {
+            out.write(htmlize(capture));
         }
 }
 

--- a/src/org/opensolaris/opengrok/analysis/c/CxxSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/c/CxxSymbolTokenizer.lex
@@ -42,6 +42,7 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 
 %state STRING COMMENT SCOMMENT QSTRING
 
+%include Common.lexh
 %%
 
 <YYINITIAL> {
@@ -70,9 +71,10 @@ Identifier = [a-zA-Z_] [a-zA-Z0-9_]*
 }
 
 <SCOMMENT> {
-\n      { yybegin(YYINITIAL);}
+{EOL}   { yybegin(YYINITIAL); }
 }
 
 <YYINITIAL, STRING, COMMENT, SCOMMENT, QSTRING> {
+{WhiteSpace}    {}
 [^]    {}
 }

--- a/test/org/opensolaris/opengrok/analysis/JFlexXrefTest.java
+++ b/test/org/opensolaris/opengrok/analysis/JFlexXrefTest.java
@@ -277,8 +277,8 @@ public class JFlexXrefTest {
         String[][] testData = {
             {"#include <abc.h>", "#<b>include</b> &lt;<a href=\"/source/s?path=abc.h\">abc.h</a>&gt;"},
             {"#include <abc/def.h>", "#<b>include</b> &lt;<a href=\"/source/s?path=abc/\">abc</a>/<a href=\"/source/s?path=abc/def.h\">def.h</a>&gt;"},
-            {"#include \"abc.h\"", "#<b>include</b> <span class=\"s\">\"<a href=\"/source/s?path=abc.h\">abc.h</a>\"</span>"},
-            {"#include \"abc/def.h\"", "#<b>include</b> <span class=\"s\">\"<a href=\"/source/s?path=abc/\">abc</a>/<a href=\"/source/s?path=abc/def.h\">def.h</a>\"</span>"},
+            {"#include \"abc.h\"", "#<b>include</b> &quot;<a href=\"/source/s?path=abc.h\">abc.h</a>&quot;"},
+            {"#include \"abc/def.h\"", "#<b>include</b> &quot;<a href=\"/source/s?path=abc/\">abc</a>/<a href=\"/source/s?path=abc/def.h\">def.h</a>&quot;"},
             {"#include <vector>", "#<b>include</b> &lt;<a href=\"/source/s?path=vector\">vector</a>&gt;"},
         };
 

--- a/test/org/opensolaris/opengrok/analysis/c/c_xrefres.html
+++ b/test/org/opensolaris/opengrok/analysis/c/c_xrefres.html
@@ -36,7 +36,7 @@ function get_sym_list(){return [["Function","xf",[["abstime_to_reltime",70],["hr
 <a class="l" name="28" href="#28">28</a><span class='fold-space'>&nbsp;</span>
 <a class="l" name="29" href="#29">29</a><span class='fold-space'>&nbsp;</span>#<b>include</b> &lt;<a href="/source/s?path=sys/">sys</a>/<a href="/source/s?path=sys/types.h">types.h</a>&gt;
 <a class="hl" name="30" href="#30">30</a><span class='fold-space'>&nbsp;</span>#<b>include</b> &lt;<a href="/source/s?path=time.h">time.h</a>&gt;
-<a class="l" name="31" href="#31">31</a><span class='fold-space'>&nbsp;</span>#<b>include</b> &lt;<a href="/source/s?path=errno.h">errno.h</a>&gt;
+<a class="l" name="31" href="#31">31</a><span class='fold-space'>&nbsp;</span>#<b>include</b> &quot;<a href="/source/s?path=errno.ext1">errno.ext1</a>&quot;
 <a class="l" name="32" href="#32">32</a><span class='fold-space'>&nbsp;</span>
 <a class="l" name="33" href="#33">33</a><span class='fold-space'>&nbsp;</span><span class="c">/*
 <a class="l" name="34" href="#34">34</a><span class='fold-space'>&nbsp;</span> * This function is blatently stolen from the kernel.

--- a/test/org/opensolaris/opengrok/analysis/c/cc_xrefres.html
+++ b/test/org/opensolaris/opengrok/analysis/c/cc_xrefres.html
@@ -37,7 +37,7 @@ function get_sym_list(){return [["Function","xf",[["Ancestor",37],["addInstance"
 <a class="l" name="29" href="#29">29</a><span class='fold-space'>&nbsp;</span>#<b>include</b> &lt;<a href="/source/s?path=stdlib.h">stdlib.h</a>&gt;
 <a class="hl" name="30" href="#30">30</a><span class='fold-space'>&nbsp;</span>#<b>include</b> &lt;<a href="/source/s?path=string.h">string.h</a>&gt;
 <a class="l" name="31" href="#31">31</a><span class='fold-space'>&nbsp;</span>
-<a class="l" name="32" href="#32">32</a><span class='fold-space'>&nbsp;</span>#<b>include</b> <span class="s">"<a href="/source/s?path=Ancestor.h">Ancestor.h</a>"</span>
+<a class="l" name="32" href="#32">32</a><span class='fold-space'>&nbsp;</span>#<b>include</b> &quot;<a href="/source/s?path=Ancestor.ext1">Ancestor.ext1</a>&quot;
 <a class="l" name="33" href="#33">33</a><span class='fold-space'>&nbsp;</span>
 <a class="l" name="34" href="#34">34</a><span class='fold-space'>&nbsp;</span><span class="c">/* ========================================================================= */</span>
 <a class="l" name="35" href="#35">35</a><span class='fold-space'>&nbsp;</span><span class="c">/* Ancestor object definitions. */</span>

--- a/test/org/opensolaris/opengrok/analysis/c/sample.c
+++ b/test/org/opensolaris/opengrok/analysis/c/sample.c
@@ -28,7 +28,7 @@
 
 #include <sys/types.h>
 #include <time.h>
-#include <errno.h>
+#include "errno.ext1"
 
 /*
  * This function is blatently stolen from the kernel.

--- a/test/org/opensolaris/opengrok/analysis/c/sample.cc
+++ b/test/org/opensolaris/opengrok/analysis/c/sample.cc
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "Ancestor.h"
+#include "Ancestor.ext1"
 
 /* ========================================================================= */
 /* Ancestor object definitions. */


### PR DESCRIPTION
Hello,

Please consider for integration this patch to fix issue #471, "Generating incorrect links for C/C++ '#include'...."

Also:
- Use Common.lexh in C[xx]SymbolTokenizer.lex.
- Make C[xx]Xref case-sensitive, revising the only affected pattern, {File}.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
