### PR TITLE
Feature/reuse htmlize

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/JFlexXref.java
+++ b/src/org/opensolaris/opengrok/analysis/JFlexXref.java
@@ -575,9 +575,7 @@ public abstract class JFlexXref extends JFlexStateStacker {
      * @return String with escaped html characters
      */
     protected String htmlize(String raw) {
-        return raw.replace("&", "&amp;").replace("<", "&lt;")
-                .replace(">", "&gt;").replace("\"", "&quot;")
-                .replace("'", "&apos;");
+        return Util.prehtmlize(raw);
     }
 
     /**

--- a/src/org/opensolaris/opengrok/search/Results.java
+++ b/src/org/opensolaris/opengrok/search/Results.java
@@ -19,9 +19,10 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- *
  * Portions Copyright 2011 Jens Elkner.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
+
 package org.opensolaris.opengrok.search;
 
 import java.io.BufferedReader;
@@ -165,11 +166,11 @@ public final class Results {
             out.write(xrefPrefixE);
             out.write(Util.URIEncodePath(parent));
             out.write("/\">");
-            out.write(parent); // htmlize ???
+            out.write(htmlize(parent));
             out.write("/</a>");
             if (sh.desc != null) {
                 out.write(" - <i>");
-                out.write(sh.desc.get(parent)); // htmlize ???
+                out.write(htmlize(sh.desc.get(parent)));
                 out.write("</i>");
             }
             JSONArray messages;
@@ -208,7 +209,7 @@ public final class Results {
                     }
                 }
                 out.write(">");
-                out.write(rpath.substring(rpath.lastIndexOf('/') + 1)); // htmlize ???
+                out.write(htmlize(rpath.substring(rpath.lastIndexOf('/') + 1)));
                 out.write("</a>");
                 out.write("</td><td><tt class=\"con\">");
                 if (sh.sourceContext != null) {
@@ -250,5 +251,9 @@ public final class Results {
                 out.write("</tt></td></tr>\n");
             }
         }
+    }
+
+    private static String htmlize(String raw) {
+        return Util.htmlize(raw);
     }
 }

--- a/src/org/opensolaris/opengrok/search/Summary.java
+++ b/src/org/opensolaris/opengrok/search/Summary.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2005 The Apache Software Foundation
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,26 +18,13 @@ package org.opensolaris.opengrok.search;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.opensolaris.opengrok.web.Util;
 
 /** A document summary dynamically generated to match a query. */
 public class Summary {
 
-    public static String htmlize(String q) {
-        StringBuilder sb = new StringBuilder(q.length() * 2);
-        char c;
-        for(int i=0; i < q.length() ; i++) {
-            c = q.charAt(i);
-            if (c == '&') {
-                sb.append("&amp;");
-            } else if(c == '>') {
-                sb.append("&gt;");
-            } else if(c == '<') {
-                sb.append("&lt;");
-            } else {
-                sb.append(c);
-            }
-        }
-        return sb.toString();
+    protected static String htmlize(String q) {
+        return Util.prehtmlize(q);
     }
 
     /** A fragment of text within a summary. */

--- a/test/org/opensolaris/opengrok/analysis/python/sample_xref.html
+++ b/test/org/opensolaris/opengrok/analysis/python/sample_xref.html
@@ -157,6 +157,6 @@ function get_sym_list(){return [["Variable","xv",[["char",121],["char_dict",93],
 <a class="l" name="149" href="#149">149</a>    <a class="d intelliWindow-symbol" href="#f" data-definition-place="defined-in-file">f</a>.<a href="/source/s?defs=writelines" class="intelliWindow-symbol" data-definition-place="undefined-in-file">writelines</a>(<a class="d intelliWindow-symbol" href="#text" data-definition-place="defined-in-file">text</a>)
 <a class="hl" name="150" href="#150">150</a>    <a class="d intelliWindow-symbol" href="#f" data-definition-place="defined-in-file">f</a>.<a href="/source/s?defs=close" class="intelliWindow-symbol" data-definition-place="undefined-in-file">close</a>()
 <a class="l" name="151" href="#151">151</a><b>print</b>(<span class="s">&apos;<a href="http://example.com?a=">http://example.com?a=</a>&apos;</span>)
-<a class="l" name="152" href="#152">152</a><b>print</b>(<span class="s">&apos;&apos;&apos;<a href="http://example.com?a='b'&amp;">http://example.com?a='b'&amp;</a>&apos;&apos;&apos;</span>)
+<a class="l" name="152" href="#152">152</a><b>print</b>(<span class="s">&apos;&apos;&apos;<a href="http://example.com?a='b'&amp;">http://example.com?a=&apos;b&apos;&amp;</a>&apos;&apos;&apos;</span>)
 <a class="l" name="153" href="#153">153</a></body>
 </html>

--- a/test/org/opensolaris/opengrok/web/UtilTest.java
+++ b/test/org/opensolaris/opengrok/web/UtilTest.java
@@ -19,7 +19,9 @@
 
  /*
  * Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
+
 package org.opensolaris.opengrok.web;
 
 import java.io.ByteArrayInputStream;
@@ -211,19 +213,19 @@ public class UtilTest {
                 "\"(ses_id, mer_id, pass_id, \" + refCol +\" , mer_ref, amnt, "
                 + "cur, ps_id, ret_url, exp_url, d_req_time, d_req_mil, "
                 + "h_resp_time, h_resp_mil) \"",
-                "\"(ses_id, mer_id, pass_id, \" + refCol +\" , mer_ref, amnt, "
+                "&quot;(ses_id, mer_id, pass_id, &quot; + refCol +&quot; , mer_ref, amnt, "
                 + "cur, ps_id, ret_url, d_req_time, d_req_mil, h_resp_time, "
-                + "h_resp_mil) \"",
-                "\"(ses_id, mer_id, pass_id, \" + refCol +\" , mer_ref, amnt, "
+                + "h_resp_mil) &quot;",
+                "&quot;(ses_id, mer_id, pass_id, &quot; + refCol +&quot; , mer_ref, amnt, "
                 + "cur, ps_id, ret_url, <span class=\"a\">exp_url, "
-                + "</span>d_req_time, d_req_mil, h_resp_time, h_resp_mil) \""
+                + "</span>d_req_time, d_req_mil, h_resp_time, h_resp_mil) &quot;"
             },
             {
                 "\"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\", values);",
                 "\"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\", values);",
-                "\"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\", values);",
-                "\"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?<span "
-                + "class=\"a\">, ?</span>)\", values);"
+                "&quot;VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)&quot;, values);",
+                "&quot;VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?<span "
+                + "class=\"a\">, ?</span>)&quot;, values);"
             },
             {
                 "char    *config_list = NULL;",


### PR DESCRIPTION
Hello,

Please consider for integration this patch to condense the disparate htmlize() implementations.

- Add Util.prehtmlize() for the mode which an Xref might need.
- Otherwise, update the Util method to also quote &amp;quot; and &amp;apos;, and update users and tests. Util.diffline() is updated to htmlize() all output -- not just when different.
- Update search/Results to htmlize() where comments had questioned "htmlize ???" — that does seem the correct handling there.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
