### PR TITLE
Fix to escape '*' under div#mandoc descendant combinator

### DIFF
--- a/web/default/mandoc.css
+++ b/web/default/mandoc.css
@@ -20,14 +20,14 @@ li, dt {	margin-top: 1em; }
 ========*/
 div#mandoc {	max-width: 100ex;
 		font-family: Helvetica,Arial,sans-serif; }
-table ~div#mandoc {
+div#mandoc table {
 		margin-top: 0em;
 		margin-bottom: 0em; }
-td ~div#mandoc {	vertical-align: top; }
-ul ~div#mandoc, ol ~div#mandoc, dl ~div#mandoc {
+div#mandoc td {	vertical-align: top; }
+div#mandoc ul, div#mandoc ol, div#mandoc dl {
 		margin-top: 0em;
 		margin-bottom: 0em; }
-li ~div#mandoc, dt ~div#mandoc {
+div#mandoc li, div#mandoc dt {
 		margin-top: 1em; }
 /*>>>> OPENGROK REVISED */
 
@@ -35,7 +35,11 @@ a.selflink {	border-bottom: thin dotted;
 		color: inherit;
 		font: inherit;
 		text-decoration: inherit; }
+/*<<<< OPENGROK REVISED
 * {		clear: both }
+========*/
+div#mandoc * {	clear: both }
+/*>>>> OPENGROK REVISED */
 
 /* Search form and search results. */
 


### PR DESCRIPTION
Hello,

Please consider for integration this patch to fix the CSS problem identified in issue #1876. This patch also fixes to use only descendant combinators w.r.t. div#mandoc.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
