### PR TITLE
Avoid two SEVERE log messages for normal startup,stop events

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -39,6 +39,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.FileSystems;
@@ -1620,10 +1621,17 @@ public final class RuntimeEnvironment {
      * @throws ParseException
      */
     public void loadStatistics() throws IOException, ParseException {
-        if (getConfiguration().getStatisticsFilePath() == null) {
+        String statsPath = getConfiguration().getStatisticsFilePath();
+        if (statsPath == null) {
             throw new FileNotFoundException("Statistics file is not set (null)");
         }
-        loadStatistics(new File(getConfiguration().getStatisticsFilePath()));
+        File statsFile = new File(statsPath);
+        if (statsFile.exists()) {
+            loadStatistics(statsFile);
+        } else {
+            LOGGER.log(Level.INFO, "Statistics file does not exist: {0}",
+                statsPath);
+        }
     }
 
     /**
@@ -1635,7 +1643,7 @@ public final class RuntimeEnvironment {
      */
     public void loadStatistics(File in) throws IOException, ParseException {
         if (in == null) {
-            throw new FileNotFoundException("Statistics file is not set (null)");
+            throw new IllegalArgumentException("`in' is null");
         }
         try (FileInputStream ifstream = new FileInputStream(in)) {
             loadStatistics(ifstream);
@@ -1819,6 +1827,9 @@ public final class RuntimeEnvironment {
                                 Message m = ((Message) obj);
                                 handleMessage(m, output);
                             }
+                        } catch (SocketException e) {
+                            LOGGER.log(Level.FINE, "SocketException: {0}",
+                                e.getMessage());
                         } catch (IOException e) {
                             LOGGER.log(Level.SEVERE, "Error reading config file: ", e);
                         } catch (RuntimeException e) {
@@ -1973,7 +1984,7 @@ public final class RuntimeEnvironment {
                 LOGGER.log(Level.WARNING, "Cannot join WatchDogService thread: ", ex);
             }
         }
-        LOGGER.log(Level.INFO, "Watchdog stoped");
+        LOGGER.log(Level.INFO, "Watchdog stopped");
     }
 
     public void startExpirationTimer() {

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -1828,7 +1828,7 @@ public final class RuntimeEnvironment {
                                 handleMessage(m, output);
                             }
                         } catch (SocketException e) {
-                            LOGGER.log(Level.FINE, "SocketException: {0}",
+                            LOGGER.log(Level.INFO, "SocketException: {0}",
                                 e.getMessage());
                         } catch (IOException e) {
                             LOGGER.log(Level.SEVERE, "Error reading config file: ", e);

--- a/src/org/opensolaris/opengrok/configuration/messages/StatsMessage.java
+++ b/src/org/opensolaris/opengrok/configuration/messages/StatsMessage.java
@@ -17,11 +17,13 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.configuration.messages;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -39,11 +41,38 @@ public class StatsMessage extends Message {
 
     static final List<String> ALLOWED_OPTIONS = Arrays.asList(new String[]{"get", "reload", "clean"});
 
+    private String statisticsFilePath;
+
+    /**
+     * @return the statisticsFilePath
+     */
+    public String getStatisticsFilePath() {
+        return statisticsFilePath;
+    }
+
+    /**
+     * Sets the statisticsFilePath
+     * @param path a defined value or null
+     */
+    public void setStatisticsFilePath(String path) {
+        this.statisticsFilePath = path;
+    }
+
     @Override
     protected byte[] applyMessage(RuntimeEnvironment env) throws IOException, ParseException {
+        String statsFilePath = getStatisticsFilePath();
+
         if (getText().equalsIgnoreCase("reload")) {
-            env.loadStatistics();
+            if (statsFilePath != null) {
+                env.loadStatistics(new File(statsFilePath));
+                env.getConfiguration().setStatisticsFilePath(statsFilePath);
+            } else {
+                env.loadStatistics();
+            }
         } else if (getText().equalsIgnoreCase("clean")) {
+            if (statsFilePath != null) {
+                env.getConfiguration().setStatisticsFilePath(statsFilePath);
+            }
             env.setStatistics(new Statistics());
         }
         return Util.statisticToJson(env.getStatistics()).toJSONString().getBytes();

--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -1059,7 +1059,7 @@ public class RuntimeEnvironmentTest {
         RuntimeEnvironment.getInstance().loadStatistics();
     }
 
-    @Test(expected = IOException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testLoadNullStatisticsFile() throws IOException, ParseException {
         RuntimeEnvironment.getInstance().loadStatistics((File) null);
     }

--- a/test/org/opensolaris/opengrok/configuration/messages/StatsMessageTest.java
+++ b/test/org/opensolaris/opengrok/configuration/messages/StatsMessageTest.java
@@ -17,11 +17,13 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.configuration.messages;
 
+import java.io.IOException;
 import java.util.TreeSet;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -151,15 +153,17 @@ public class StatsMessageTest {
     }
 
     @Test
-    public void testInvalidReload() {
-        Message m = new StatsMessage();
+    public void testInvalidReload() throws Exception {
+        StatsMessage m = new StatsMessage();
         m.setText("reload");
-        env.getConfiguration().setStatisticsFilePath("/file/that/doesnot/exists");
+        m.setStatisticsFilePath("/file/that/doesnot/exists");
 
+        IOException expex = null;
         try {
             m.apply(env);
-            Assert.fail("Should throw an exception");
-        } catch (Exception ex) {
+        } catch (IOException ex) {
+            expex = ex;
         }
+        Assert.assertNotNull("Should throw an IOException", expex);
     }
 }


### PR DESCRIPTION
Hello,

Please consider for integration this patch to avoid two spurious SEVERE log messages on startup when data/ is empty, or upon stop.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
