### PR TITLE
Bugfix/ruby end interp

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/ruby/RubyProductions.lexh
+++ b/src/org/opensolaris/opengrok/analysis/ruby/RubyProductions.lexh
@@ -324,12 +324,9 @@ Here_EOF3 = [\`][^\r\n\`]*[\`]
 
     [\{\}]    {
         String capture = yytext();
-        if (h.maybeEndInterpolation(capture)) {
-            popHelper();
-            yypop();
-            disjointSpan(HtmlConsts.STRING_CLASS);
+        if (!h.maybeEndInterpolation(capture)) {
+            offerNonword(capture);
         }
-        offerNonword(capture);
     }
 }
 

--- a/src/org/opensolaris/opengrok/analysis/ruby/RubySymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/ruby/RubySymbolTokenizer.lex
@@ -133,7 +133,7 @@ import org.opensolaris.opengrok.web.Util;
         h = getNewHelper();
     }
 
-    protected void popHelper() {
+    public void popHelper() {
         h = helpers.pop();
     }
 

--- a/src/org/opensolaris/opengrok/analysis/ruby/RubyXref.lex
+++ b/src/org/opensolaris/opengrok/analysis/ruby/RubyXref.lex
@@ -121,7 +121,7 @@ import org.opensolaris.opengrok.web.Util;
         h = getNewHelper();
     }
 
-    protected void popHelper() {
+    public void popHelper() {
         h = helpers.pop();
     }
 

--- a/test/org/opensolaris/opengrok/analysis/ruby/RubyXrefTest.java
+++ b/test/org/opensolaris/opengrok/analysis/ruby/RubyXrefTest.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import org.junit.Test;
@@ -69,6 +70,26 @@ public class RubyXrefTest {
         String ostr = new String(baos.toByteArray(), "UTF-8");
         String estr = new String(baosExp.toByteArray(), "UTF-8");
         assertLinesEqual("Ruby xref", estr, ostr);
+    }
+
+    @Test
+    public void colonQuoteAfterInterpolation() throws IOException {
+        final String RUBY_COLON_QUOTE =
+            "\"from #{logfn}:\"\n";
+        RubyXref xref = new RubyXref(new StringReader(RUBY_COLON_QUOTE));
+
+        StringWriter out = new StringWriter();
+        xref.write(out);
+        String xout = out.toString();
+
+        final String xexpected = "<a class=\"l\" name=\"1\" href=\"#1\">1</a>"
+                + "<span class=\"s\">&quot;from #{</span>"
+                + "<a href=\"/source/s?defs=logfn\" "
+                + "class=\"intelliWindow-symbol\" "
+                + "data-definition-place=\"undefined-in-file\">logfn</a>"
+                + "<span class=\"s\">}:&quot;</span>\n" +
+            "<a class=\"l\" name=\"2\" href=\"#2\">2</a>\n";
+        assertLinesEqual("Ruby colon-quote", xexpected, xout);
     }
 
     private void writeRubyXref(InputStream iss, PrintStream oss)

--- a/test/org/opensolaris/opengrok/analysis/ruby/ruby_xrefres.html
+++ b/test/org/opensolaris/opengrok/analysis/ruby/ruby_xrefres.html
@@ -183,5 +183,7 @@ function get_sym_list(){return [["Class","xc",[["Board",4]]],["Method","xmt",[["
 <a class="l" name="175" href="#175">175</a><b>end</b>
 <a class="l" name="176" href="#176">176</a><b>print</b> <span class="s">&quot;\n&quot;</span>
 <a class="l" name="177" href="#177">177</a><b>print</b> <span class="s">&apos;<a href="http://example.com">http://example.com</a>&apos;</span>
-<a class="l" name="178" href="#178">178</a></body>
+<a class="l" name="178" href="#178">178</a><b>puts</b> <span class="s">&quot;Last #{</span><a href="/source/s?defs=log_lines" class="intelliWindow-symbol" data-definition-place="undefined-in-file">log_lines</a><span class="s">} lines from #{</span><a href="/source/s?defs=logfn" class="intelliWindow-symbol" data-definition-place="undefined-in-file">logfn</a><span class="s">}:&quot;</span>
+<a class="l" name="179" href="#179">179</a><b>print</b> <span class="s">&quot;\n&quot;</span>
+<a class="hl" name="180" href="#180">180</a></body>
 </html>

--- a/test/org/opensolaris/opengrok/analysis/ruby/sample.rb
+++ b/test/org/opensolaris/opengrok/analysis/ruby/sample.rb
@@ -175,3 +175,5 @@ ensure
 end
 print "\n"
 print 'http://example.com'
+puts "Last #{log_lines} lines from #{logfn}:"
+print "\n"

--- a/test/org/opensolaris/opengrok/analysis/ruby/samplesymbols.txt
+++ b/test/org/opensolaris/opengrok/analysis/ruby/samplesymbols.txt
@@ -184,3 +184,5 @@ over?
 STDIN
 bd
 reset
+log_lines	# 177:puts "Last #{log_lines} lines from #{logfn}:"
+logfn


### PR DESCRIPTION
Hello,

Please consider for integration this patch to fix an arcane Ruby problem where colon-quote — i.e., :&quot; — following the end-token of a Ruby string interpolation was being misinterpreted together with the end-token as the start of an interpolated symbolic quoting operator (i.e., as an erroneous {Symquo} match) and interfering with the correct interpretation of the end-token.

(This would have applied to other quoting operator tokens following the heuristic {WxSigils} match and is fixed for those too.)

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
