### PR TITLE
Add Ruby magics and path-less magic for Escript, Perl, PHP, Python

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.csharp;
@@ -35,11 +36,8 @@ public class CSharpAnalyzerFactory extends FileAnalyzerFactory {
         "CS"
     };
 
-    private static final String[] MAGICS = {
-    };
-
     public CSharpAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, "text/plain", Genre.PLAIN, name);
+        super(null, null, SUFFIXES, null, null, "text/plain", Genre.PLAIN, name);
     }
 
     @Override

--- a/src/org/opensolaris/opengrok/analysis/erlang/ErlangAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/erlang/ErlangAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.erlang;
@@ -35,7 +36,8 @@ public class ErlangAnalyzerFactory extends FileAnalyzerFactory {
         "ERL", "HRL", "ESCRIPT"
     };
     private static final String[] MAGICS = {
-        "#!/usr/bin/env escript"
+        "#!/usr/bin/env escript",
+        "#!escript"
     };
 
     public ErlangAnalyzerFactory() {

--- a/src/org/opensolaris/opengrok/analysis/haskell/HaskellAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/haskell/HaskellAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.haskell;
@@ -39,11 +40,9 @@ public class HaskellAnalyzerFactory extends FileAnalyzerFactory {
         "HS",
         "HSC"
     };
-    private static final String[] MAGICS = {
-    };
     
     public HaskellAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, "text/plain", Genre.PLAIN, name);
+        super(null, null, SUFFIXES, null, null, "text/plain", Genre.PLAIN, name);
     }
 
     @Override

--- a/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.javascript;
@@ -36,11 +37,8 @@ public class JavaScriptAnalyzerFactory extends FileAnalyzerFactory {
         "TS"
     };
 
-    private static final String[] MAGICS = {    
-    };
-
     public JavaScriptAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, "text/plain", Genre.PLAIN, name);
+        super(null, null, SUFFIXES, null, null, "text/plain", Genre.PLAIN, name);
     }
 
     @Override

--- a/src/org/opensolaris/opengrok/analysis/json/JsonAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/json/JsonAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.json;
@@ -35,11 +36,8 @@ public class JsonAnalyzerFactory extends FileAnalyzerFactory {
         "JSON"        
     };
 
-    private static final String[] MAGICS = {    
-    };
-
     public JsonAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, "text/plain", Genre.PLAIN, name);
+        super(null, null, SUFFIXES, null, null, "text/plain", Genre.PLAIN, name);
     }
 
     @Override

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlAnalyzerFactory.java
@@ -48,7 +48,8 @@ public class PerlAnalyzerFactory extends FileAnalyzerFactory {
         "#!/usr/bin/env perl",
         "#!/usr/bin/perl",
         "#!/usr/local/bin/perl",
-        "#!/bin/perl"
+        "#!/bin/perl",
+        "#!perl",
     };
 
     public PerlAnalyzerFactory() {

--- a/src/org/opensolaris/opengrok/analysis/php/PhpAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/php/PhpAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.php;
@@ -41,7 +42,8 @@ public class PhpAnalyzerFactory extends FileAnalyzerFactory {
     private static final String[] MAGICS = {
         "#!/usr/bin/env php",
         "#!/usr/bin/php",
-        "#!/bin/php"
+        "#!/bin/php",
+        "#!php"
     };
 
     public PhpAnalyzerFactory() {

--- a/src/org/opensolaris/opengrok/analysis/python/PythonAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/python/PythonAnalyzerFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.python;
@@ -45,7 +46,8 @@ public class PythonAnalyzerFactory extends FileAnalyzerFactory {
     private static final String[] MAGICS = {
         "#!/usr/bin/env python",
         "#!/usr/bin/python",
-        "#!/bin/python"
+        "#!/bin/python",
+        "#!python"
     };
 
     public PythonAnalyzerFactory() {

--- a/src/org/opensolaris/opengrok/analysis/ruby/RubyAnalyzerFactory.java
+++ b/src/org/opensolaris/opengrok/analysis/ruby/RubyAnalyzerFactory.java
@@ -40,12 +40,20 @@ public class RubyAnalyzerFactory extends FileAnalyzerFactory {
         "RB",
         "RUBY"
     };
+    private static final String[] MAGICS = {
+        "#!/usr/bin/env ruby",
+        "#!/usr/bin/ruby",
+        "#!/usr/local/bin/ruby",
+        "#!/bin/ruby",
+        "#!ruby",
+    };
 
     /**
      * Creates a new instance of {@link RubyAnalyzerFactory}.
      */
     public RubyAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", Genre.PLAIN, name);
+        super(null, null, SUFFIXES, MAGICS, null, "text/plain", Genre.PLAIN,
+            name);
     }
 
     /**


### PR DESCRIPTION
Hello,

Please consider for integration this patch to add Ruby magics and path-less magic for Escript, Perl, PHP, and Python, which is seen in some unit test files for those languages. Also the patch removes empty MAGICS for e.g. CSharp, Haskell, etc.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
