### PR TITLE
Issue #1896 : remove INC as a default Fortran suffix

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/fortran/FortranAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/fortran/FortranAnalyzerFactory.java
@@ -19,7 +19,9 @@
 
 /*
  * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
+
 package org.opensolaris.opengrok.analysis.fortran;
 
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
@@ -29,11 +31,27 @@ import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 public class FortranAnalyzerFactory extends FileAnalyzerFactory {
 
     private static final String name = "Fortran";
-    
+
+    /**
+     * Includes Fortran free-form extension F90 and its successors, per
+     * "Fortran"¹: F95, F03, F08, F15.
+     * <p>
+     * "Intel® Fortran Compiler -- effect of file extensions on source form"
+     * enumerates "F", "FTN", and "FOR" as "Fortran fixed-form source" -- which
+     * is not specifically handled by {@link FortranAnalyzer} -- but "F" is
+     * also kept as an originally-supported suffix.
+     * <p>
+     * ¹https://en.wikipedia.org/wiki/Fortran, Wikipedia, Creative Commons
+     * Attribution-ShareAlike 3.0,
+     * https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License
+     */    
     private static final String[] SUFFIXES = {
         "F",
         "F90",
-        "INC",};
+        "F95",
+        "F03",
+        "F08",
+        "F15"};
      
     public FortranAnalyzerFactory() {
         super(null, null, SUFFIXES, null, null, "text/plain", Genre.PLAIN, name);


### PR DESCRIPTION
Hello,

Please consider for integration this patch to revise the FortranAnalyzerFactory suffixes: remove INC and add free-form suffixes subsequent to F90.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
