### PR TITLE
add auth options and --non-interactive to getHistoryGet()

### DIFF
--- a/src/org/opensolaris/opengrok/history/SubversionRepository.java
+++ b/src/org/opensolaris/opengrok/history/SubversionRepository.java
@@ -259,6 +259,8 @@ public class SubversionRepository extends Repository {
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         cmd.add(RepoCommand);
         cmd.add("cat");
+        cmd.add("--non-interactive");
+        cmd.addAll(getAuthCommandLineParams());
         cmd.add("-r");
         cmd.add(rev);
         cmd.add(escapeFileName(filename));


### PR DESCRIPTION
I don't have a setup to test this on, however it conforms to the `svn cat` usage.