### PR TITLE
Plugins session invalidate

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1101,7 +1101,7 @@ Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
     </target>
 
     <!-- Build the plugins. -->
-    <target name="plugins" depends="jar">
+    <target name="plugins" depends="jar" description="create jar of all authorization plugins for distribution">
         <mkdir dir="${build.dir}/plugins"/>
         <javac srcdir="plugins/"
                destdir="${build.dir}/plugins"

--- a/plugins/LdapPlugin/src/opengrok/auth/plugin/AbstractLdapPlugin.java
+++ b/plugins/LdapPlugin/src/opengrok/auth/plugin/AbstractLdapPlugin.java
@@ -32,11 +32,9 @@ import opengrok.auth.plugin.entity.User;
 import opengrok.auth.plugin.ldap.AbstractLdapProvider;
 import opengrok.auth.plugin.ldap.FakeLdapFacade;
 import opengrok.auth.plugin.ldap.LdapFacade;
-import org.opensolaris.opengrok.authorization.AuthorizationFramework;
 import org.opensolaris.opengrok.authorization.IAuthorizationPlugin;
 import org.opensolaris.opengrok.configuration.Group;
 import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 
 /**
  * Abstract class for all plug-ins working with LDAP. Takes care of

--- a/plugins/LdapPlugin/src/opengrok/auth/plugin/AbstractLdapPlugin.java
+++ b/plugins/LdapPlugin/src/opengrok/auth/plugin/AbstractLdapPlugin.java
@@ -32,6 +32,7 @@ import opengrok.auth.plugin.entity.User;
 import opengrok.auth.plugin.ldap.AbstractLdapProvider;
 import opengrok.auth.plugin.ldap.FakeLdapFacade;
 import opengrok.auth.plugin.ldap.LdapFacade;
+import org.opensolaris.opengrok.authorization.AuthorizationFramework;
 import org.opensolaris.opengrok.authorization.IAuthorizationPlugin;
 import org.opensolaris.opengrok.configuration.Group;
 import org.opensolaris.opengrok.configuration.Project;
@@ -42,7 +43,6 @@ import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
  * <ul>
  * <li>controlling the established session</li>
  * <li>controlling if the session belongs to the user</li>
- * <li>controlling plug-in version</li>
  * </ul>
  *
  * <p>
@@ -63,9 +63,9 @@ abstract public class AbstractLdapPlugin implements IAuthorizationPlugin {
     protected static final String CONFIGURATION_PARAM = "configuration";
     protected static final String FAKE_PARAM = "fake";
 
-    protected String SESSION_USERNAME = "opengrok-group-plugin-username";
-    protected String SESSION_ESTABLISHED = "opengrok-group-plugin-session-established";
-    protected String SESSION_VERSION = "opengrok-group-plugin-session-version";
+    private final static String SESSION_PREFIX = "opengrok-abstract-ldap-plugin-";
+    protected String SESSION_USERNAME = SESSION_PREFIX + "username";
+    protected String SESSION_ESTABLISHED = SESSION_PREFIX + "session-established";
 
     /**
      * Configuration for the LDAP servers.
@@ -86,7 +86,6 @@ abstract public class AbstractLdapPlugin implements IAuthorizationPlugin {
     public AbstractLdapPlugin() {
         SESSION_USERNAME += "-" + nextId;
         SESSION_ESTABLISHED += "-" + nextId;
-        SESSION_VERSION += "-" + nextId;
         nextId++;
     }
 
@@ -197,11 +196,8 @@ abstract public class AbstractLdapPlugin implements IAuthorizationPlugin {
      * @return true if it does; false otherwise
      */
     protected boolean isSameUser(String sessionUsername, String authUser) {
-        if (sessionUsername != null
-                && sessionUsername.equals(authUser)) {
-            return true;
-        }
-        return false;
+        return sessionUsername != null
+                && sessionUsername.equals(authUser);
     }
 
     /**
@@ -214,7 +210,6 @@ abstract public class AbstractLdapPlugin implements IAuthorizationPlugin {
     protected boolean sessionExists(HttpServletRequest req) {
         return req != null && req.getSession() != null
                 && req.getSession().getAttribute(SESSION_ESTABLISHED) != null
-                && req.getSession().getAttribute(SESSION_VERSION) != null
                 && req.getSession().getAttribute(SESSION_USERNAME) != null;
     }
 
@@ -234,13 +229,16 @@ abstract public class AbstractLdapPlugin implements IAuthorizationPlugin {
     @SuppressWarnings("unchecked")
     private void ensureSessionExists(HttpServletRequest req) {
         User user;
+        
         if (req.getSession() == null) {
             // old/invalid request (should not happen)
             return;
         }
-
+        
+        // The cast to User should not be problem as this object is stored
+        // in the request itself (as opposed to in the session).
         if ((user = (User) req.getAttribute(UserPlugin.REQUEST_ATTR)) == null) {
-            updateSession(req, null, false, getPluginVersion());
+            updateSession(req, null, false);
             return;
         }
 
@@ -248,9 +246,7 @@ abstract public class AbstractLdapPlugin implements IAuthorizationPlugin {
                 // we've already filled the groups and projects
                 && (boolean) req.getSession().getAttribute(SESSION_ESTABLISHED)
                 // the session belongs to the user from the request
-                && isSameUser((String) req.getSession().getAttribute(SESSION_USERNAME), user.getUsername())
-                // and this is not a case when we want to renew all sessions
-                && !isSessionInvalidated(req)) {
+                && isSameUser((String) req.getSession().getAttribute(SESSION_USERNAME), user.getUsername())) {
             /**
              * The session is already filled so no need to
              * {@link #updateSession()}
@@ -258,7 +254,7 @@ abstract public class AbstractLdapPlugin implements IAuthorizationPlugin {
             return;
         }
 
-        updateSession(req, user.getUsername(), false, getPluginVersion());
+        updateSession(req, user.getUsername(), false);
 
         if (ldap == null) {
             return;
@@ -266,7 +262,7 @@ abstract public class AbstractLdapPlugin implements IAuthorizationPlugin {
 
         fillSession(req, user);
 
-        updateSession(req, user.getUsername(), true, getPluginVersion());
+        updateSession(req, user.getUsername(), true);
     }
 
     /**
@@ -275,44 +271,12 @@ abstract public class AbstractLdapPlugin implements IAuthorizationPlugin {
      * @param req the request
      * @param username new username
      * @param established new value for established
-     * @param sessionV new value for session version
      */
     protected void updateSession(HttpServletRequest req,
             String username,
-            boolean established,
-            int sessionV) {
+            boolean established) {
         setSessionEstablished(req, established);
         setSessionUsername(req, username);
-        setSessionVersion(req, sessionV);
-    }
-
-    /**
-     * Is this session marked as invalid?
-     *
-     * @param req the request
-     * @return true if it is; false otherwise
-     */
-    protected boolean isSessionInvalidated(HttpServletRequest req) {
-        Integer version;
-        if ((version = (Integer) req.getAttribute(SESSION_VERSION)) != null) {
-            return version != getPluginVersion();
-        }
-        if ((version = (Integer) req.getSession().getAttribute(SESSION_VERSION)) != null) {
-            req.setAttribute(SESSION_VERSION, version);
-            return version != getPluginVersion();
-        }
-        return true;
-    }
-
-    /**
-     * Set session version into the session.
-     *
-     * @param req request containing the session
-     * @param value the value
-     */
-    protected void setSessionVersion(HttpServletRequest req, Integer value) {
-        req.getSession().setAttribute(SESSION_VERSION, value);
-        req.setAttribute(SESSION_VERSION, value);
     }
 
     /**
@@ -333,15 +297,6 @@ abstract public class AbstractLdapPlugin implements IAuthorizationPlugin {
      */
     protected void setSessionUsername(HttpServletRequest req, String value) {
         req.getSession().setAttribute(SESSION_USERNAME, value);
-    }
-
-    /**
-     * Return the current plug-in version tracked by the authorization framework.
-     *
-     * @return the version
-     */
-    protected static int getPluginVersion() {
-        return RuntimeEnvironment.getInstance().getPluginVersion();
     }
 
     @Override

--- a/plugins/LdapPlugin/src/opengrok/auth/plugin/LdapAttrPlugin.java
+++ b/plugins/LdapPlugin/src/opengrok/auth/plugin/LdapAttrPlugin.java
@@ -127,7 +127,7 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
     protected void updateSession(HttpServletRequest req, boolean allowed) {
         req.getSession().setAttribute(SESSION_ALLOWED, allowed);
     }
-
+    
     @Override
     public boolean checkEntity(HttpServletRequest request, Project project) {
         return ((Boolean) request.getSession().getAttribute(SESSION_ALLOWED));

--- a/plugins/LdapPlugin/test/opengrok/auth/plugin/LdapAttrPluginTest.java
+++ b/plugins/LdapPlugin/test/opengrok/auth/plugin/LdapAttrPluginTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import opengrok.auth.entity.LdapUser;
 import opengrok.auth.plugin.entity.User;
 import opengrok.auth.plugin.util.DummyHttpServletRequestLdap;
@@ -45,7 +46,7 @@ import org.opensolaris.opengrok.authorization.AuthorizationFramework;
 import org.opensolaris.opengrok.configuration.Group;
 import org.opensolaris.opengrok.configuration.Project;
 
-public class LdapAttrTest {
+public class LdapAttrPluginTest {
 
     private HttpServletRequest dummyRequest;
     private LdapAttrPlugin plugin;
@@ -80,7 +81,6 @@ public class LdapAttrTest {
         plugin.load(parameters);
 
         framework = new AuthorizationFramework(null);
-        framework.setPluginVersion(1);
     }
 
     private void prepareRequest(String username, String mail, String... ous) {
@@ -90,7 +90,6 @@ public class LdapAttrTest {
                 new TreeSet<>(Arrays.asList(ous))));
         plugin.setSessionEstablished(dummyRequest, true);
         plugin.setSessionUsername(dummyRequest, username);
-        plugin.setSessionVersion(dummyRequest, 1);
     }
 
     private Project makeProject(String name) {
@@ -136,36 +135,6 @@ public class LdapAttrTest {
 
         prepareRequest("00A", "random@email.com", "MI6", "MI7");
 
-        Assert.assertTrue(plugin.isAllowed(dummyRequest, makeProject("Random Project")));
-        Assert.assertTrue(plugin.isAllowed(dummyRequest, makeProject("Project 1")));
-        Assert.assertTrue(plugin.isAllowed(dummyRequest, makeGroup("Group 1")));
-        Assert.assertTrue(plugin.isAllowed(dummyRequest, makeGroup("Group 2")));
-
-    }
-
-    @Test
-    public void testInvalidateSession() {
-        /**
-         * whitelist[mail] => [james@bond.com, random@email.com, just_a_text]
-         */
-        prepareRequest("007", "james@bond.com", "MI6", "MI7");
-        
-        Assert.assertTrue(plugin.isAllowed(dummyRequest, makeProject("Random Project")));
-        Assert.assertTrue(plugin.isAllowed(dummyRequest, makeProject("Project 1")));
-        Assert.assertTrue(plugin.isAllowed(dummyRequest, makeGroup("Group 1")));
-        Assert.assertTrue(plugin.isAllowed(dummyRequest, makeGroup("Group 2")));
-
-        framework.increasePluginVersion();
-        prepareRequest("007", "james@bond.com", "MI6", "MI7");
-
-        Assert.assertTrue(plugin.isAllowed(dummyRequest, makeProject("Random Project")));
-        Assert.assertTrue(plugin.isAllowed(dummyRequest, makeProject("Project 1")));
-        Assert.assertTrue(plugin.isAllowed(dummyRequest, makeGroup("Group 1")));
-        Assert.assertTrue(plugin.isAllowed(dummyRequest, makeGroup("Group 2")));
-
-        plugin.setSessionVersion(dummyRequest, 2);
-        prepareRequest("007", "james@bond.com", "MI6", "MI7");
-        
         Assert.assertTrue(plugin.isAllowed(dummyRequest, makeProject("Random Project")));
         Assert.assertTrue(plugin.isAllowed(dummyRequest, makeProject("Project 1")));
         Assert.assertTrue(plugin.isAllowed(dummyRequest, makeGroup("Group 1")));

--- a/plugins/LdapPlugin/test/opengrok/auth/plugin/LdapAttrPluginTest.java
+++ b/plugins/LdapPlugin/test/opengrok/auth/plugin/LdapAttrPluginTest.java
@@ -80,7 +80,8 @@ public class LdapAttrPluginTest {
 
         plugin.load(parameters);
 
-        framework = new AuthorizationFramework(null);
+        framework = new AuthorizationFramework();
+        framework.reload();
     }
 
     private void prepareRequest(String username, String mail, String... ous) {

--- a/plugins/LdapPlugin/test/opengrok/auth/plugin/LdapFilterPluginTest.java
+++ b/plugins/LdapPlugin/test/opengrok/auth/plugin/LdapFilterPluginTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class LdapFilterTest {
+public class LdapFilterPluginTest {
 
     private LdapFilterPlugin plugin;
 

--- a/plugins/LdapPlugin/test/opengrok/auth/plugin/util/DummyHttpServletRequestLdap.java
+++ b/plugins/LdapPlugin/test/opengrok/auth/plugin/util/DummyHttpServletRequestLdap.java
@@ -40,6 +40,7 @@ import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionContext;
 import opengrok.auth.plugin.UserPlugin;
 import opengrok.auth.plugin.entity.User;
+import org.opensolaris.opengrok.util.RandomString;
 
 public class DummyHttpServletRequestLdap implements HttpServletRequest {
 
@@ -60,7 +61,7 @@ public class DummyHttpServletRequestLdap implements HttpServletRequest {
             if ((user = (User) getAttribute(UserPlugin.REQUEST_ATTR)) != null) {
                 return user.getUsername();
             }
-            return Strings.generate(5);
+            return RandomString.generate(5);
         }
 
         @Override

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationFramework.java
@@ -86,11 +86,6 @@ public final class AuthorizationFramework {
      * stored in HTTP session.
      *
      * Starting at 0 and increases with every reload.
-     *
-     * External consumers should call RuntimeEnvironment.getPluginVersion() 
-     * to get this number.
-     *
-     * @see RuntimeEnvironment#getPluginVersion()
      */
     private long pluginVersion = 0;
 
@@ -550,7 +545,7 @@ public final class AuthorizationFramework {
         });
 
         // clone a new stack not interfering with the current stack
-        AuthorizationStack newStack = RuntimeEnvironment.getInstance().getPluginStack().clone();
+        AuthorizationStack newStack = getStack().clone();
 
         // load all other possible plugin classes
         loadClasses(newStack,
@@ -595,7 +590,6 @@ public final class AuthorizationFramework {
      * Assumes the {@code lock} is held for reading.
      *
      * @return the current version number
-     * @see RuntimeEnvironment#getPluginVersion()
      */
     private long getPluginVersion() {
         return pluginVersion;
@@ -642,9 +636,9 @@ public final class AuthorizationFramework {
      * <h3>Order of plugin invocation</h3>
      *
      * <p>
-     * The order of plugin invocation is given by the configuration
-     * {@link RuntimeEnvironment#getPluginStack()} and appropriate actions are
-     * taken when traversing the stack with set of keywords, such as:</p>
+     * The order of plugin invocation is given by the stack and appropriate
+     * actions are taken when traversing the stack with set of keywords,
+     * such as:</p>
      *
      * <h4>required</h4>
      * Failure of such a plugin will ultimately lead to the authorization

--- a/src/org/opensolaris/opengrok/authorization/AuthorizationStack.java
+++ b/src/org/opensolaris/opengrok/authorization/AuthorizationStack.java
@@ -17,7 +17,7 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.authorization;

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -1663,7 +1663,7 @@ public final class RuntimeEnvironment {
      */
     synchronized public AuthorizationFramework getAuthorizationFramework() {
         if (authFramework == null) {
-            authFramework = new AuthorizationFramework(threadConfig.get().getPluginDirectory());
+            authFramework = new AuthorizationFramework(getPluginDirectory(), getPluginStack());
         }
         return authFramework;
     }
@@ -1750,6 +1750,7 @@ public final class RuntimeEnvironment {
 
         // set the new plugin directory and reload the authorization framework
         getAuthorizationFramework().setPluginDirectory(config.getPluginDirectory());
+        getAuthorizationFramework().setStack(config.getPluginStack());
         getAuthorizationFramework().reload();
     }
 

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -1657,16 +1657,6 @@ public final class RuntimeEnvironment {
     }
 
     /**
-     * Return the current plugin version tracked by the authorization framework.
-     *
-     * @return the version
-     * @see AuthorizationFramework#getPluginVersion()
-     */
-    public int getPluginVersion() {
-        return getAuthorizationFramework().getPluginVersion();
-    }
-
-    /**
      * Return the authorization framework used in this environment.
      *
      * @return the framework
@@ -1686,7 +1676,7 @@ public final class RuntimeEnvironment {
      */
     synchronized public void setAuthorizationFramework(AuthorizationFramework fw) {
         if (this.authFramework != null) {
-            this.authFramework.removeAll(this.authFramework.getStack());
+            this.authFramework.removeAll();
         }
         this.authFramework = fw;
     }

--- a/src/org/opensolaris/opengrok/util/RandomString.java
+++ b/src/org/opensolaris/opengrok/util/RandomString.java
@@ -17,16 +17,16 @@
  * CDDL HEADER END
  */
 
- /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+/*
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
  */
-package opengrok.auth.plugin.util;
+package org.opensolaris.opengrok.util;
 
 /**
  *
- * @author ktulinge
+ * @author Krystof Tulinger
  */
-public class Strings {
+public class RandomString {
     
     public static String generateLower(int length) {
         return generate(length, "abcdefghijklmnopqrstuvwxyz");

--- a/src/org/opensolaris/opengrok/web/JSONSearchServlet.java
+++ b/src/org/opensolaris/opengrok/web/JSONSearchServlet.java
@@ -17,7 +17,7 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2014, 2017 Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.web;
@@ -39,7 +39,7 @@ import org.opensolaris.opengrok.search.SearchEngine;
 public class JSONSearchServlet extends HttpServlet {
 
     private static final long serialVersionUID = -1675062445999680962L;
-    private static final Base64Converter conv = new Base64Converter();
+    private static final Base64Converter BASE64CONV = new Base64Converter();
     private static final int MAX_RESULTS = 1000; // hard coded limit
     private static final String PARAM_FREETEXT = "freetext";
     private static final String PARAM_DEF = "def";
@@ -49,6 +49,7 @@ public class JSONSearchServlet extends HttpServlet {
     private static final String PARAM_START = "start";
     private static final String PARAM_MAXRESULTS = "maxresults";
     private static final String PARAM_PROJECT = "project";
+    private static final String PARAM_TYPE = "type";
     private static final String ATTRIBUTE_DIRECTORY = "directory";
     private static final String ATTRIBUTE_FILENAME = "filename";
     private static final String ATTRIBUTE_LINENO = "lineno";
@@ -73,6 +74,7 @@ public class JSONSearchServlet extends HttpServlet {
         String path = req.getParameter(PARAM_PATH);
         String hist = req.getParameter(PARAM_HIST);
         String projects[] = req.getParameterValues(PARAM_PROJECT);
+        String type = req.getParameter(PARAM_TYPE);
 
         if (freetext != null) {
             freetext = URLDecoder.decode(freetext);
@@ -109,6 +111,13 @@ public class JSONSearchServlet extends HttpServlet {
             result.put(PARAM_HIST, hist);
         }
 
+        if (type != null) {
+            type = URLDecoder.decode(type);
+            engine.setType(type);
+            valid = true;
+            result.put(PARAM_TYPE, type);
+        }
+        
         if (!valid) {
             return;
         }
@@ -141,7 +150,7 @@ public class JSONSearchServlet extends HttpServlet {
                 hitJson.put(ATTRIBUTE_FILENAME,
                         JSONObject.escape(hit.getFilename()));
                 hitJson.put(ATTRIBUTE_LINENO, hit.getLineno());
-                hitJson.put(ATTRIBUTE_LINE, conv.encode(hit.getLine()));
+                hitJson.put(ATTRIBUTE_LINE, BASE64CONV.encode(hit.getLine()));
                 hitJson.put(ATTRIBUTE_PATH, hit.getPath());
                 resultsArray.add(hitJson);
             }
@@ -172,7 +181,9 @@ public class JSONSearchServlet extends HttpServlet {
      * @return The integer value of the request param if present or the
      *         defaultValue if none is present.
      */
-    private static Integer getIntParameter(final HttpServletRequest request, final String paramName, final Integer defaultValue) {
+    private static Integer getIntParameter(final HttpServletRequest request,
+            final String paramName, final Integer defaultValue) {
+        
         final String paramValue = request.getParameter(paramName);
         if (paramValue == null) {
             return defaultValue;

--- a/src/org/opensolaris/opengrok/web/Statistics.java
+++ b/src/org/opensolaris/opengrok/web/Statistics.java
@@ -108,6 +108,15 @@ public class Statistics {
         val += 1;
         requestCategories.put(category, val);
     }
+    
+    /**
+     * Get value of given counter
+     * @param category
+     * @return Long value
+     */
+    synchronized public Long getRequest(String category) {
+        return requestCategories.get(category);
+    }
 
     /**
      * Adds a request's process time into given category.

--- a/src/org/opensolaris/opengrok/web/WebappListener.java
+++ b/src/org/opensolaris/opengrok/web/WebappListener.java
@@ -17,7 +17,7 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.web;
@@ -80,7 +80,7 @@ public final class WebappListener
          * (reading the configuration) failed then the plugin directory is
          * possibly {@code null} causing the framework to allow every request.
          */
-        env.setAuthorizationFramework(new AuthorizationFramework(env.getPluginDirectory()));
+        env.setAuthorizationFramework(new AuthorizationFramework(env.getPluginDirectory(), env.getPluginStack()));
 
         String address = context.getInitParameter("ConfigAddress");
         if (address != null && address.length() > 0) {

--- a/src/org/opensolaris/opengrok/web/WebappListener.java
+++ b/src/org/opensolaris/opengrok/web/WebappListener.java
@@ -81,6 +81,7 @@ public final class WebappListener
          * possibly {@code null} causing the framework to allow every request.
          */
         env.setAuthorizationFramework(new AuthorizationFramework(env.getPluginDirectory(), env.getPluginStack()));
+        env.getAuthorizationFramework().reload();
 
         String address = context.getInitParameter("ConfigAddress");
         if (address != null && address.length() > 0) {

--- a/test/org/opensolaris/opengrok/authorization/AuthorizationEntityTest.java
+++ b/test/org/opensolaris/opengrok/authorization/AuthorizationEntityTest.java
@@ -17,7 +17,7 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.authorization;

--- a/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkReloadTest.java
+++ b/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkReloadTest.java
@@ -1,0 +1,167 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.authorization;
+
+import java.io.File;
+import java.net.URL;
+import javax.servlet.http.HttpSession;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.opensolaris.opengrok.configuration.Project;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
+import org.opensolaris.opengrok.web.DummyHttpServletRequest;
+import org.opensolaris.opengrok.web.Statistics;
+
+/**
+ * Test behavior of AuthorizationFramework {@code reload()} w.r.t. HTTP sessions.
+ * 
+ * Note that the tests are accompanied with noise when reloading since
+ * the plugin directory contains classes of other tests from this package
+ * which the authorization framework is trying (unsuccessfully, since they
+ * do not implement the plugin interface) to load.
+ * 
+ * @author Vladimir Kotal
+ */
+public class AuthorizationFrameworkReloadTest {
+    
+    private final File pluginDirectory;
+    
+    volatile boolean runThread;
+    
+    public AuthorizationFrameworkReloadTest() {
+        URL resource = AuthorizationFrameworkReloadTest.class.getResource("testplugins.jar");
+        pluginDirectory = new File(resource.getFile()).getParentFile();
+    }
+    
+    /**
+     * After {@code reload()} the session attributes should be invalidated.
+     * It is assumed that invalidation of HttpSession objects means that all
+     * the attributes will be unset.
+     */
+    @Test
+    public void testReloadSimple() {
+        DummyHttpServletRequest req = new DummyHttpServletRequest();
+        AuthorizationFramework framework = new AuthorizationFramework(pluginDirectory.getPath());
+        Statistics stats = RuntimeEnvironment.getInstance().getStatistics();
+        
+        // Ensure the framework was setup correctly.
+        assertNotNull(framework.getPluginDirectory());
+        assertEquals(pluginDirectory, framework.getPluginDirectory());
+        
+        // Create pre-requisite objects - mainly the HTTP session with attribute.
+        Project p = new Project("project" + Math.random());
+        HttpSession session = req.getSession();
+        String attrName = "foo";
+        session.setAttribute(attrName, "bar");
+        assertNotNull(session.getAttribute(attrName));
+        
+        // Reload the framework to increment the plugin generation version.
+        framework.reload();
+        // Let the framework check the request. This should invalidate the session
+        // since the version was incremented. In this test we are not interested
+        // in the actual result.
+        framework.isAllowed(req, p);
+        assertNull(stats.getRequest("authorization_cache_hits"));
+        // Verify that the session no longer has the attribute.
+        assertNull(session.getAttribute(attrName));
+    }
+    
+    /**
+     * Sort of a stress test - call isAllowed() and reload() in parallel.
+     * This might uncover any snags with locking within AuthorizationFramework.
+     */
+    @Test
+    public void testReloadCycle() {
+        Statistics stats = RuntimeEnvironment.getInstance().getStatistics();
+        Long reloads;
+        String projectName = "project" + Math.random();
+        
+        // Create authorization stack for single project.
+        AuthorizationStack stack = new AuthorizationStack(AuthControlFlag.REQUIRED,
+                "stack for project " + projectName);
+        assertNotNull(stack);
+        stack.add(new AuthorizationPlugin(AuthControlFlag.REQUIRED, 
+                "opengrok.auth.plugin.FalsePlugin"));
+        stack.setForProjects(projectName);
+        RuntimeEnvironment re = RuntimeEnvironment.getInstance();
+        // Unfortunately even though the AuthorizationFramework is instantiated with given stack,
+        // this does not work because the reload() method called from the constructor grabs
+        // the stack from RuntimeEnvironment and not from the AuthorizationFramework itself.
+        re.setPluginStack(stack);
+        re.setPluginDirectory(pluginDirectory.getPath());
+        
+        AuthorizationFramework framework = 
+                new AuthorizationFramework(pluginDirectory.getPath());
+        
+        // Perform simple sanity check before long run is entered. If this fails,
+        // it will be waste of time to continue with the test.
+        Project p = new Project(projectName);
+        DummyHttpServletRequest req = new DummyHttpServletRequest();
+        assertFalse(framework.isAllowed(req, p));
+        
+        // Create a thread that does reload() every now and then.
+        runThread = true;
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                while (runThread) {
+                    framework.reload();
+                    try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException ex) {
+                    }
+                }
+            }
+        });
+        t.start();
+        
+        reloads = stats.getRequest("authorization_stack_reload");
+        assertNotNull(reloads);
+        // Process number or requests and check that framework decision is consistent.
+        for (int i = 0; i < 100; i++) {
+            req = new DummyHttpServletRequest();
+            assertFalse(framework.isAllowed(req, p));
+            try {
+                // XXX random sleep
+                Thread.sleep(50);
+            } catch (InterruptedException ex) {
+            }
+        }
+        
+        try {
+            // Terminate the thread.
+            runThread = false;
+            t.join();
+        } catch (InterruptedException ex) {
+        }
+        
+        // Double check that at least one reload() was done.
+        reloads = stats.getRequest("authorization_stack_reload") - reloads;
+        System.out.println("number of reloads: " + reloads);
+        assertTrue(reloads > 0);
+    }
+}

--- a/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkReloadTest.java
+++ b/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkReloadTest.java
@@ -39,11 +39,6 @@ import org.opensolaris.opengrok.web.Statistics;
 /**
  * Test behavior of AuthorizationFramework {@code reload()} w.r.t. HTTP sessions.
  * 
- * Note that the tests are accompanied with noise when reloading since
- * the plugin directory contains classes of other tests from this package
- * which the authorization framework is trying (unsuccessfully, since they
- * do not implement the plugin interface) to load.
- * 
  * @author Vladimir Kotal
  */
 public class AuthorizationFrameworkReloadTest {
@@ -66,6 +61,8 @@ public class AuthorizationFrameworkReloadTest {
     public void testReloadSimple() {
         DummyHttpServletRequest req = new DummyHttpServletRequest();
         AuthorizationFramework framework = new AuthorizationFramework(pluginDirectory.getPath());
+        framework.setLoadClasses(false); // to avoid noise when loading classes of other tests
+        framework.reload();
         Statistics stats = RuntimeEnvironment.getInstance().getStatistics();
         
         // Ensure the framework was setup correctly.
@@ -109,6 +106,8 @@ public class AuthorizationFrameworkReloadTest {
         stack.setForProjects(projectName);
         AuthorizationFramework framework = 
                 new AuthorizationFramework(pluginDirectory.getPath(), stack);
+        framework.setLoadClasses(false); // to avoid noise when loading classes of other tests
+        framework.reload();
         
         // Perform simple sanity check before long run is entered. If this fails,
         // it will be waste of time to continue with the test.
@@ -157,5 +156,21 @@ public class AuthorizationFrameworkReloadTest {
         reloads = stats.getRequest("authorization_stack_reload") - reloads;
         System.out.println("number of reloads: " + reloads);
         assertTrue(reloads > 0);
+    }
+    
+    @Test
+    public void testSetLoadClasses() {
+        AuthorizationFramework framework = new AuthorizationFramework();
+        assertTrue(framework.isLoadClassesEnabled());
+        framework.setLoadClasses(false);
+        assertFalse(framework.isLoadClassesEnabled());
+    }
+    
+    @Test
+    public void testSetLoadJars() {
+        AuthorizationFramework framework = new AuthorizationFramework();
+        assertTrue(framework.isLoadJarsEnabled());
+        framework.setLoadJars(false);
+        assertFalse(framework.isLoadJarsEnabled());
     }
 }

--- a/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkTest.java
+++ b/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkTest.java
@@ -30,7 +30,6 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -45,7 +44,6 @@ public class AuthorizationFrameworkTest {
 
     private static final Random RANDOM = new Random();
 
-    private AuthorizationFramework framework;
     private final StackSetup setup;
 
     public AuthorizationFrameworkTest(StackSetup setup) {
@@ -651,7 +649,7 @@ public class AuthorizationFrameworkTest {
 
     @Test
     public void testPluginsGeneric() {
-        framework.setStack(setup.stack);
+        AuthorizationFramework framework = new AuthorizationFramework(null, setup.stack);
         framework.loadAllPlugins(setup.stack);
 
         boolean actual;
@@ -670,11 +668,6 @@ public class AuthorizationFrameworkTest {
                         actual);
             }
         }
-    }
-
-    @Before
-    public void setUp() {
-        framework = new AuthorizationFramework(null);
     }
 
     static private Project createAllowedProject() {
@@ -782,7 +775,6 @@ public class AuthorizationFrameworkTest {
             }
 
         };
-
     }
 
     static public class TestCase {

--- a/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkTest.java
+++ b/test/org/opensolaris/opengrok/authorization/AuthorizationFrameworkTest.java
@@ -43,7 +43,7 @@ import org.opensolaris.opengrok.web.DummyHttpServletRequest;
 @RunWith(Parameterized.class)
 public class AuthorizationFrameworkTest {
 
-    private static final Random random = new Random();
+    private static final Random RANDOM = new Random();
 
     private AuthorizationFramework framework;
     private final StackSetup setup;
@@ -688,12 +688,12 @@ public class AuthorizationFrameworkTest {
     }
 
     static private Group createAllowedGroup() {
-        Group g = new Group("allowed" + "_" + "group_" + random.nextInt());
+        Group g = new Group("allowed" + "_" + "group_" + RANDOM.nextInt());
         return g;
     }
 
     static private Group createUnallowedGroup() {
-        Group g = new Group("not_allowed" + "_" + "group_" + random.nextInt());
+        Group g = new Group("not_allowed" + "_" + "group_" + RANDOM.nextInt());
         return g;
     }
 

--- a/test/org/opensolaris/opengrok/authorization/AuthorizationPluginClassLoaderTest.java
+++ b/test/org/opensolaris/opengrok/authorization/AuthorizationPluginClassLoaderTest.java
@@ -32,7 +32,7 @@ import org.opensolaris.opengrok.web.DummyHttpServletRequest;
 
 public class AuthorizationPluginClassLoaderTest {
 
-    private File pluginDirectory;
+    private final File pluginDirectory;
 
     public AuthorizationPluginClassLoaderTest() {
         URL resource = AuthorizationPluginClassLoaderTest.class.getResource("testplugins.jar");

--- a/test/org/opensolaris/opengrok/authorization/TestPlugin.java
+++ b/test/org/opensolaris/opengrok/authorization/TestPlugin.java
@@ -17,7 +17,7 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.authorization;

--- a/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
@@ -18,19 +18,16 @@
  */
 
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.index;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.history.HistoryGuru;

--- a/test/org/opensolaris/opengrok/web/DummyHttpServletRequest.java
+++ b/test/org/opensolaris/opengrok/web/DummyHttpServletRequest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.web;
 
@@ -32,10 +32,13 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionContext;
+import static org.opensolaris.opengrok.util.RandomString.generate;
 
 /**
  * <p>
@@ -55,7 +58,99 @@ import javax.servlet.http.HttpSession;
 public class DummyHttpServletRequest implements HttpServletRequest {
 
     private final Map<String, Object> attrs = new HashMap<String, Object>();
+    
+    private class DummyHttpSession implements HttpSession {
+        private Map<String, Object> attrs = new HashMap<>();
 
+        @Override
+        public long getCreationTime() {
+            return 0;
+        }
+
+        @Override
+        public String getId() {
+            return generate(32, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.");
+        }
+
+        @Override
+        public long getLastAccessedTime() {
+            return 0;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return (ServletContext) DummyHttpServletRequest.this;
+        }
+
+        @Override
+        public void setMaxInactiveInterval(int i) {
+        }
+
+        @Override
+        public int getMaxInactiveInterval() {
+            return 3600;
+        }
+
+        @SuppressWarnings("deprecation")
+        public HttpSessionContext getSessionContext() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Object getAttribute(String string) {
+            return attrs.get(string);
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public Object getValue(String string) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Enumeration getAttributeNames() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public String[] getValueNames() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void setAttribute(String string, Object o) {
+            attrs.put(string, o);
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public void putValue(String string, Object o) {
+        }
+
+        @Override
+        public void removeAttribute(String string) {
+            attrs.remove(string);
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public void removeValue(String string) {
+        }
+
+        @Override
+        public void invalidate() {
+            attrs = new HashMap<String, Object>();
+        }
+
+        @Override
+        public boolean isNew() {
+            return true;
+        }
+    };
+    
+    private HttpSession session;
+    
     @Override
     public String getAuthType() {
         throw new UnsupportedOperationException("Not supported yet.");
@@ -153,14 +248,21 @@ public class DummyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public HttpSession getSession(boolean bln) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        if (bln) {
+            session = new DummyHttpSession();
+        }
+        
+        return session;
     }
 
     @Override
     public HttpSession getSession() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        if (session == null) {
+            session = new DummyHttpSession();
+        }
+        return session;
     }
-
+    
     @Override
     public boolean isRequestedSessionIdValid() {
         throw new UnsupportedOperationException("Not supported yet.");

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -17,7 +17,7 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.web;
@@ -187,7 +187,8 @@ public class PageConfigTest {
          *  - disabling "mercurial"
          * </pre>
          */
-        env.setAuthorizationFramework(new AuthorizationFramework(null));
+        env.setAuthorizationFramework(new AuthorizationFramework());
+        env.getAuthorizationFramework().reload();
         env.getAuthorizationFramework().getStack()
                 .add(new AuthorizationPlugin(AuthControlFlag.REQUIRED, new TestPlugin() {
                     @Override

--- a/test/org/opensolaris/opengrok/web/ProjectHelperTest.java
+++ b/test/org/opensolaris/opengrok/web/ProjectHelperTest.java
@@ -61,7 +61,7 @@ public class ProjectHelperTest extends ProjectHelperTestBase {
         List<RepositoryInfo> oldRepositories = new ArrayList<>(env.getRepositories());
         Set<Group> oldGroups = new TreeSet<>(env.getGroups());
         Map<Project, List<RepositoryInfo>> oldMap = new TreeMap<>(getRepositoriesMap());
-        env.getAuthorizationFramework().removeAll(env.getAuthorizationFramework().getStack());
+        env.getAuthorizationFramework().removeAll();
         env.setSourceRoot("/src"); // needed for setDirectoryName() below
 
         cfg = PageConfig.get(getRequest());

--- a/test/org/opensolaris/opengrok/web/ProjectHelperTestBase.java
+++ b/test/org/opensolaris/opengrok/web/ProjectHelperTestBase.java
@@ -266,7 +266,8 @@ public class ProjectHelperTestBase {
         Assert.assertNotNull("Repository map should not be null", env.getProjectRepositoriesMap());
         Assert.assertEquals("Repository map should contain 20 project", 20, env.getProjectRepositoriesMap().size());
 
-        env.setAuthorizationFramework(new AuthorizationFramework(null));
+        env.setAuthorizationFramework(new AuthorizationFramework());
+        env.getAuthorizationFramework().reload();
 
         IAuthorizationPlugin plugin = new TestPlugin() {
             @Override

--- a/test/org/opensolaris/opengrok/web/ProjectHelperTestBase.java
+++ b/test/org/opensolaris/opengrok/web/ProjectHelperTestBase.java
@@ -288,6 +288,6 @@ public class ProjectHelperTestBase {
 
     @After
     public void tearDown() {
-        env.getAuthorizationFramework().removeAll(env.getAuthorizationFramework().getStack());
+        env.getAuthorizationFramework().removeAll();
     }
 }


### PR DESCRIPTION
fixes bunch of problems in `AuthorizationFramework`.

Notable changes:
  - HTTP session invalidation now happens in `AuthorizationFramework` as opposed to in the plugins
  - random string generation moved from plugin tests to `src/opengrok` so that all tests can use it
  - some bad object programming practices softened
