### PR TITLE
Plugin fixes for internal deployment

### DIFF
--- a/plugins/LdapPlugin/src/opengrok/auth/plugin/LdapUserPlugin.java
+++ b/plugins/LdapPlugin/src/opengrok/auth/plugin/LdapUserPlugin.java
@@ -47,7 +47,7 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
     protected static final String OBJECT_CLASS = "objectclass";
     
     private String objectClass;
-    private Pattern usernameCnPattern = Pattern.compile("(cn=[a-zA-Z_]+)");
+    private final Pattern usernameCnPattern = Pattern.compile("(cn=[a-zA-Z0-9_-]+)");
 
     private boolean isAlphanumeric(String str) {
         for (int i = 0; i < str.length(); i++) {
@@ -124,25 +124,25 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
         String filter = getFilter(user);
         if ((records = getLdapProvider().lookupLdapContent(null, filter,
                 new String[]{"uid", "mail", "ou"})) == null) {
-            LOGGER.log(Level.FINER, "failed to get LDAP contents for user '{0}' with filter '{1}'",
+            LOGGER.log(Level.WARNING, "failed to get LDAP contents for user '{0}' with filter '{1}'",
                     new Object[]{user, filter});
             return;
         }
 
         if (records.isEmpty()) {
-            LOGGER.log(Level.FINER, "LDAP records for user {0} are empty",
+            LOGGER.log(Level.WARNING, "LDAP records for user {0} are empty",
                     user);
             return;
         }
 
         if (!records.containsKey("uid") || records.get("uid").isEmpty()) {
-            LOGGER.log(Level.FINER, "uid record for user {0} is not present or empty",
+            LOGGER.log(Level.WARNING, "uid record for user {0} is not present or empty",
                     user);
             return;
         }
 
         if (!records.containsKey("mail") || records.get("mail").isEmpty()) {
-            LOGGER.log(Level.FINER, "mail record for user {0} is not present or empty",
+            LOGGER.log(Level.WARNING, "mail record for user {0} is not present or empty",
                     user);
             return;
         }

--- a/plugins/LdapPlugin/src/opengrok/auth/plugin/LdapUserPlugin.java
+++ b/plugins/LdapPlugin/src/opengrok/auth/plugin/LdapUserPlugin.java
@@ -33,6 +33,7 @@ import opengrok.auth.entity.LdapUser;
 import opengrok.auth.plugin.entity.User;
 import org.opensolaris.opengrok.configuration.Group;
 import org.opensolaris.opengrok.configuration.Project;
+import org.opensolaris.opengrok.util.StringUtils;
 
 /**
  * Authorization plug-in to extract user's LDAP attributes.
@@ -49,17 +50,6 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
     private String objectClass;
     private final Pattern usernameCnPattern = Pattern.compile("(cn=[a-zA-Z0-9_-]+)");
 
-    private boolean isAlphanumeric(String str) {
-        for (int i = 0; i < str.length(); i++) {
-            char c = str.charAt(i);
-            if (!Character.isDigit(c) && !Character.isLetter(c)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-    
     @Override
     public void load(Map<String, Object> parameters) {
         super.load(parameters);
@@ -69,7 +59,7 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
                     "] in the setup");
         }
 
-        if (!isAlphanumeric(objectClass)) {
+        if (!StringUtils.isAlphanumeric(objectClass)) {
             throw new NullPointerException("object class '" + objectClass +
                     "' contains non-alphanumeric characters");
         }

--- a/plugins/LdapPlugin/test/opengrok/auth/plugin/LdapUserPluginTest.java
+++ b/plugins/LdapPlugin/test/opengrok/auth/plugin/LdapUserPluginTest.java
@@ -88,7 +88,7 @@ public class LdapUserPluginTest {
         String cl = "posixUser";
         params.put(LdapUserPlugin.OBJECT_CLASS, (Object) cl);
         plugin.load(params);
-        String cn = "cn=foo";
+        String cn = "cn=foo-foo_bar1";
         User user = new User(cn + ",l=EMEA,dc=foobar,dc=com", "id", null, false);
         String filter = plugin.getFilter(user);
         Assert.assertEquals("(&(" + LdapUserPlugin.OBJECT_CLASS + "=" + cl + ")(" + cn + "))",

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -17,7 +17,7 @@ In general, it should be possible to increase log level in Tomcat's
 ### UserPlugin
 
 Has a special property called "fake" that allows to insert custom headers
-with the "my-" prefix that would be evaluated instead of the usual SSO headers.
+with the "fake-" prefix that would be evaluated instead of the usual SSO headers.
 
 Header insertion can be done e.g. using the Modify headers Firefox plugin.
 

--- a/plugins/UserPlugin/src/opengrok/auth/plugin/decoders/FakeOSSOHeaderDecoder.java
+++ b/plugins/UserPlugin/src/opengrok/auth/plugin/decoders/FakeOSSOHeaderDecoder.java
@@ -23,20 +23,22 @@
 package opengrok.auth.plugin.decoders;
 
 /**
- * Almost like @{code OSSOHeaderDecoder} however uses HTTP headers with
- * the "my-" prefix which allows for custom header insertion.
+ * Almost like @{code OSSOHeaderDecoder} however uses OSSO HTTP headers with
+ * prefix which allows for custom header insertion.
  * This class should therefore only be used for debugging.
  *
  * @author Krystof Tulinger
  */
 public class FakeOSSOHeaderDecoder extends OSSOHeaderDecoder {
 
+    private final String PREFIX = "fake-";
+    
     public FakeOSSOHeaderDecoder() {
-        OSSO_COOKIE_TIMESTAMP_HEADER = "my-osso-cookie-timestamp";
-        OSSO_TIMEOUT_EXCEEDED_HEADER = "my-osso-idle-timeout-exceeded";
-        OSSO_SUBSCRIBER_DN_HEADER = "my-osso-subscriber-dn";
-        OSSO_SUBSCRIBER_HEADER = "my-osso-subscriber";
-        OSSO_USER_DN_HEADER = "my-osso-user-dn";
-        OSSO_USER_GUID_HEADER = "my-osso-user-guid";
+        OSSO_COOKIE_TIMESTAMP_HEADER = PREFIX + OSSOHeaderDecoder.OSSO_COOKIE_TIMESTAMP_HEADER;
+        OSSO_TIMEOUT_EXCEEDED_HEADER = PREFIX + OSSOHeaderDecoder.OSSO_TIMEOUT_EXCEEDED_HEADER;
+        OSSO_SUBSCRIBER_DN_HEADER = PREFIX + OSSOHeaderDecoder.OSSO_SUBSCRIBER_DN_HEADER;
+        OSSO_SUBSCRIBER_HEADER = PREFIX + OSSOHeaderDecoder.OSSO_SUBSCRIBER_HEADER;
+        OSSO_USER_DN_HEADER = PREFIX + OSSOHeaderDecoder.OSSO_USER_DN_HEADER;
+        OSSO_USER_GUID_HEADER = PREFIX + OSSOHeaderDecoder.OSSO_USER_GUID_HEADER;
     }
 }

--- a/src/org/opensolaris/opengrok/util/StringUtils.java
+++ b/src/org/opensolaris/opengrok/util/StringUtils.java
@@ -225,4 +225,20 @@ public final class StringUtils {
         }
         return n;
     }
+    
+    /**
+     * Find out if string contains only alphanumeric characters.
+     * @param str string to check
+     * @return {@code true} if the string is alphanumeric, {@code false} otherwise
+     */
+    public static boolean isAlphanumeric(String str) {
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            if (!Character.isDigit(c) && !Character.isLetter(c)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/test/org/opensolaris/opengrok/util/StringUtilsTest.java
+++ b/test/org/opensolaris/opengrok/util/StringUtilsTest.java
@@ -17,11 +17,12 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.util;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -128,5 +129,11 @@ public class StringUtilsTest {
         String uri = "";
         int n = StringUtils.countURIEndingPushback(uri);
         assertEquals("empty pushback", 0, n);
+    }
+    
+    @Test
+    public void testIsAlphanumeric() {
+        Assert.assertTrue(StringUtils.isAlphanumeric("foo123"));
+        Assert.assertFalse(StringUtils.isAlphanumeric("foo_123"));
     }
 }


### PR DESCRIPTION
- Looks like the regexp used in `LdapUser` plugin is too strict so I relaxed it a bit.
- the fake OSSO header decoder could be initialized better + make the fake nature more prominent by using `fake-` prefix