### PR TITLE
bugfix: #1810 Keyboard shortcuts are active when typing into search b…

### DIFF
--- a/web/js/diff-0.0.2.js
+++ b/web/js/diff-0.0.2.js
@@ -17,6 +17,8 @@
  * CDDL HEADER END
  */
 
+/* global textInputHasFocus */
+
 /*
  * Copyright (c) 2016, 2017 Oracle and/or its affiliates. All rights reserved.
  */
@@ -124,6 +126,9 @@
                 load: function ($window) {
                     var that = this
                     $(document).keypress(function (e) {
+                        if (textInputHasFocus()) {
+                            return true;
+                        }
                         var key = e.keyCode || e.which
                         switch (key) {
                             case 110: // n

--- a/web/js/utils-0.0.18.js
+++ b/web/js/utils-0.0.18.js
@@ -846,6 +846,9 @@
                 load: function ($window) {
                     var that = this;
                     $(document).keypress(function (e) {
+                        if (textInputHasFocus()) {
+                            return true;
+                        }
                         var key = e.which;
                         switch (key) {
                             case 49: // 1
@@ -1953,13 +1956,14 @@ function isOnSearchPage() {
  */
 function searchSubmit(form) {
     var submitInitiator = '';
-    if (document.activeElement && document.activeElement.nodeName === 'INPUT') {
+    if (textInputHasFocus()) {
         submitInitiator = document.activeElement.getAttribute('id');
     }
     if (submitInitiator) {
         var input = document.createElement('INPUT');
         input.setAttribute('name', 'si');
         input.value = submitInitiator;
+        input.type = 'hidden';
         form.appendChild(input);
     }
 }
@@ -1979,4 +1983,13 @@ function restoreFocusAfterSearchSubmit() {
             $input.focus();
         }
     }
+}
+
+/**
+ * @return {boolean} true if focus is on a input[type=text] element
+ */
+function textInputHasFocus() {
+    return !!document.activeElement &&
+        document.activeElement.nodeName === 'INPUT' &&
+        document.activeElement.type === 'text';
 }


### PR DESCRIPTION
>bugfix: #1810 Keyboard shortcuts are active when typing into search box + type=hidden for input created in searchSubmit as it sometimes is visible in new Chromium before actual form submission.

Because of global (document level) keypress hooks defined in the _Diff jumper_ it is impossible to write `n` or `b` in the _Search_ input on any /diff/ page.
Both `prevHandler` and `nextHandler` call Event#preventDefault which disables keyboard event propagation.

A bit simillar problem occurs in _Intelligence window_ hooks for `1`-`5`, `n` and `b` keys.
There is no #preventDefault call, so it is possible to write those characters, but pressing keys while typing in the Search input triggers both _Intelligence window_ hook and text field modification. This is not a proper UI behaviour:
![peek 2017-11-18 20-16](https://user-images.githubusercontent.com/2456881/33089253-50422586-cef0-11e7-81e8-d7f94f5c574e.gif)

Intentionally I have not updated utils-0.0.18.js version number as it would introduce conflict with PR https://github.com/OpenGrok/OpenGrok/pull/1883.

Resolves #1810.

I accept OCA for this fix.