### PR TITLE
Also recognize .markdown README

### DIFF
--- a/web/list.jsp
+++ b/web/list.jsp
@@ -19,8 +19,8 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
-
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
 
 --%>
 <%@page errorPage="error.jsp" import="
@@ -123,7 +123,8 @@ document.pageReady.push(function() { pageReadyList();});
                 }
 %>
 <%
-    if (readMes.get(i).toLowerCase().endsWith(".md")) {
+    String lcName = readMes.get(i).toLowerCase();
+    if (lcName.endsWith(".md") || lcName.endsWith(".markdown")) {
     %><div id="src<%=i%>" data-markdown>
         <div class="markdown-heading">
             <h3><%= readMes.get(i) %></h3>


### PR DESCRIPTION
Hello,

Please consider for integration this patch to also recognize a ".markdown" suffix for READMEs.

E.g., https://github.com/jekyll/jekyll

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
